### PR TITLE
Fix: Read provider clientId instead of clientSecret

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -38,8 +38,8 @@ type CrowdStrikeProvider struct {
 // CrowdStrikeProviderModel describes the provider data model.
 type CrowdStrikeProviderModel struct {
 	Cloud        types.String `tfsdk:"cloud"`
-	ClientSecret types.String `tfsdk:"client_id"`
-	ClientId     types.String `tfsdk:"client_secret"`
+	ClientSecret types.String `tfsdk:"client_secret"`
+	ClientId     types.String `tfsdk:"client_id"`
 }
 
 func (p *CrowdStrikeProvider) Metadata(
@@ -145,7 +145,7 @@ func (p *CrowdStrikeProvider) Configure(
 	}
 
 	if !config.ClientId.IsNull() {
-		clientId = config.ClientSecret.ValueString()
+		clientId = config.ClientId.ValueString()
 	}
 
 	if !config.ClientSecret.IsNull() {


### PR DESCRIPTION
When configuring the provider via properties, as shown below, instead of environment variables, the local `clientId` is being incorrectly set with `ClientSecret`. 

```
provider "crowdstrike" {
  cloud = "eu-1"
  client_id = var.falcon_client_id
  client_secret = var.falcon_client_secret
}

variable "falcon_client_id" {
  type = string
}
variable "falcon_client_secret" {
  type = string
}
```

This makes it impossible to configure the provider using configuration properties. The observed error:
```
│  "errors": [
│   {
│    "code": 403,
│    "message": "Failed to issue access token - Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method)"
│   }
│  ]
```

This PR addresses the issue above.