### PR TITLE
make host_group description required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     if: |
       (github.event_name == 'pull_request_target' &&
       github.event.label.name == 'ok-to-test') ||
-      contains(fromJson('["push", "pull_request", "workflow_dispatch", "schedule"]'), github.event_name)
+      contains(fromJson('["push", "workflow_dispatch", "schedule"]'), github.event_name)
     name: Terraform Provider Acceptance Tests
     needs: build
     runs-on: ubuntu-latest

--- a/docs/resources/host_group.md
+++ b/docs/resources/host_group.md
@@ -57,13 +57,13 @@ output "host_group" {
 
 ### Required
 
+- `description` (String) Description of the host group.
 - `name` (String) Name of the host group.
 - `type` (String) The host group type, case sensitive. (dynamic, static, staticByID)
 
 ### Optional
 
 - `assignment_rule` (String) The assignment rule for dynamic host groups.
-- `description` (String) Description of the host group.
 
 ### Read-Only
 

--- a/internal/provider/host_group_resource.go
+++ b/internal/provider/host_group_resource.go
@@ -166,8 +166,11 @@ func (r *hostGroupResource) Schema(
 				},
 			},
 			"description": schema.StringAttribute{
-				Optional:    true,
+				Required:    true,
 				Description: "Description of the host group.",
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
 			},
 		},
 	}


### PR DESCRIPTION
due to the api being unable to make a description null, we need to require a description to provide idempotence

closes #25 