### PR TITLE
validate host group and rule groups for prevention policy

### DIFF
--- a/internal/fim/rule_group.go
+++ b/internal/fim/rule_group.go
@@ -911,7 +911,7 @@ func handleRuleGroupErrors(
 		)
 	}
 
-	if res.Resources == nil || len(res.Resources) == 0 {
+	if len(res.Resources) == 0 {
 		diags.AddError(
 			summary,
 			fmt.Sprintf(
@@ -1001,7 +1001,7 @@ func handleRuleGroupRulesErrors(
 		)
 	}
 
-	if res.Resources == nil || len(res.Resources) == 0 {
+	if len(res.Resources) == 0 {
 		diags.AddError(
 			summary,
 			fmt.Sprintf(

--- a/internal/prevention_policy/linux.go
+++ b/internal/prevention_policy/linux.go
@@ -229,6 +229,11 @@ func (r *preventionPolicyLinuxResource) Create(
 	plan.Name = types.StringValue(*preventionPolicy.Name)
 	plan.LastUpdated = types.StringValue(time.Now().Format(time.RFC850))
 
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	if plan.Enabled.ValueBool() {
 		actionResp, diags := updatePolicyEnabledState(
 			ctx,
@@ -455,6 +460,9 @@ func (r *preventionPolicyLinuxResource) ValidateConfig(
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	resp.Diagnostics.Append(validateHostGroups(ctx, config.HostGroups)...)
+	resp.Diagnostics.Append(validateIOARuleGroups(ctx, config.RuleGroups)...)
 
 	if config.CloudAntiMalware != nil {
 		resp.Diagnostics.Append(

--- a/internal/prevention_policy/mac.go
+++ b/internal/prevention_policy/mac.go
@@ -247,6 +247,11 @@ func (r *preventionPolicyMacResource) Create(
 	plan.Name = types.StringValue(*preventionPolicy.Name)
 	plan.LastUpdated = types.StringValue(time.Now().Format(time.RFC850))
 
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	if plan.Enabled.ValueBool() {
 		actionResp, diags := updatePolicyEnabledState(
 			ctx,
@@ -473,6 +478,9 @@ func (r *preventionPolicyMacResource) ValidateConfig(
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	resp.Diagnostics.Append(validateHostGroups(ctx, config.HostGroups)...)
+	resp.Diagnostics.Append(validateIOARuleGroups(ctx, config.RuleGroups)...)
 
 	resp.Diagnostics.Append(
 		validateRequiredAttribute(

--- a/internal/prevention_policy/shared.go
+++ b/internal/prevention_policy/shared.go
@@ -116,15 +116,15 @@ func updateRuleGroups(
 
 	if err != nil {
 		diags.AddError("Error updating prevention policy rule groups", fmt.Sprintf(
-			"Could not %s prevention policy (%s) rule group (%s): %s",
+			"Error %s rule groups (%s) to prevention policy (%s): %s",
 			actionMsg,
-			id,
 			strings.Join(ruleGroupIDs, ", "),
+			id,
 			err.Error(),
 		))
 	}
 
-	if res != nil && res.Payload == nil {
+	if res == nil || res.Payload == nil {
 		return diags
 	}
 
@@ -132,10 +132,10 @@ func updateRuleGroups(
 		diags.AddError(
 			"Error updating prevention policy rule groups",
 			fmt.Sprintf(
-				"Could not %s prevention policy (%s) rule group (%s): %s",
+				"Error %s rule group (%s) to prevention policy (%s): %s",
 				actionMsg,
-				id,
 				err.ID,
+				id,
 				err.String(),
 			),
 		)
@@ -403,6 +403,54 @@ func validateRequiredAttribute(
 	return diags
 }
 
+// validateHostGroups validates the host groups in the resource model.
+func validateHostGroups(ctx context.Context, hostGroupSet types.Set) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	var hostGroups []string
+
+	diags.Append(hostGroupSet.ElementsAs(ctx, &hostGroups, false)...)
+	if diags.HasError() {
+		return diags
+	}
+
+	for _, id := range hostGroups {
+		if len(id) == 0 {
+			diags.AddAttributeError(
+				path.Root("host_groups"),
+				"Error validating host group",
+				"Host group ID cannot be empty",
+			)
+		}
+	}
+
+	return diags
+}
+
+// validateIOARuleGroups validates the rule groups in the resource model.
+func validateIOARuleGroups(ctx context.Context, ioaRuleGroupSet types.Set) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	var ioaRuleGroups []string
+
+	diags.Append(ioaRuleGroupSet.ElementsAs(ctx, &ioaRuleGroups, false)...)
+	if diags.HasError() {
+		return diags
+	}
+
+	for _, id := range ioaRuleGroups {
+		if len(id) == 0 {
+			diags.AddAttributeError(
+				path.Root("ioa_rule_groups"),
+				"Error validating ioa rule group",
+				"ioa rule group ID cannot be empty",
+			)
+		}
+	}
+
+	return diags
+}
+
 // deletePreventionPolicy deletes a prevention policy by id.
 func deletePreventionPolicy(
 	ctx context.Context,
@@ -623,15 +671,15 @@ func updateHostGroups(
 
 	if err != nil {
 		diags.AddError("Error updating prevention policy host groups", fmt.Sprintf(
-			"Could not %s prevention policy (%s) host group (%s): %s",
+			"Error %s host groups (%s) to prevention policy (%s): %s",
 			actionMsg,
-			id,
 			strings.Join(hostGroupIDs, ", "),
+			id,
 			err.Error(),
 		))
 	}
 
-	if res != nil && res.Payload == nil {
+	if res == nil || res.Payload == nil {
 		return diags
 	}
 
@@ -639,10 +687,10 @@ func updateHostGroups(
 		diags.AddError(
 			"Error updating prevention policy host groups",
 			fmt.Sprintf(
-				"Could not %s prevention policy (%s) host group (%s): %s",
+				"Error %s host groups (%s) to prevention policy (%s): %s",
 				actionMsg,
-				id,
 				err.ID,
+				id,
 				err.String(),
 			),
 		)

--- a/internal/prevention_policy/windows.go
+++ b/internal/prevention_policy/windows.go
@@ -399,6 +399,11 @@ func (r *preventionPolicyWindowsResource) Create(
 	plan.Name = types.StringValue(*preventionPolicy.Name)
 	plan.LastUpdated = types.StringValue(time.Now().Format(time.RFC850))
 
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	if plan.Enabled.ValueBool() {
 		actionResp, diags := updatePolicyEnabledState(
 			ctx,
@@ -416,7 +421,6 @@ func (r *preventionPolicyWindowsResource) Create(
 	} else {
 		plan.Enabled = types.BoolValue(*preventionPolicy.Enabled)
 	}
-
 	r.assignPreventionSettings(&plan, preventionPolicy.PreventionSettings)
 
 	emptySet, diags := types.SetValueFrom(ctx, types.StringType, []string{})
@@ -625,6 +629,9 @@ func (r *preventionPolicyWindowsResource) ValidateConfig(
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	resp.Diagnostics.Append(validateHostGroups(ctx, config.HostGroups)...)
+	resp.Diagnostics.Append(validateIOARuleGroups(ctx, config.RuleGroups)...)
 
 	resp.Diagnostics.Append(
 		validateRequiredAttribute(


### PR DESCRIPTION
prevents empty string host groups and rule groups.

Error handling no longer panics when an invalid host group is provided.

closes issues found in #35 