### PR TITLE
make host_groups & ioa_rule_groups required for prevention policies

### DIFF
--- a/docs/resources/prevention_policy_linux.md
+++ b/docs/resources/prevention_policy_linux.md
@@ -74,6 +74,8 @@ output "prevention_policy_linux" {
 
 ### Required
 
+- `host_groups` (Set of String) Host Group ids to attach to the prevention policy.
+- `ioa_rule_groups` (Set of String) IOA Rule Group to attach to the prevention policy.
 - `name` (String) Name of the prevention policy.
 
 ### Optional
@@ -86,9 +88,7 @@ output "prevention_policy_linux" {
 - `enabled` (Boolean) Enable the prevention policy.
 - `filesystem_visibility` (Boolean) Whether to enable the setting. Allows the sensor to monitor filesystem activity for additional telemetry and improved detections.
 - `ftp_visibility` (Boolean) Whether to enable the setting. Allows the sensor to monitor unencrypted FTP traffic for malicious patterns and improved detections.
-- `host_groups` (Set of String) Host Group ids to attach to the prevention policy.
 - `http_visibility` (Boolean) Whether to enable the setting. Allows the sensor to monitor unencrypted HTTP traffic for malicious patterns and improved detections.
-- `ioa_rule_groups` (Set of String) IOA Rule Group to attach to the prevention policy.
 - `network_visibility` (Boolean) Whether to enable the setting. Allows the sensor to monitor network activity for additional telemetry and improved detections.
 - `prevent_suspicious_processes` (Boolean) Whether to enable the setting. Block processes that CrowdStrike analysts classify as suspicious. These are focused on dynamic IOAs, such as malware, exploits and other threats.
 - `quarantine` (Boolean) Whether to enable the setting. Quarantine executable files after they’re prevented by NGAV. When this is enabled, we recommend setting anti-malware prevention levels to Moderate or higher and not using other antivirus solutions.

--- a/docs/resources/prevention_policy_linux.md
+++ b/docs/resources/prevention_policy_linux.md
@@ -40,7 +40,7 @@ resource "crowdstrike_prevention_policy_linux" "example" {
   enabled         = true
   description     = "made with terraform"
   host_groups     = ["d6e3c1e1b3d0467da0fowc96a5e6ecb5"]
-  ioa_rule_groups = ["ed334b3243bc4b6bb8e7d40a2ecd86fa"]
+  ioa_rule_groups = []
   cloud_anti_malware = {
     "detection"  = "MODERATE"
     "prevention" = "CAUTIOUS"

--- a/docs/resources/prevention_policy_mac.md
+++ b/docs/resources/prevention_policy_mac.md
@@ -40,7 +40,7 @@ resource "crowdstrike_prevention_policy_mac" "example" {
   enabled         = false
   description     = "made with terraform"
   host_groups     = ["d6e3c1e1b3d0467da0fowc96a5e6ecb5"]
-  ioa_rule_groups = ["ed334b3243bc4b6bb8e7d40a2ecd86fa"]
+  ioa_rule_groups = []
   cloud_adware_and_pup = {
     "detection"  = "MODERATE"
     "prevention" = "CAUTIOUS"

--- a/docs/resources/prevention_policy_mac.md
+++ b/docs/resources/prevention_policy_mac.md
@@ -85,6 +85,8 @@ output "prevention_policy_mac" {
 
 ### Required
 
+- `host_groups` (Set of String) Host Group ids to attach to the prevention policy.
+- `ioa_rule_groups` (Set of String) IOA Rule Group to attach to the prevention policy.
 - `name` (String) Name of the prevention policy.
 
 ### Optional
@@ -98,9 +100,7 @@ output "prevention_policy_mac" {
 - `empyre_backdoor` (Boolean) Whether to enable the setting. A process with behaviors indicative of the Empyre Backdoor was terminated.
 - `enabled` (Boolean) Enable the prevention policy.
 - `hash_collector` (Boolean) Whether to enable the setting. An attempt to dump a user’s hashed password was blocked.
-- `host_groups` (Set of String) Host Group ids to attach to the prevention policy.
 - `intelligence_sourced_threats` (Boolean) Whether to enable the setting. Block processes that CrowdStrike Intelligence analysts classify as malicious. These are focused on static hash-based IOCs.
-- `ioa_rule_groups` (Set of String) IOA Rule Group to attach to the prevention policy.
 - `kc_password_decoded` (Boolean) Whether to enable the setting. An attempt to recover a plaintext password via the kcpassword file was blocked.
 - `notify_end_users` (Boolean) Whether to enable the setting. Show a pop-up notification to the end user when the Falcon sensor blocks, kills, or quarantines. See these messages in Console.app by searching for Process: Falcon Notifications.
 - `prevent_suspicious_processes` (Boolean) Whether to enable the setting. Block processes that CrowdStrike analysts classify as suspicious. These are focused on dynamic IOAs, such as malware, exploits and other threats.

--- a/docs/resources/prevention_policy_windows.md
+++ b/docs/resources/prevention_policy_windows.md
@@ -40,7 +40,7 @@ resource "crowdstrike_prevention_policy_windows" "example" {
   enabled         = false
   description     = "made with terraform"
   host_groups     = ["d6e3c1e1b3d0467da0fowc96a5e6ecb5"]
-  ioa_rule_groups = ["ed334b3243bc4b6bb8e7d40a2ecd86fa"]
+  ioa_rule_groups = []
   adware_and_pup = {
     "detection"  = "MODERATE"
     "prevention" = "CAUTIOUS"

--- a/docs/resources/prevention_policy_windows.md
+++ b/docs/resources/prevention_policy_windows.md
@@ -130,6 +130,8 @@ output "prevention_policy_windows" {
 
 ### Required
 
+- `host_groups` (Set of String) Host Group ids to attach to the prevention policy.
+- `ioa_rule_groups` (Set of String) IOA Rule Group to attach to the prevention policy.
 - `name` (String) Name of the prevention policy.
 
 ### Optional
@@ -163,11 +165,9 @@ output "prevention_policy_windows" {
 - `force_dep` (Boolean) Whether to enable the setting. A process that had Force Data Execution Prevention (Force DEP) applied tried to execute non-executable memory and was blocked. Requires additional_user_mode_data to be enabled.
 - `hardware_enhanced_exploit_detection` (Boolean) Whether to enable the setting. Provides additional visibility into application exploits by using CPU hardware features that detect suspicious control flows. Available only for hosts running Windows 10 (RS4) or Windows Server 2016 Version 1803 or later and Skylake or later CPU.
 - `heap_spray_preallocation` (Boolean) Whether to enable the setting. A heap spray attempt was detected and blocked. This may have been part of an attempted exploit. Requires additional_user_mode_data to be enabled.
-- `host_groups` (Set of String) Host Group ids to attach to the prevention policy.
 - `http_detections` (Boolean) Whether to enable the setting. Allows the sensor to monitor unencrypted HTTP traffic and certain encrypted HTTPS traffic on the sensor for malicious patterns and generate detection events on non-Server systems.
 - `intelligence_sourced_threats` (Boolean) Whether to enable the setting. Block processes that CrowdStrike Intelligence analysts classify as malicious. These are focused on static hash-based IOCs.
 - `interpreter_only` (Boolean) Whether to enable the setting. Provides visibility into malicious PowerShell interpreter usage. For hosts running Windows 10, Script-Based Execution Monitoring may be used instead.
-- `ioa_rule_groups` (Set of String) IOA Rule Group to attach to the prevention policy.
 - `javascript_via_rundll32` (Boolean) Whether to enable the setting. JavaScript executing from a command line via rundll32.exe was prevented.
 - `locky` (Boolean) Whether to enable the setting. A process determined to be associated with Locky was blocked.
 - `memory_scanning` (Boolean) Whether to enable the setting. Provides visibility into in-memory attacks by scanning for suspicious artifacts on hosts with the following: an integrated GPU and supporting OS libraries, Windows 10 v1607 (RS1) or later, and a Skylake or newer Intel CPU.

--- a/examples/resources/crowdstrike_prevention_policy_linux/resource.tf
+++ b/examples/resources/crowdstrike_prevention_policy_linux/resource.tf
@@ -16,7 +16,7 @@ resource "crowdstrike_prevention_policy_linux" "example" {
   enabled         = true
   description     = "made with terraform"
   host_groups     = ["d6e3c1e1b3d0467da0fowc96a5e6ecb5"]
-  ioa_rule_groups = ["ed334b3243bc4b6bb8e7d40a2ecd86fa"]
+  ioa_rule_groups = []
   cloud_anti_malware = {
     "detection"  = "MODERATE"
     "prevention" = "CAUTIOUS"

--- a/examples/resources/crowdstrike_prevention_policy_mac/resource.tf
+++ b/examples/resources/crowdstrike_prevention_policy_mac/resource.tf
@@ -16,7 +16,7 @@ resource "crowdstrike_prevention_policy_mac" "example" {
   enabled         = false
   description     = "made with terraform"
   host_groups     = ["d6e3c1e1b3d0467da0fowc96a5e6ecb5"]
-  ioa_rule_groups = ["ed334b3243bc4b6bb8e7d40a2ecd86fa"]
+  ioa_rule_groups = []
   cloud_adware_and_pup = {
     "detection"  = "MODERATE"
     "prevention" = "CAUTIOUS"

--- a/examples/resources/crowdstrike_prevention_policy_windows/resource.tf
+++ b/examples/resources/crowdstrike_prevention_policy_windows/resource.tf
@@ -16,7 +16,7 @@ resource "crowdstrike_prevention_policy_windows" "example" {
   enabled         = false
   description     = "made with terraform"
   host_groups     = ["d6e3c1e1b3d0467da0fowc96a5e6ecb5"]
-  ioa_rule_groups = ["ed334b3243bc4b6bb8e7d40a2ecd86fa"]
+  ioa_rule_groups = []
   adware_and_pup = {
     "detection"  = "MODERATE"
     "prevention" = "CAUTIOUS"

--- a/internal/prevention_policy/linux.go
+++ b/internal/prevention_policy/linux.go
@@ -132,12 +132,12 @@ func (r *preventionPolicyLinuxResource) Schema(
 				Default:     booldefault.StaticBool(true),
 			},
 			"host_groups": schema.SetAttribute{
-				Optional:    true,
+				Required:    true,
 				ElementType: types.StringType,
 				Description: "Host Group ids to attach to the prevention policy.",
 			},
 			"ioa_rule_groups": schema.SetAttribute{
-				Optional:    true,
+				Required:    true,
 				ElementType: types.StringType,
 				Description: "IOA Rule Group to attach to the prevention policy.",
 			},

--- a/internal/prevention_policy/mac.go
+++ b/internal/prevention_policy/mac.go
@@ -137,12 +137,12 @@ func (r *preventionPolicyMacResource) Schema(
 				Default:     booldefault.StaticBool(true),
 			},
 			"host_groups": schema.SetAttribute{
-				Optional:    true,
+				Required:    true,
 				ElementType: types.StringType,
 				Description: "Host Group ids to attach to the prevention policy.",
 			},
 			"ioa_rule_groups": schema.SetAttribute{
-				Optional:    true,
+				Required:    true,
 				ElementType: types.StringType,
 				Description: "IOA Rule Group to attach to the prevention policy.",
 			},

--- a/internal/prevention_policy/windows.go
+++ b/internal/prevention_policy/windows.go
@@ -174,12 +174,12 @@ func (r *preventionPolicyWindowsResource) Schema(
 				Default:     booldefault.StaticBool(true),
 			},
 			"host_groups": schema.SetAttribute{
-				Optional:    true,
+				Required:    true,
 				ElementType: types.StringType,
 				Description: "Host Group ids to attach to the prevention policy.",
 			},
 			"ioa_rule_groups": schema.SetAttribute{
-				Optional:    true,
+				Required:    true,
 				ElementType: types.StringType,
 				Description: "IOA Rule Group to attach to the prevention policy.",
 			},

--- a/internal/prevention_policy/windows_test.go
+++ b/internal/prevention_policy/windows_test.go
@@ -15,6 +15,8 @@ func testAccPreventionPolicyWindowsConfig_basic(rName string, enabled bool) stri
 resource "crowdstrike_prevention_policy_windows" "test" {
   name                      = "%s"
   enabled                   = %t 
+  host_groups               = []
+  ioa_rule_groups           = []
   description               = "made with terraform"
   additional_user_mode_data = true
   cloud_anti_malware_microsoft_office_files = {


### PR DESCRIPTION
`host_groups` & `ioa_rule_groups` are currently optional, but changes made to make resource references (#49) and variable references (#51) exposed some state issues.

The existing behavior is to remove any groups from a resource that does not specify a `host_groups` or `ioa_rule_groups` attribute. This keeps that behavior, but makes the action more explicit by requiring the attributes to be to set `host_groups = []` & `ioa_rule_groups = []` while preventing a slew of state issues.