### PR TITLE
handle zlinux builds

### DIFF
--- a/internal/provider/sensor_update_policy_builds_data_source.go
+++ b/internal/provider/sensor_update_policy_builds_data_source.go
@@ -203,7 +203,7 @@ func (d *sensorUpdatePolicyBuildsDataSource) Read(
 		case "linux":
 			mapBuild(&linuxPlatformBuilds, build)
 			linuxBuilds = append(linuxBuilds, build)
-		default:
+		case "linuxarm64":
 			mapBuild(&linuxArm64PlatformBuilds, build)
 			linuxArm64Builds = append(linuxArm64Builds, build)
 		}


### PR DESCRIPTION
zlinux builds were defaulting to LinuxArm64 which could lead to an api error