### PR TITLE
poll for eventbus arn when creating

### DIFF
--- a/internal/fcs/cloud_aws_account.go
+++ b/internal/fcs/cloud_aws_account.go
@@ -1390,7 +1390,7 @@ func (r *cloudAWSAccountResource) ValidateConfig(
 	}
 }
 
-// pollMissingValues waits for missing backend values [eventbus_arn, eventbus_name, cloudtrail_bucket_name] to be set
+// pollMissingValues waits for missing backend values [eventbus_arn, eventbus_name, cloudtrail_bucket_name] to be set.
 func (r *cloudAWSAccountResource) pollMissingValues(
 	ctx context.Context,
 	config *cloudAWSAccountModel,

--- a/internal/fcs/cloud_aws_account.go
+++ b/internal/fcs/cloud_aws_account.go
@@ -745,7 +745,7 @@ func (r *cloudAWSAccountResource) Read(
 	}
 
 	state.AccountID = types.StringValue(cspmAccount.AccountID)
-	state.OrganizationID = types.StringValue(cspmAccount.OrganizationID)
+	state.OrganizationID = oldState.OrganizationID
 	state.AccountType = types.StringValue(cspmAccount.AccountType)
 	state.DeploymentMethod = oldState.DeploymentMethod
 	if state.DeploymentMethod.IsNull() {

--- a/internal/fcs/cloud_aws_account.go
+++ b/internal/fcs/cloud_aws_account.go
@@ -31,6 +31,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"golang.org/x/exp/maps"
 )
 
 type cloudAWSAccountResource struct {
@@ -526,10 +527,9 @@ func (r *cloudAWSAccountResource) Create(
 		}
 	}
 
-	// if IDP or realtime visibility are enabled wait until we get a value for EventbusArn
-	if (state.IDP.Enabled.ValueBool() || state.RealtimeVisibility.Enabled.ValueBool()) &&
-		state.EventbusArn.ValueString() == "" {
-		resp.Diagnostics.Append(r.pollEventbusArn(ctx, &state)...)
+	// if IDP or realtime visibility are enabled wait until we get all values back
+	if state.IDP.Enabled.ValueBool() || state.RealtimeVisibility.Enabled.ValueBool() {
+		resp.Diagnostics.Append(r.pollMissingValues(ctx, &state)...)
 	}
 
 	// Set refreshed state
@@ -1368,12 +1368,29 @@ func (r *cloudAWSAccountResource) ValidateConfig(
 	}
 }
 
-// pollEventbusArn waits for eventbus_arn to be set
-func (r *cloudAWSAccountResource) pollEventbusArn(
+// pollMissingValues waits for missing backend values [eventbus_arn, eventbus_name, cloudtrail_bucket_name] to be set
+func (r *cloudAWSAccountResource) pollMissingValues(
 	ctx context.Context,
 	config *cloudAWSAccountModel,
 ) diag.Diagnostics {
 	var diags diag.Diagnostics
+	missingValues := make(map[string]interface{})
+
+	if config.EventbusArn.ValueString() == "" {
+		missingValues["eventbus_arn"] = nil
+	}
+
+	if config.EventbusName.ValueString() == "" {
+		missingValues["eventbus_name"] = nil
+	}
+
+	if config.CloudTrailBucketName.ValueString() == "" {
+		missingValues["cloudtrail_bucket_name"] = nil
+	}
+
+	if len(missingValues) == 0 {
+		return diags
+	}
 
 	pollCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
@@ -1389,18 +1406,48 @@ func (r *cloudAWSAccountResource) pollEventbusArn(
 				return diag
 			}
 
-			if account.AwsEventbusArn != "" {
+			if _, ok := missingValues["eventbus_arn"]; ok && account.AwsEventbusArn != "" {
 				config.EventbusArn = types.StringValue(account.AwsEventbusArn)
+				delete(missingValues, "eventbus_arn")
+			}
+
+			if _, ok := missingValues["eventbus_name"]; ok && account.EventbusName != "" {
 				config.EventbusName = types.StringValue(account.EventbusName)
+				delete(missingValues, "eventbus_name")
+			}
+
+			if _, ok := missingValues["cloudtrail_bucket_name"]; ok &&
+				account.AwsCloudtrailBucketName != "" {
+				config.CloudTrailBucketName = types.StringValue(account.AwsCloudtrailBucketName)
+				delete(missingValues, "cloudtrail_bucket_name")
+			}
+
+			if len(missingValues) == 0 {
 				return diags
 			}
 
-			tflog.Debug(pollCtx, "EventBus ARN not yet available, polling again in 10s...")
+			fields := strings.Join(maps.Keys(missingValues), ", ")
+			tflog.Debug(
+				pollCtx,
+				fmt.Sprintf("[%s] not yet available, polling again in 10s...", fields),
+			)
 
 		case <-pollCtx.Done():
+			if pollCtx.Err() != context.DeadlineExceeded {
+				return diags
+			}
+
+			if len(missingValues) == 0 {
+				return diags
+			}
+
+			fields := strings.Join(maps.Keys(missingValues), ", ")
 			diags.AddError(
-				"Timed out waiting for eventbus_arn",
-				"Timed out on create waiting for eventbus arn to return from API.",
+				"Timed out waiting for missing fields to populate",
+				fmt.Sprintf(
+					"Timed out on create waiting for missing fields [%s] to return from API.",
+					fields,
+				),
 			)
 			return diags
 		}

--- a/internal/fcs/cloud_aws_account.go
+++ b/internal/fcs/cloud_aws_account.go
@@ -1366,8 +1366,8 @@ func (r *cloudAWSAccountResource) ImportState(
 	ous := []string{}
 	if account.IsMaster && len(account.TargetOus) != 0 {
 		ous = account.TargetOus
-
 	}
+
 	targetOUs, diags := types.ListValueFrom(ctx, types.StringType, ous)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)


### PR DESCRIPTION
- adds polling logic to ensure eventbus_arn is set when creating
- uses stateforunknown for computed variables to prevent inconsistent plans
- sets organization id on read to prevent import errors