### PR TITLE
add default_sensor_update_policy resource

### DIFF
--- a/docs/resources/default_sensor_update_policy.md
+++ b/docs/resources/default_sensor_update_policy.md
@@ -1,16 +1,16 @@
 ---
-page_title: "crowdstrike_sensor_update_policy Resource - crowdstrike"
+page_title: "crowdstrike_default_sensor_update_policy Resource - crowdstrike"
 subcategory: "Sensor Update Policy"
 description: |-
-  This resource allows management of sensor update policies in the CrowdStrike Falcon platform. Sensor update policies allow you to control the update process across a set of hosts.
+  This resource allows management of the default sensor update policy in the CrowdStrike Falcon platform.
   API Scopes
   The following API scopes are required:
   Sensor update policies | Read & Write
 ---
 
-# crowdstrike_sensor_update_policy (Resource)
+# crowdstrike_default_sensor_update_policy (Resource)
 
-This resource allows management of sensor update policies in the CrowdStrike Falcon platform. Sensor update policies allow you to control the update process across a set of hosts.
+This resource allows management of the default sensor update policy in the CrowdStrike Falcon platform.
 
 ## API Scopes
 
@@ -36,14 +36,10 @@ provider "crowdstrike" {
 
 data "crowdstrike_sensor_update_policy_builds" "all" {}
 
-resource "crowdstrike_sensor_update_policy" "example" {
-  name                 = "example_prevention_policy"
-  enabled              = false
-  description          = "made with terraform"
-  platform_name        = "Windows"
+resource "crowdstrike_default_sensor_update_policy" "default" {
+  platform_name        = "windows"
   build                = data.crowdstrike_sensor_update_policy_builds.all.windows.n1.build
-  uninstall_protection = false
-  host_groups          = ["host_group_id"]
+  uninstall_protection = true
   schedule = {
     enabled  = true
     timezone = "Etc/UTC"
@@ -57,8 +53,9 @@ resource "crowdstrike_sensor_update_policy" "example" {
   }
 }
 
+
 output "sensor_policy" {
-  value = crowdstrike_sensor_update_policy.example
+  value = crowdstrike_default_sensor_update_policy.default
 }
 ```
 
@@ -67,17 +64,13 @@ output "sensor_policy" {
 
 ### Required
 
-- `build` (String) Sensor build to use for the sensor update policy.
-- `name` (String) Name of the sensor update policy.
-- `platform_name` (String) Platform for the sensor update policy to manage. (Windows, Mac, Linux)
+- `build` (String) Sensor build to use for the default sensor update policy.
+- `platform_name` (String) Chooses which default sensor update policy to manage. (Windows, Mac, Linux)
 - `schedule` (Attributes) Prohibit sensor updates during a set of time blocks. (see [below for nested schema](#nestedatt--schedule))
 
 ### Optional
 
-- `build_arm64` (String) Sensor arm64 build to use for the sensor update policy (Linux only). Required if platform_name is Linux.
-- `description` (String) Description of the sensor update policy.
-- `enabled` (Boolean) Enable the sensor update policy.
-- `host_groups` (Set of String) Host Group ids to attach to the sensor update policy.
+- `build_arm64` (String) Sensor arm64 build to use for the default sensor update policy (Linux only). Required if platform_name is Linux.
 - `uninstall_protection` (Boolean) Enable uninstall protection. Windows and Mac only.
 
 ### Read-Only
@@ -111,6 +104,6 @@ Required:
 Import is supported using the following syntax:
 
 ```shell
-# sensor update policies can be imported by specifying the policy id.
-terraform import crowdstrike_sensor_update_policy.example 7fb858a949034a0cbca175f660f1e769
+# A default sensor update policy can be imported by specifying the policy id.
+terraform import crowdstrike_default_sensor_update_policy.default 7fb858a949034a0cbca175f660f1e769
 ```

--- a/examples/resources/crowdstrike_default_sensor_update_policy/import.sh
+++ b/examples/resources/crowdstrike_default_sensor_update_policy/import.sh
@@ -1,0 +1,3 @@
+# A default sensor update policy can be imported by specifying the policy id.
+terraform import crowdstrike_default_sensor_update_policy.default 7fb858a949034a0cbca175f660f1e769
+

--- a/examples/resources/crowdstrike_default_sensor_update_policy/resource.tf
+++ b/examples/resources/crowdstrike_default_sensor_update_policy/resource.tf
@@ -1,0 +1,35 @@
+terraform {
+  required_providers {
+    crowdstrike = {
+      source = "registry.terraform.io/crowdstrike/crowdstrike"
+    }
+  }
+}
+
+provider "crowdstrike" {
+  cloud = "us-2"
+}
+
+data "crowdstrike_sensor_update_policy_builds" "all" {}
+
+resource "crowdstrike_default_sensor_update_policy" "default" {
+  platform_name        = "windows"
+  build                = data.crowdstrike_sensor_update_policy_builds.all.windows.n1.build
+  uninstall_protection = true
+  schedule = {
+    enabled  = true
+    timezone = "Etc/UTC"
+    time_blocks = [
+      {
+        days       = ["sunday", "wednesday"]
+        start_time = "12:40"
+        end_time   = "16:40"
+      }
+    ]
+  }
+}
+
+
+output "sensor_policy" {
+  value = crowdstrike_default_sensor_update_policy.default
+}

--- a/examples/resources/crowdstrike_sensor_update_policy/import.sh
+++ b/examples/resources/crowdstrike_sensor_update_policy/import.sh
@@ -1,3 +1,3 @@
-# prevention policy can be imported by specifying the policy id.
+# sensor update policies can be imported by specifying the policy id.
 terraform import crowdstrike_sensor_update_policy.example 7fb858a949034a0cbca175f660f1e769
 

--- a/examples/resources/crowdstrike_sensor_update_policy/resource.tf
+++ b/examples/resources/crowdstrike_sensor_update_policy/resource.tf
@@ -10,13 +10,14 @@ provider "crowdstrike" {
   cloud = "us-2"
 }
 
+data "crowdstrike_sensor_update_policy_builds" "all" {}
 
 resource "crowdstrike_sensor_update_policy" "example" {
   name                 = "example_prevention_policy"
   enabled              = false
   description          = "made with terraform"
   platform_name        = "Windows"
-  build                = "18110"
+  build                = data.crowdstrike_sensor_update_policy_builds.all.windows.n1.build
   uninstall_protection = false
   host_groups          = ["host_group_id"]
   schedule = {

--- a/internal/prevention_policy/linux.go
+++ b/internal/prevention_policy/linux.go
@@ -8,6 +8,7 @@ import (
 	"github.com/crowdstrike/gofalcon/falcon/client"
 	"github.com/crowdstrike/gofalcon/falcon/models"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/scopes"
+	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/utils"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -473,8 +474,8 @@ func (r *preventionPolicyLinuxResource) ValidateConfig(
 		return
 	}
 
-	resp.Diagnostics.Append(validateHostGroups(ctx, config.HostGroups)...)
-	resp.Diagnostics.Append(validateIOARuleGroups(ctx, config.RuleGroups)...)
+	resp.Diagnostics.Append(utils.ValidateEmptyIDs(ctx, config.HostGroups, "host_groups")...)
+	resp.Diagnostics.Append(utils.ValidateEmptyIDs(ctx, config.RuleGroups, "ioa_rule_groups")...)
 
 	if config.CloudAntiMalware != nil {
 		resp.Diagnostics.Append(

--- a/internal/prevention_policy/mac.go
+++ b/internal/prevention_policy/mac.go
@@ -8,6 +8,7 @@ import (
 	"github.com/crowdstrike/gofalcon/falcon/client"
 	"github.com/crowdstrike/gofalcon/falcon/models"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/scopes"
+	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/utils"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -479,8 +480,8 @@ func (r *preventionPolicyMacResource) ValidateConfig(
 		return
 	}
 
-	resp.Diagnostics.Append(validateHostGroups(ctx, config.HostGroups)...)
-	resp.Diagnostics.Append(validateIOARuleGroups(ctx, config.RuleGroups)...)
+	resp.Diagnostics.Append(utils.ValidateEmptyIDs(ctx, config.HostGroups, "host_groups")...)
+	resp.Diagnostics.Append(utils.ValidateEmptyIDs(ctx, config.RuleGroups, "ioa_rule_groups")...)
 
 	resp.Diagnostics.Append(
 		validateRequiredAttribute(

--- a/internal/prevention_policy/shared.go
+++ b/internal/prevention_policy/shared.go
@@ -449,68 +449,6 @@ func validateRequiredAttribute(
 	return diags
 }
 
-// validateHostGroups validates the host groups in the resource model.
-func validateHostGroups(ctx context.Context, hostGroupSet types.Set) diag.Diagnostics {
-	var diags diag.Diagnostics
-
-	if hostGroupSet.IsNull() {
-		return diags
-	}
-
-	if hostGroupSet.IsUnknown() {
-		return diags
-	}
-
-	hostGroups := make([]types.String, 0, len(hostGroupSet.Elements()))
-	diags.Append(hostGroupSet.ElementsAs(ctx, &hostGroups, false)...)
-	if diags.HasError() {
-		return diags
-	}
-
-	for _, id := range hostGroups {
-		if !id.IsUnknown() && len(id.ValueString()) == 0 {
-			diags.AddAttributeError(
-				path.Root("host_groups"),
-				"Error validating host group",
-				"Host group ID cannot be empty",
-			)
-		}
-	}
-
-	return diags
-}
-
-// validateIOARuleGroups validates the rule groups in the resource model.
-func validateIOARuleGroups(ctx context.Context, ioaRuleGroupSet types.Set) diag.Diagnostics {
-	var diags diag.Diagnostics
-
-	if ioaRuleGroupSet.IsNull() {
-		return diags
-	}
-
-	if ioaRuleGroupSet.IsUnknown() {
-		return diags
-	}
-
-	ioaRuleGroups := make([]types.String, 0, len(ioaRuleGroupSet.Elements()))
-	diags.Append(ioaRuleGroupSet.ElementsAs(ctx, &ioaRuleGroups, false)...)
-	if diags.HasError() {
-		return diags
-	}
-
-	for _, id := range ioaRuleGroups {
-		if !id.IsUnknown() && len(id.ValueString()) == 0 {
-			diags.AddAttributeError(
-				path.Root("ioa_rule_groups"),
-				"Error validating ioa rule group",
-				"ioa rule group ID cannot be empty",
-			)
-		}
-	}
-
-	return diags
-}
-
 // deletePreventionPolicy deletes a prevention policy by id.
 func deletePreventionPolicy(
 	ctx context.Context,

--- a/internal/prevention_policy/windows.go
+++ b/internal/prevention_policy/windows.go
@@ -8,6 +8,7 @@ import (
 	"github.com/crowdstrike/gofalcon/falcon/client"
 	"github.com/crowdstrike/gofalcon/falcon/models"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/scopes"
+	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/utils"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -634,8 +635,8 @@ func (r *preventionPolicyWindowsResource) ValidateConfig(
 		return
 	}
 
-	resp.Diagnostics.Append(validateHostGroups(ctx, config.HostGroups)...)
-	resp.Diagnostics.Append(validateIOARuleGroups(ctx, config.RuleGroups)...)
+	resp.Diagnostics.Append(utils.ValidateEmptyIDs(ctx, config.HostGroups, "host_groups")...)
+	resp.Diagnostics.Append(utils.ValidateEmptyIDs(ctx, config.RuleGroups, "ioa_rule_groups")...)
 
 	resp.Diagnostics.Append(
 		validateRequiredAttribute(

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -13,6 +13,7 @@ import (
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/fcs"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/fim"
 	preventionpolicy "github.com/crowdstrike/terraform-provider-crowdstrike/internal/prevention_policy"
+	sensorupdatepolicy "github.com/crowdstrike/terraform-provider-crowdstrike/internal/sensor_update_policy"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/function"
@@ -229,7 +230,8 @@ func (p *CrowdStrikeProvider) Configure(
 
 func (p *CrowdStrikeProvider) Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
-		NewSensorUpdatePolicyResource,
+		sensorupdatepolicy.NewSensorUpdatePolicyResource,
+		sensorupdatepolicy.NewDefaultSensorUpdatePolicyResource,
 		NewHostGroupResource,
 		preventionpolicy.NewPreventionPolicyWindowsResource,
 		preventionpolicy.NewPreventionPolicyLinuxResource,
@@ -242,7 +244,7 @@ func (p *CrowdStrikeProvider) Resources(ctx context.Context) []func() resource.R
 
 func (p *CrowdStrikeProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
-		NewSensorUpdateBuildsDataSource,
+		sensorupdatepolicy.NewSensorUpdateBuildsDataSource,
 		fcs.NewCloudAwsAccountsDataSource,
 	}
 }

--- a/internal/sensor_update_policy/default_sensor_update_policy_resource.go
+++ b/internal/sensor_update_policy/default_sensor_update_policy_resource.go
@@ -1,0 +1,709 @@
+package sensorupdatepolicy
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/crowdstrike/gofalcon/falcon/client"
+	"github.com/crowdstrike/gofalcon/falcon/client/sensor_update_policies"
+	"github.com/crowdstrike/gofalcon/falcon/models"
+	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/scopes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"golang.org/x/exp/maps"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ resource.Resource                   = &defaultSensorUpdatePolicyResource{}
+	_ resource.ResourceWithConfigure      = &defaultSensorUpdatePolicyResource{}
+	_ resource.ResourceWithImportState    = &defaultSensorUpdatePolicyResource{}
+	_ resource.ResourceWithValidateConfig = &defaultSensorUpdatePolicyResource{}
+)
+
+// NewDefaultSensorUpdatePolicyResource is a helper function to simplify the provider implementation.
+func NewDefaultSensorUpdatePolicyResource() resource.Resource {
+	return &defaultSensorUpdatePolicyResource{}
+}
+
+// defaultSensorUpdatePolicyResource is the resource implementation.
+type defaultSensorUpdatePolicyResource struct {
+	client *client.CrowdStrikeAPISpecification
+}
+
+// defaultSensorUpdatePolicyResourceModel is the resource model.
+type defaultSensorUpdatePolicyResourceModel struct {
+	ID                  types.String `tfsdk:"id"`
+	Build               types.String `tfsdk:"build"`
+	BuildArm64          types.String `tfsdk:"build_arm64"`
+	PlatformName        types.String `tfsdk:"platform_name"`
+	UninstallProtection types.Bool   `tfsdk:"uninstall_protection"`
+	LastUpdated         types.String `tfsdk:"last_updated"`
+	Schedule            types.Object `tfsdk:"schedule"`
+
+	schedule *policySchedule `tfsdk:"-"`
+}
+
+// extract extracts the Go values form their terraform wrapped values.
+func (d *defaultSensorUpdatePolicyResourceModel) extract(ctx context.Context) diag.Diagnostics {
+	var diags diag.Diagnostics
+	if !d.Schedule.IsNull() {
+		d.schedule = &policySchedule{}
+		diags = d.Schedule.As(ctx, d.schedule, basetypes.ObjectAsOptions{})
+	}
+
+	return diags
+}
+
+// wrap transforms Go values to their terraform wrapped values.
+func (d *defaultSensorUpdatePolicyResourceModel) wrap(
+	ctx context.Context,
+	policy models.SensorUpdatePolicyV2,
+	validateBuilds bool,
+) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	d.ID = types.StringValue(*policy.ID)
+	if validateBuilds && d.Build.ValueString() != *policy.Settings.Build {
+		diags.AddError(
+			"Inconsistent build returned",
+			fmt.Sprintf(
+				"The API returned a build that did not match the build in plan: %s This normally occurs when an invalid build is provided, please check the build you are passing is valid. It is recommended to use crowdstrike_sensor_update_policy_builds data source to query for build numbers.\n\nIf you believe there is a bug in the provider or need help please let us know by opening a github issue here: https://github.com/CrowdStrike/terraform-provider-crowdstrike/issues",
+				d.Build,
+			),
+		)
+	}
+	d.Build = types.StringValue(*policy.Settings.Build)
+
+	if d.PlatformName.IsNull() {
+		d.PlatformName = types.StringValue(*policy.PlatformName)
+	}
+
+	if !strings.EqualFold(d.PlatformName.ValueString(), *policy.PlatformName) {
+		diags.AddError(
+			"Mismatch platform_name",
+			fmt.Sprintf(
+				"The api returned the following platform_name: %s for default sensor update policy: %s, the terraform config has a platform_name value of %s. This should not be possible, if you imported this resource ensure you updated the platform_name to the correct value in your terraform config.\n\nIf you believe there is a bug in the provider or need help please let us know by opening a github issue here: https://github.com/CrowdStrike/terraform-provider-crowdstrike/issues",
+				*policy.PlatformName,
+				d.ID,
+				d.PlatformName.ValueString(),
+			),
+		)
+
+	}
+
+	if strings.ToLower(d.PlatformName.ValueString()) == "linux" &&
+		policy.Settings.Variants != nil {
+		for _, v := range policy.Settings.Variants {
+			vCopy := *v
+			if vCopy.Platform == nil {
+				continue
+			}
+
+			if strings.EqualFold(*vCopy.Platform, linuxArm64Varient) {
+				if validateBuilds && d.BuildArm64.ValueString() != *vCopy.Build {
+					diags.AddError(
+						"Inconsistent build_arm64 returned",
+						fmt.Sprintf(
+							"The API returned a build_arm64 that did not match the build in plan: %s This normally occurs when an invalid build is provided, please check the build you are passing is valid. It is recommended to use crowdstrike_sensor_update_policy_builds data source to query for build numbers.\n\nIf you believe there is a bug in the provider or need help please let us know by opening a github issue here: https://github.com/CrowdStrike/terraform-provider-crowdstrike/issues",
+							d.BuildArm64,
+						),
+					)
+				}
+				d.BuildArm64 = types.StringValue(*vCopy.Build)
+			}
+		}
+	}
+
+	if *policy.Settings.UninstallProtection == "ENABLED" {
+		d.UninstallProtection = types.BoolValue(true)
+	} else {
+		d.UninstallProtection = types.BoolValue(false)
+	}
+
+	if policy.Settings.Scheduler != nil {
+		d.schedule = &policySchedule{}
+		d.schedule.Enabled = types.BoolValue(*policy.Settings.Scheduler.Enabled)
+
+		// ignore the timzezone and time_blocks if the schedule is DISABLED
+		// this allows terraform import to work correctly
+		if d.schedule.Enabled.ValueBool() {
+			d.schedule.Timezone = types.StringValue(*policy.Settings.Scheduler.Timezone)
+
+			if policy.Settings.Scheduler.Schedules != nil {
+				if len(policy.Settings.Scheduler.Schedules) > 0 {
+					d.schedule.TimeBlocks = []timeBlock{}
+
+					for _, s := range policy.Settings.Scheduler.Schedules {
+						sCopy := s
+						daysStr := []string{}
+
+						for _, d := range sCopy.Days {
+							dCopy := d
+							daysStr = append(daysStr, int64ToDay[dCopy])
+						}
+
+						days, diags := types.SetValueFrom(ctx, types.StringType, daysStr)
+						diags.Append(diags...)
+						if diags.HasError() {
+							return diags
+						}
+						d.schedule.TimeBlocks = append(d.schedule.TimeBlocks, timeBlock{
+							Days:      days,
+							StartTime: types.StringValue(*sCopy.Start),
+							EndTime:   types.StringValue(*sCopy.End),
+						})
+					}
+				}
+			}
+		}
+	}
+
+	if d.schedule != nil {
+		policyScheduleObj, diag := types.ObjectValueFrom(
+			ctx,
+			d.schedule.AttributeTypes(),
+			d.schedule,
+		)
+		d.Schedule = policyScheduleObj
+		diags.Append(diag...)
+
+	}
+
+	return diags
+}
+
+// Configure adds the provider configured client to the resource.
+func (r *defaultSensorUpdatePolicyResource) Configure(
+	ctx context.Context,
+	req resource.ConfigureRequest,
+	resp *resource.ConfigureResponse,
+) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*client.CrowdStrikeAPISpecification)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf(
+				"Expected *client.CrowdStrikeAPISpecification, got: %T. Please report this issue to the provider developers.",
+				req.ProviderData,
+			),
+		)
+
+		return
+	}
+
+	r.client = client
+}
+
+// Metadata returns the resource type name.
+func (r *defaultSensorUpdatePolicyResource) Metadata(
+	_ context.Context,
+	req resource.MetadataRequest,
+	resp *resource.MetadataResponse,
+) {
+	resp.TypeName = req.ProviderTypeName + "_default_sensor_update_policy"
+}
+
+// Schema defines the schema for the resource.
+func (r *defaultSensorUpdatePolicyResource) Schema(
+	_ context.Context,
+	_ resource.SchemaRequest,
+	resp *resource.SchemaResponse,
+) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: fmt.Sprintf(
+			"Sensor Update Policy --- This resource allows management of the default sensor update policy in the CrowdStrike Falcon platform.\n\n%s",
+			scopes.GenerateScopeDescription(
+				[]scopes.Scope{
+					{
+						Name:  "Sensor update policies",
+						Read:  true,
+						Write: true,
+					},
+				},
+			),
+		),
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Identifier for the sensor update policy.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"last_updated": schema.StringAttribute{
+				Computed:    true,
+				Description: "Timestamp of the last Terraform update of the resource.",
+			},
+			"build": schema.StringAttribute{
+				Required:    true,
+				Description: "Sensor build to use for the default sensor update policy.",
+			},
+			"build_arm64": schema.StringAttribute{
+				Optional:    true,
+				Description: "Sensor arm64 build to use for the default sensor update policy (Linux only). Required if platform_name is Linux.",
+			},
+			"platform_name": schema.StringAttribute{
+				Required:    true,
+				Description: "Chooses which default sensor update policy to manage. (Windows, Mac, Linux)",
+				Validators: []validator.String{
+					stringvalidator.OneOfCaseInsensitive("Windows", "Linux", "Mac"),
+				},
+			},
+			"uninstall_protection": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "Enable uninstall protection. Windows and Mac only.",
+				Default:     booldefault.StaticBool(false),
+			},
+			"schedule": schema.SingleNestedAttribute{
+				Required:    true,
+				Description: "Prohibit sensor updates during a set of time blocks.",
+				Attributes: map[string]schema.Attribute{
+					"enabled": schema.BoolAttribute{
+						Required:    true,
+						Description: "Enable the scheduler for sensor update policy.",
+					},
+					"timezone": schema.StringAttribute{
+						Optional:    true,
+						Description: "The time zones that will be used for the time blocks. Only set when enabled is true.",
+						Validators: []validator.String{
+							stringvalidator.OneOf(timezones...),
+						},
+					},
+					"time_blocks": schema.SetNestedAttribute{
+						Optional:    true,
+						Description: "The time block to prevent sensor updates. Only set when enabled is true.",
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"days": schema.SetAttribute{
+									Required:    true,
+									ElementType: types.StringType,
+									Description: "The days of the week the time block should be active.",
+									Validators: []validator.Set{
+										setvalidator.ValueStringsAre(
+											stringvalidator.OneOfCaseInsensitive(
+												maps.Keys(dayToInt64)...,
+											),
+										),
+									},
+								},
+								"start_time": schema.StringAttribute{
+									Required:    true,
+									Description: "The start time for the time block in 24HR format. Must be atleast 1 hour before end_time.",
+								},
+								"end_time": schema.StringAttribute{
+									Required:    true,
+									Description: "The end time for the time block in 24HR format. Must be atleast 1 hour more than start_time.",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// Create imports the resource into state and configures it. The default resource policy can't be created or deleted.
+func (r *defaultSensorUpdatePolicyResource) Create(
+	ctx context.Context,
+	req resource.CreateRequest,
+	resp *resource.CreateResponse,
+) {
+	var plan defaultSensorUpdatePolicyResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(plan.extract(ctx)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	policy, diags := r.getDefaultPolicy(ctx, plan.PlatformName.ValueString())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	plan.ID = types.StringValue(*policy.ID)
+	resp.Diagnostics.Append(
+		resp.State.SetAttribute(ctx, path.Root("id"), plan.ID)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	policy, diags = r.updateDefaultPolicy(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	plan.LastUpdated = types.StringValue(time.Now().Format(time.RFC850))
+	resp.Diagnostics.Append(plan.wrap(ctx, *policy, true)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (r *defaultSensorUpdatePolicyResource) Read(
+	ctx context.Context,
+	req resource.ReadRequest,
+	resp *resource.ReadResponse,
+) {
+	var state defaultSensorUpdatePolicyResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	res, err := r.client.SensorUpdatePolicies.GetSensorUpdatePoliciesV2(
+		&sensor_update_policies.GetSensorUpdatePoliciesV2Params{
+			Context: ctx,
+			Ids:     []string{state.ID.ValueString()},
+		},
+	)
+
+	if notFound, ok := err.(*sensor_update_policies.GetSensorUpdatePoliciesV2NotFound); ok {
+		tflog.Warn(
+			ctx,
+			fmt.Sprintf("sensor update policy %s not found, removing from state", state.ID),
+			map[string]interface{}{"resp": notFound},
+		)
+
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading CrowdStrike sensor update policy",
+			"Could not read CrowdStrike sensor update policy: "+state.ID.ValueString()+": "+err.Error(),
+		)
+		return
+	}
+
+	policy := res.Payload.Resources[0]
+
+	resp.Diagnostics.Append(state.wrap(ctx, *policy, false)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Update updates the resource and sets the updated Terraform state on success.
+func (r *defaultSensorUpdatePolicyResource) Update(
+	ctx context.Context,
+	req resource.UpdateRequest,
+	resp *resource.UpdateResponse,
+) {
+	var plan defaultSensorUpdatePolicyResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(plan.extract(ctx)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	policy, diags := r.updateDefaultPolicy(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	plan.LastUpdated = types.StringValue(time.Now().Format(time.RFC850))
+
+	resp.Diagnostics.Append(plan.wrap(ctx, *policy, true)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Delete deletes the resource and removes the Terraform state on success.
+func (r *defaultSensorUpdatePolicyResource) Delete(
+	ctx context.Context,
+	req resource.DeleteRequest,
+	resp *resource.DeleteResponse,
+) {
+	// We can not delete the default sensor update policy, so we will just remove it from state.
+}
+
+// ImportState implements the logic to support resource imports.
+func (r *defaultSensorUpdatePolicyResource) ImportState(
+	ctx context.Context,
+	req resource.ImportStateRequest,
+	resp *resource.ImportStateResponse,
+) {
+	// Retrieve import ID and save to id attribute
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+// ValidateConfig runs during validate, plan, and apply
+// validate resource is configured as expected.
+func (r *defaultSensorUpdatePolicyResource) ValidateConfig(
+	ctx context.Context,
+	req resource.ValidateConfigRequest,
+	resp *resource.ValidateConfigResponse,
+) {
+
+	var config defaultSensorUpdatePolicyResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	resp.Diagnostics.Append(config.extract(ctx)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	platform := strings.ToLower(config.PlatformName.ValueString())
+
+	if platform == "linux" && config.BuildArm64.IsNull() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("build_arm64"),
+			"Attribute build_arm64 missing",
+			"Attribute build_arm64 is required when platform_name is linux.",
+		)
+
+		return
+	}
+
+	if config.UninstallProtection.ValueBool() && platform == "linux" {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("uninstall_protection"),
+			"Linux doesn't support uninstall protection",
+			"Uninstall protection is not supported by linux sensor update policies. Set to false or remove attribute.",
+		)
+
+		return
+	}
+
+	scheduleEnabled := config.schedule.Enabled.ValueBool()
+
+	if !scheduleEnabled && !config.schedule.Timezone.IsNull() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("schedule"),
+			"Invalid schedule block: timezone provided",
+			"To implement idempotency timezone and time_blocks should not be provided when enabled is false.",
+		)
+
+		return
+	}
+
+	if !scheduleEnabled && len(config.schedule.TimeBlocks) > 0 {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("schedule"),
+			"Invalid schedule block: time_blocks provided",
+			"To implement idempotency timezone and time_blocks should not be provided when enabled is false.",
+		)
+
+		return
+	}
+
+	if scheduleEnabled {
+		if config.schedule.Timezone.IsUnknown() || config.schedule.Timezone.IsNull() {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("schedule"),
+				"missing required attribute",
+				"timezone is required when the schedule is set to enabled true.",
+			)
+			return
+		}
+
+		if len(config.schedule.TimeBlocks) == 0 {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("schedule"),
+				"missing required attribute",
+				"time_blocks is required when the schedule is set to enabled true.",
+			)
+			return
+		}
+		usedDays := make(map[string]interface{})
+
+		for _, b := range config.schedule.TimeBlocks {
+			ok, err := validTime(b.StartTime.ValueString(), b.EndTime.ValueString())
+
+			if err != nil {
+				resp.Diagnostics.AddError(
+					"Unable to validate config",
+					"Error while validating start and end times for time_block: "+err.Error(),
+				)
+				return
+			}
+
+			if !ok {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("schedule"),
+					"Invalid start_time or end_time",
+					"start_time and end_time should be at least 1 hour apart.",
+				)
+				return
+			}
+
+			days := []string{}
+			resp.Diagnostics.Append(b.Days.ElementsAs(ctx, &days, false)...)
+
+			for _, day := range days {
+				_, ok := usedDays[day]
+				if ok {
+					resp.Diagnostics.AddAttributeError(
+						path.Root("schedule"),
+						"Duplicate days in schedule",
+						fmt.Sprintf(
+							"Day %s declared in multiple time_blocks. Multiple time_blocks can't reference the same day.",
+							day,
+						),
+					)
+				}
+
+				usedDays[day] = nil
+			}
+		}
+	}
+}
+
+func (r *defaultSensorUpdatePolicyResource) updateDefaultPolicy(
+	ctx context.Context,
+	config *defaultSensorUpdatePolicyResourceModel,
+) (*models.SensorUpdatePolicyV2, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	policyParams := sensor_update_policies.UpdateSensorUpdatePoliciesV2Params{
+		Context: ctx,
+		Body: &models.SensorUpdateUpdatePoliciesReqV2{
+			Resources: []*models.SensorUpdateUpdatePolicyReqV2{
+				{
+					ID: config.ID.ValueStringPointer(),
+					Settings: &models.SensorUpdateSettingsReqV2{
+						Build: config.Build.ValueString(),
+					},
+				},
+			},
+		},
+	}
+
+	if strings.ToLower(config.PlatformName.ValueString()) == "linux" {
+		variants := []*models.SensorUpdateBuildReqV1{
+			{
+				Build:    config.BuildArm64.ValueStringPointer(),
+				Platform: &linuxArm64Varient,
+			},
+		}
+		policyParams.Body.Resources[0].Settings.Variants = variants
+	}
+
+	if config.UninstallProtection.ValueBool() {
+		policyParams.Body.Resources[0].Settings.UninstallProtection = "ENABLED"
+	} else {
+		policyParams.Body.Resources[0].Settings.UninstallProtection = "DISABLED"
+
+	}
+
+	updateSchedular := models.PolicySensorUpdateScheduler{}
+	updateSchedular.Timezone = config.schedule.Timezone.ValueStringPointer()
+	updateSchedular.Enabled = config.schedule.Enabled.ValueBoolPointer()
+
+	// WORKAROUND: The API requires a timezone when we are trying to enable/diable the Scheduler
+	// due to other limitiations when it comes to imports we need to allow timezone to be null.
+	// Everything should exist in state etc so knowingly adding drift isn't the best, but
+	// when the schedule is disabled the timezone does not matter.
+	// When the schedule is enabled the timezone is required so we will not have issues.
+	// Permanent fix is to update the API to allow us to provide a null value for timezone when
+	// the schedule is disabled.
+	defaultTimezone := "Etc/UTC"
+	if !*updateSchedular.Enabled && updateSchedular.Timezone == nil {
+		updateSchedular.Timezone = &defaultTimezone
+	}
+
+	if len(config.schedule.TimeBlocks) > 0 {
+		updateSchedules, diags := createUpdateSchedules(ctx, config.schedule.TimeBlocks)
+		diags.Append(diags...)
+		if diags.HasError() {
+			return nil, diags
+		}
+
+		updateSchedular.Schedules = updateSchedules
+	}
+	policyParams.Body.Resources[0].Settings.Scheduler = &updateSchedular
+
+	res, err := r.client.SensorUpdatePolicies.UpdateSensorUpdatePoliciesV2(&policyParams)
+
+	if err != nil {
+		diags.AddError(
+			"Error updating CrowdStrike sensor update policy",
+			"Could not update sensor update policy with ID: "+config.ID.ValueString()+": "+err.Error(),
+		)
+		return nil, diags
+	}
+
+	policy := res.Payload.Resources[0]
+
+	return policy, diags
+}
+
+func (r *defaultSensorUpdatePolicyResource) getDefaultPolicy(
+	ctx context.Context,
+	platformName string,
+) (*models.SensorUpdatePolicyV2, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	caser := cases.Title(language.English)
+	platformName = caser.String(platformName)
+
+	filter := fmt.Sprintf(
+		`platform_name:'%s'+name.raw:'platform_default'+description:'platform'+description:'default'+description:'policy'`,
+		platformName,
+	)
+	sort := "precedence.desc"
+
+	res, err := r.client.SensorUpdatePolicies.QueryCombinedSensorUpdatePoliciesV2(
+		&sensor_update_policies.QueryCombinedSensorUpdatePoliciesV2Params{
+			Context: ctx,
+			Filter:  &filter,
+			Sort:    &sort,
+		},
+	)
+
+	if err != nil {
+		diags.AddError(
+			"Failed to get default sensor update policy",
+			fmt.Sprintf("Failed to get default sensor update policy: %s", err),
+		)
+
+		return nil, diags
+	}
+
+	if res == nil || res.Payload == nil || len(res.Payload.Resources) == 0 {
+		diags.AddError(
+			"Unable to find default sensor update policy",
+			fmt.Sprintf(
+				"No policy matched filter: %s, a default policy should exist. Please report this issue to the provider developers.",
+				filter,
+			),
+		)
+
+		return nil, diags
+	}
+
+	// we sort by descending precedence, default policy is always first
+	defaultPolicy := res.Payload.Resources[0]
+
+	return defaultPolicy, diags
+}

--- a/internal/sensor_update_policy/default_sensor_update_policy_resource_test.go
+++ b/internal/sensor_update_policy/default_sensor_update_policy_resource_test.go
@@ -1,0 +1,152 @@
+package sensorupdatepolicy_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/acctest"
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+)
+
+const resourceName = "crowdstrike_default_sensor_update_policy.default"
+
+func TestAccDefaultSensorUpdatePolicyResourceBadBuildUpdate(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderConfig + `
+resource "crowdstrike_default_sensor_update_policy" "default" {
+  platform_name        = "Windows"
+  build                = "18721"
+  uninstall_protection = false 
+  schedule = {
+    enabled = false
+  }
+}`,
+			},
+			{
+				Config: acctest.ProviderConfig + `
+resource "crowdstrike_default_sensor_update_policy" "default" {
+  platform_name        = "Windows"
+  build                = "invalid"
+  uninstall_protection = false 
+  schedule = {
+    enabled = false
+  }
+}`,
+				ExpectError: regexp.MustCompile(
+					"The API returned a build that did not match the build in plan: \"invalid\"",
+				),
+			},
+		},
+	})
+}
+
+func TestAccDefaultSensorUpdatePolicyResourceWithSchedule(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderConfig + `
+resource "crowdstrike_default_sensor_update_policy" "default" {
+  platform_name        = "Windows"
+  build                = "18721"
+  uninstall_protection = true 
+  schedule = {
+    enabled = true 
+    timezone = "Etc/UTC"
+    time_blocks = [
+     {
+       days       = ["sunday", "wednesday"]
+       start_time = "12:40"
+       end_time   = "16:40"
+     }
+   ]
+  }
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"platform_name",
+						"Windows",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"build",
+						"18721",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"uninstall_protection",
+						"true",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"schedule.enabled",
+						"true",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"schedule.timezone",
+						"Etc/UTC",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"schedule.time_blocks.#",
+						"1",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"schedule.time_blocks.0.days.#",
+						"2",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"schedule.time_blocks.0.days.0",
+						"sunday",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"schedule.time_blocks.0.days.1",
+						"wednesday",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"schedule.time_blocks.0.start_time",
+						"12:40",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"schedule.time_blocks.0.end_time",
+						"16:40",
+					),
+					resource.TestCheckResourceAttrSet(
+						resourceName,
+						"id",
+					),
+					resource.TestCheckResourceAttrSet(
+						resourceName,
+						"last_updated",
+					),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_updated"},
+			},
+		},
+	})
+}

--- a/internal/sensor_update_policy/sensor_update_policy_builds_data_source.go
+++ b/internal/sensor_update_policy/sensor_update_policy_builds_data_source.go
@@ -1,4 +1,4 @@
-package provider
+package sensorupdatepolicy
 
 import (
 	"context"

--- a/internal/sensor_update_policy/sensor_update_policy_builds_data_source_test.go
+++ b/internal/sensor_update_policy/sensor_update_policy_builds_data_source_test.go
@@ -1,19 +1,20 @@
-package provider
+package sensorupdatepolicy_test
 
 import (
 	"testing"
 
+	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccSensorUpdatePolicyBuildsDataSource(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		Steps: []resource.TestStep{
 			// Read testing
 			{
-				Config: providerConfig + `data "crowdstrike_sensor_update_policy_builds" "test" {}`,
+				Config: acctest.ProviderConfig + `data "crowdstrike_sensor_update_policy_builds" "test" {}`,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(
 						"data.crowdstrike_sensor_update_policy_builds.test",

--- a/internal/sensor_update_policy/sensor_update_policy_resource.go
+++ b/internal/sensor_update_policy/sensor_update_policy_resource.go
@@ -1,4 +1,4 @@
-package provider
+package sensorupdatepolicy
 
 import (
 	"context"
@@ -12,6 +12,8 @@ import (
 	hostgroups "github.com/crowdstrike/terraform-provider-crowdstrike/internal/host_groups"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/scopes"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/utils"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -23,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"golang.org/x/exp/maps"
 )
@@ -34,108 +37,6 @@ var (
 	_ resource.ResourceWithImportState    = &sensorUpdatePolicyResource{}
 	_ resource.ResourceWithValidateConfig = &sensorUpdatePolicyResource{}
 )
-
-// int64ToDay maps numbers used by api to a string representation of the day.
-var int64ToDay = map[int64]string{
-	0: "sunday",
-	1: "monday",
-	2: "tuesday",
-	3: "wednesday",
-	4: "thursday",
-	5: "friday",
-	6: "saturday",
-}
-
-// dayToInt64 maps a string representation of the day to the numbers used by the api.
-var dayToInt64 = map[string]int64{
-	"sunday":    0,
-	"monday":    1,
-	"tuesday":   2,
-	"wednesday": 3,
-	"thursday":  4,
-	"friday":    5,
-	"saturday":  6,
-}
-
-// timezones a slice of supported timezones for sensor update policy.
-var timezones = []string{
-	"Etc/GMT-2",
-	"Etc/UTC",
-	"Etc/GMT+7",
-	"Etc/GMT+12",
-	"Atlantic/Cape_Verde",
-	"America/Noronha",
-	"America/Sao_Paulo",
-	"America/St_Johns",
-	"America/Santo_Domingo",
-	"America/Caracas",
-	"America/New_York",
-	"America/Lima",
-	"America/Havana",
-	"America/Mexico_City",
-	"America/Phoenix",
-	"America/Los_Angeles",
-	"America/Anchorage",
-	"Pacific/Kiritimati",
-	"Pacific/Marquesas",
-	"Pacific/Honolulu",
-	"Pacific/Tahiti",
-	"Pacific/Niue",
-	"Pacific/Pago_Pago",
-	"Pacific/Gambier",
-	"Pacific/Pitcairn",
-	"Pacific/Chatham",
-	"Pacific/Auckland",
-	"Pacific/Guam",
-	"Pacific/Fiji",
-	"Pacific/Norfolk",
-	"Pacific/Galapagos",
-	"Asia/Sakhalin",
-	"Asia/Chita",
-	"Asia/Jayapura",
-	"Asia/Seoul",
-	"Asia/Tokyo",
-	"Asia/Kuala_Lumpur",
-	"Asia/Vladivostok",
-	"Asia/Shanghai",
-	"Asia/Hong_Kong",
-	"Asia/Makassar",
-	"Asia/Manila",
-	"Asia/Bangkok",
-	"Asia/Jakarta",
-	"Asia/Rangoon",
-	"Asia/Dhaka",
-	"Asia/Kathmandu",
-	"Asia/Kolkata",
-	"Asia/Colombo",
-	"Asia/Tashkent",
-	"Asia/Karachi",
-	"Asia/Kabul",
-	"Asia/Dubai",
-	"Asia/Tehran",
-	"Asia/Jerusalem",
-	"Australia/Sydney",
-	"Australia/Adelaide",
-	"Australia/Brisbane",
-	"Australia/Darwin",
-	"Australia/Eucla",
-	"Australia/Perth",
-	"Africa/Nairobi",
-	"Africa/Khartoum",
-	"Africa/Cairo",
-	"Africa/Johannesburg",
-	"Africa/Lagos",
-	"Africa/Casablanca",
-	"Europe/Istanbul",
-	"Europe/Moscow",
-	"Europe/Paris",
-	"Europe/London",
-	"Europe/Lisbon",
-	"Antartica/Troll",
-	"MET",
-}
-
-var linuxArm64Varient = "LinuxArm64"
 
 // NewSensorUpdatePolicyResource is a helper function to simplify the provider implementation.
 func NewSensorUpdatePolicyResource() resource.Resource {
@@ -149,31 +50,178 @@ type sensorUpdatePolicyResource struct {
 
 // sensorUpdatePolicyResourceModel is the resource model.
 type sensorUpdatePolicyResourceModel struct {
-	ID                  types.String   `tfsdk:"id"`
-	Enabled             types.Bool     `tfsdk:"enabled"`
-	Name                types.String   `tfsdk:"name"`
-	Build               types.String   `tfsdk:"build"`
-	BuildArm64          types.String   `tfsdk:"build_arm64"`
-	Description         types.String   `tfsdk:"description"`
-	PlatformName        types.String   `tfsdk:"platform_name"`
-	UninstallProtection types.Bool     `tfsdk:"uninstall_protection"`
-	LastUpdated         types.String   `tfsdk:"last_updated"`
-	HostGroups          types.Set      `tfsdk:"host_groups"`
-	Schedule            policySchedule `tfsdk:"schedule"`
+	ID                  types.String `tfsdk:"id"`
+	Enabled             types.Bool   `tfsdk:"enabled"`
+	Name                types.String `tfsdk:"name"`
+	Build               types.String `tfsdk:"build"`
+	BuildArm64          types.String `tfsdk:"build_arm64"`
+	Description         types.String `tfsdk:"description"`
+	PlatformName        types.String `tfsdk:"platform_name"`
+	UninstallProtection types.Bool   `tfsdk:"uninstall_protection"`
+	LastUpdated         types.String `tfsdk:"last_updated"`
+	HostGroups          types.Set    `tfsdk:"host_groups"`
+	Schedule            types.Object `tfsdk:"schedule"`
+
+	schedule *policySchedule `tfsdk:"-"`
 }
 
-// policySchedule the schedule for a sensor update policy.
-type policySchedule struct {
-	Enabled    types.Bool   `tfsdk:"enabled"`
-	Timezone   types.String `tfsdk:"timezone"`
-	TimeBlocks []timeBlock  `tfsdk:"time_blocks"`
+// extract extracts the Go values form their terraform wrapped values.
+func (d *sensorUpdatePolicyResourceModel) extract(ctx context.Context) diag.Diagnostics {
+	var diags diag.Diagnostics
+	if !d.Schedule.IsNull() {
+		d.schedule = &policySchedule{}
+		diags = d.Schedule.As(ctx, d.schedule, basetypes.ObjectAsOptions{})
+	}
+
+	return diags
 }
 
-// timeBlock a time block for a sensor update policy schedule.
-type timeBlock struct {
-	Days      types.Set    `tfsdk:"days"`
-	StartTime types.String `tfsdk:"start_time"`
-	EndTime   types.String `tfsdk:"end_time"`
+// wrap transforms Go values to their terraform wrapped values.
+func (d *sensorUpdatePolicyResourceModel) wrap(
+	ctx context.Context,
+	policy models.SensorUpdatePolicyV2,
+	validateBuilds bool,
+	validateHostGroups bool,
+) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	d.ID = types.StringValue(*policy.ID)
+	d.Name = types.StringValue(*policy.Name)
+	d.Description = types.StringValue(*policy.Description)
+	d.Enabled = types.BoolValue(*policy.Enabled)
+
+	if validateHostGroups {
+		policyGroups := make([]string, 0, len(policy.Groups))
+		modelGroups := make([]string, 0, len(d.HostGroups.Elements()))
+
+		if len(policy.Groups) > 0 {
+			for _, hostGroup := range policy.Groups {
+				policyGroups = append(policyGroups, *hostGroup.ID)
+			}
+		}
+
+		diags.Append(d.HostGroups.ElementsAs(ctx, &modelGroups, true)...)
+
+		if modelGroups == nil {
+			modelGroups = []string{}
+		}
+
+		if policyGroups == nil {
+			policyGroups = []string{}
+		}
+
+		less := func(a, b string) bool { return a < b }
+		hostGroupDiff := cmp.Diff(policyGroups, modelGroups, cmpopts.SortSlices(less))
+		if hostGroupDiff != "" {
+			summary := "Apply ran without issue, but sensor update policy is still missing host groups. This usually happens when an invalid host group is provided."
+
+			if len(policyGroups) > 0 {
+				summary = fmt.Sprintf(
+					"%s\n\nThe following host groups are valid and assigned to the sensor update policy:\n\n%s",
+					summary,
+					strings.Join(policyGroups, "\n"),
+				)
+			}
+			diags.AddAttributeError(path.Root("host_groups"), "Host group mismatch", summary)
+		}
+	}
+
+	diags.Append(d.assignHostGroups(ctx, policy.Groups)...)
+
+	if validateBuilds && d.Build.ValueString() != *policy.Settings.Build {
+		diags.AddError(
+			"Inconsistent build returned",
+			fmt.Sprintf(
+				"The API returned a build that did not match the build in plan: %s This normally occurs when an invalid build is provided, please check the build you are passing is valid. It is recommended to use crowdstrike_sensor_update_policy_builds data source to query for build numbers.\n\nIf you believe there is a bug in the provider or need help please let us know by opening a github issue here: https://github.com/CrowdStrike/terraform-provider-crowdstrike/issues",
+				d.Build,
+			),
+		)
+	}
+	d.Build = types.StringValue(*policy.Settings.Build)
+
+	if d.PlatformName.IsNull() {
+		d.PlatformName = types.StringValue(*policy.PlatformName)
+	}
+
+	if strings.ToLower(d.PlatformName.ValueString()) == "linux" &&
+		policy.Settings.Variants != nil {
+		for _, v := range policy.Settings.Variants {
+			vCopy := *v
+			if vCopy.Platform == nil {
+				continue
+			}
+
+			if strings.EqualFold(*vCopy.Platform, linuxArm64Varient) {
+				if validateBuilds && d.BuildArm64.ValueString() != *vCopy.Build {
+					diags.AddError(
+						"Inconsistent build_arm64 returned",
+						fmt.Sprintf(
+							"The API returned a build_arm64 that did not match the build in plan: %s This normally occurs when an invalid build is provided, please check the build you are passing is valid. It is recommended to use crowdstrike_sensor_update_policy_builds data source to query for build numbers.\n\nIf you believe there is a bug in the provider or need help please let us know by opening a github issue here: https://github.com/CrowdStrike/terraform-provider-crowdstrike/issues",
+							d.BuildArm64,
+						),
+					)
+				}
+				d.BuildArm64 = types.StringValue(*vCopy.Build)
+			}
+		}
+	}
+
+	if *policy.Settings.UninstallProtection == "ENABLED" {
+		d.UninstallProtection = types.BoolValue(true)
+	} else {
+		d.UninstallProtection = types.BoolValue(false)
+	}
+
+	if policy.Settings.Scheduler != nil {
+		d.schedule = &policySchedule{}
+		d.schedule.Enabled = types.BoolValue(*policy.Settings.Scheduler.Enabled)
+
+		// ignore the timzezone and time_blocks if the schedule is DISABLED
+		// this allows terraform import to work correctly
+		if d.schedule.Enabled.ValueBool() {
+			d.schedule.Timezone = types.StringValue(*policy.Settings.Scheduler.Timezone)
+
+			if policy.Settings.Scheduler.Schedules != nil {
+				if len(policy.Settings.Scheduler.Schedules) > 0 {
+					d.schedule.TimeBlocks = []timeBlock{}
+
+					for _, s := range policy.Settings.Scheduler.Schedules {
+						sCopy := s
+						daysStr := []string{}
+
+						for _, d := range sCopy.Days {
+							dCopy := d
+							daysStr = append(daysStr, int64ToDay[dCopy])
+						}
+
+						days, diags := types.SetValueFrom(ctx, types.StringType, daysStr)
+						diags.Append(diags...)
+						if diags.HasError() {
+							return diags
+						}
+						d.schedule.TimeBlocks = append(d.schedule.TimeBlocks, timeBlock{
+							Days:      days,
+							StartTime: types.StringValue(*sCopy.Start),
+							EndTime:   types.StringValue(*sCopy.End),
+						})
+					}
+				}
+			}
+		}
+	}
+
+	if d.schedule != nil {
+		policyScheduleObj, diag := types.ObjectValueFrom(
+			ctx,
+			d.schedule.AttributeTypes(),
+			d.schedule,
+		)
+		d.Schedule = policyScheduleObj
+		diags.Append(diag...)
+
+	}
+
+	return diags
 }
 
 // Configure adds the provider configured client to the resource.
@@ -339,10 +387,9 @@ func (r *sensorUpdatePolicyResource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-
 	var plan sensorUpdatePolicyResourceModel
-	diags := req.Plan.Get(ctx, &plan)
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(plan.extract(ctx)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -381,13 +428,13 @@ func (r *sensorUpdatePolicyResource) Create(
 	}
 	policyParams.Body.Resources[0].Settings.UninstallProtection = uninstallProtection
 
-	if plan.Schedule.Enabled.ValueBool() {
+	if plan.schedule.Enabled.ValueBool() {
 		updateSchedular := models.PolicySensorUpdateScheduler{}
-		updateSchedular.Enabled = plan.Schedule.Enabled.ValueBoolPointer()
-		updateSchedular.Timezone = plan.Schedule.Timezone.ValueStringPointer()
+		updateSchedular.Enabled = plan.schedule.Enabled.ValueBoolPointer()
+		updateSchedular.Timezone = plan.schedule.Timezone.ValueStringPointer()
 
-		if len(plan.Schedule.TimeBlocks) > 0 {
-			updateSchedules, diags := createUpdateSchedules(ctx, plan.Schedule.TimeBlocks)
+		if len(plan.schedule.TimeBlocks) > 0 {
+			updateSchedules, diags := createUpdateSchedules(ctx, plan.schedule.TimeBlocks)
 			resp.Diagnostics.Append(diags...)
 			if resp.Diagnostics.HasError() {
 				return
@@ -398,7 +445,7 @@ func (r *sensorUpdatePolicyResource) Create(
 		policyParams.Body.Resources[0].Settings.Scheduler = &updateSchedular
 	}
 
-	policy, err := r.client.SensorUpdatePolicies.CreateSensorUpdatePoliciesV2(&policyParams)
+	res, err := r.client.SensorUpdatePolicies.CreateSensorUpdatePoliciesV2(&policyParams)
 
 	// todo: if we should handle scope and timeout errors instead of giving a vague error
 	if err != nil {
@@ -409,9 +456,9 @@ func (r *sensorUpdatePolicyResource) Create(
 		return
 	}
 
-	policyResource := policy.Payload.Resources[0]
+	policy := res.Payload.Resources[0]
 
-	plan.ID = types.StringValue(*policyResource.ID)
+	plan.ID = types.StringValue(*policy.ID)
 	plan.LastUpdated = types.StringValue(time.Now().Format(time.RFC850))
 
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), plan.ID)...)
@@ -461,8 +508,15 @@ func (r *sensorUpdatePolicyResource) Create(
 		}
 	}
 
-	diags = resp.State.Set(ctx, plan)
+	policy, diags := getSensorUpdatePolicy(ctx, r.client, plan.ID.ValueString())
+
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(plan.wrap(ctx, *policy, true, true)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -475,13 +529,12 @@ func (r *sensorUpdatePolicyResource) Read(
 	resp *resource.ReadResponse,
 ) {
 	var state sensorUpdatePolicyResourceModel
-	diags := req.State.Get(ctx, &state)
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	policy, err := r.client.SensorUpdatePolicies.GetSensorUpdatePoliciesV2(
+	res, err := r.client.SensorUpdatePolicies.GetSensorUpdatePoliciesV2(
 		&sensor_update_policies.GetSensorUpdatePoliciesV2Params{
 			Context: ctx,
 			Ids:     []string{state.ID.ValueString()},
@@ -507,82 +560,10 @@ func (r *sensorUpdatePolicyResource) Read(
 		return
 	}
 
-	policyResource := policy.Payload.Resources[0]
+	policy := res.Payload.Resources[0]
 
-	state.ID = types.StringValue(*policyResource.ID)
-	state.Name = types.StringValue(*policyResource.Name)
-	state.Description = types.StringValue(*policyResource.Description)
-	state.Build = types.StringValue(*policyResource.Settings.Build)
-	state.PlatformName = types.StringValue(*policyResource.PlatformName)
-	state.Enabled = types.BoolValue(*policyResource.Enabled)
-
-	if strings.ToLower(state.PlatformName.ValueString()) == "linux" &&
-		policyResource.Settings.Variants != nil {
-		for _, v := range policyResource.Settings.Variants {
-			vCopy := *v
-			if vCopy.Platform == nil {
-				continue
-			}
-
-			if strings.EqualFold(*vCopy.Platform, linuxArm64Varient) {
-				state.BuildArm64 = types.StringValue(*vCopy.Build)
-			}
-		}
-
-	}
-
-	if *policyResource.Settings.UninstallProtection == "ENABLED" {
-		state.UninstallProtection = types.BoolValue(true)
-	} else {
-		state.UninstallProtection = types.BoolValue(false)
-	}
-
-	resp.Diagnostics.Append(r.assignHostGroups(ctx, &state, policyResource.Groups)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	if policyResource.Settings.Scheduler != nil {
-		state.Schedule = policySchedule{}
-		state.Schedule.Enabled = types.BoolValue(*policyResource.Settings.Scheduler.Enabled)
-
-		// ignore the timzezone and time_blocks if the schedule is DISABLED
-		// this allows terraform import to work correctly
-		if state.Schedule.Enabled.ValueBool() {
-			state.Schedule.Timezone = types.StringValue(*policyResource.Settings.Scheduler.Timezone)
-
-			if policyResource.Settings.Scheduler.Schedules != nil {
-				if len(policyResource.Settings.Scheduler.Schedules) > 0 {
-					state.Schedule.TimeBlocks = []timeBlock{}
-
-					for _, s := range policyResource.Settings.Scheduler.Schedules {
-						sCopy := s
-						daysStr := []string{}
-
-						for _, d := range sCopy.Days {
-							dCopy := d
-							daysStr = append(daysStr, int64ToDay[dCopy])
-						}
-
-						days, diags := types.SetValueFrom(ctx, types.StringType, daysStr)
-						resp.Diagnostics.Append(diags...)
-						if resp.Diagnostics.HasError() {
-							return
-						}
-						state.Schedule.TimeBlocks = append(state.Schedule.TimeBlocks, timeBlock{
-							Days:      days,
-							StartTime: types.StringValue(*sCopy.Start),
-							EndTime:   types.StringValue(*sCopy.End),
-						})
-					}
-				}
-			}
-		}
-	}
-
-	// Set refreshed state
-	diags = resp.State.Set(ctx, &state)
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(state.wrap(ctx, *policy, false, false)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -596,15 +577,15 @@ func (r *sensorUpdatePolicyResource) Update(
 ) {
 	// Retrieve values from plan
 	var plan sensorUpdatePolicyResourceModel
-	diags := req.Plan.Get(ctx, &plan)
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(plan.extract(ctx)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 	// Retrieve values from state
 	var state sensorUpdatePolicyResourceModel
-	diags = req.State.Get(ctx, &state)
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	resp.Diagnostics.Append(state.extract(ctx)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -695,8 +676,8 @@ func (r *sensorUpdatePolicyResource) Update(
 	}
 
 	updateSchedular := models.PolicySensorUpdateScheduler{}
-	updateSchedular.Timezone = plan.Schedule.Timezone.ValueStringPointer()
-	updateSchedular.Enabled = plan.Schedule.Enabled.ValueBoolPointer()
+	updateSchedular.Timezone = plan.schedule.Timezone.ValueStringPointer()
+	updateSchedular.Enabled = plan.schedule.Enabled.ValueBoolPointer()
 
 	// WORKAROUND: The API requires a timezone when we are trying to enable/diable the Scheduler
 	// due to other limitiations when it comes to imports we need to allow timezone to be null.
@@ -710,8 +691,8 @@ func (r *sensorUpdatePolicyResource) Update(
 		updateSchedular.Timezone = &defaultTimezone
 	}
 
-	if len(plan.Schedule.TimeBlocks) > 0 {
-		updateSchedules, diags := createUpdateSchedules(ctx, plan.Schedule.TimeBlocks)
+	if len(plan.schedule.TimeBlocks) > 0 {
+		updateSchedules, diags := createUpdateSchedules(ctx, plan.schedule.TimeBlocks)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
@@ -721,7 +702,7 @@ func (r *sensorUpdatePolicyResource) Update(
 	}
 	policyParams.Body.Resources[0].Settings.Scheduler = &updateSchedular
 
-	policy, err := r.client.SensorUpdatePolicies.UpdateSensorUpdatePoliciesV2(&policyParams)
+	res, err := r.client.SensorUpdatePolicies.UpdateSensorUpdatePoliciesV2(&policyParams)
 
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -731,18 +712,8 @@ func (r *sensorUpdatePolicyResource) Update(
 		return
 	}
 
-	policyResource := policy.Payload.Resources[0]
+	policy := res.Payload.Resources[0]
 
-	plan.ID = types.StringValue(*policyResource.ID)
-	plan.Name = types.StringValue(*policyResource.Name)
-	plan.Description = types.StringValue(*policyResource.Description)
-	plan.PlatformName = types.StringValue(*policyResource.PlatformName)
-	plan.Build = types.StringValue(*policyResource.Settings.Build)
-	if *policyResource.Settings.UninstallProtection == "ENABLED" {
-		plan.UninstallProtection = types.BoolValue(true)
-	} else {
-		plan.UninstallProtection = types.BoolValue(false)
-	}
 	plan.LastUpdated = types.StringValue(time.Now().Format(time.RFC850))
 
 	if plan.Enabled.ValueBool() != state.Enabled.ValueBool() {
@@ -771,16 +742,18 @@ func (r *sensorUpdatePolicyResource) Update(
 
 		plan.Enabled = types.BoolValue(*actionResp.Payload.Resources[0].Enabled)
 	} else {
-		plan.Enabled = types.BoolValue(*policyResource.Enabled)
+		plan.Enabled = types.BoolValue(*policy.Enabled)
 	}
 
-	resp.Diagnostics.Append(r.assignHostGroups(ctx, &state, policyResource.Groups)...)
+	policy, diags = getSensorUpdatePolicy(ctx, r.client, plan.ID.ValueString())
+
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	diags = resp.State.Set(ctx, plan)
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(plan.wrap(ctx, *policy, true, true)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -855,13 +828,7 @@ func (r *sensorUpdatePolicyResource) ImportState(
 	req resource.ImportStateRequest,
 	resp *resource.ImportStateResponse,
 ) {
-	// Retrieve import ID and save to id attribute
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
-	resp.Diagnostics.Append(
-		resp.State.SetAttribute(ctx, path.Root("schedule").AtName("enabled"), false)...)
-	// resp.Diagnostics.Append(
-	// 	resp.State.SetAttribute(ctx, path.Root("schedule").AtName("timezone"), nil)...)
-
 }
 
 // ValidateConfig runs during validate, plan, and apply
@@ -874,9 +841,12 @@ func (r *sensorUpdatePolicyResource) ValidateConfig(
 
 	var config sensorUpdatePolicyResourceModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	resp.Diagnostics.Append(config.extract(ctx)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	resp.Diagnostics.Append(utils.ValidateEmptyIDs(ctx, config.HostGroups, "host_groups")...)
 
 	platform := strings.ToLower(config.PlatformName.ValueString())
 
@@ -900,9 +870,9 @@ func (r *sensorUpdatePolicyResource) ValidateConfig(
 		return
 	}
 
-	scheduleEnabled := config.Schedule.Enabled.ValueBool()
+	scheduleEnabled := config.schedule.Enabled.ValueBool()
 
-	if !scheduleEnabled && !config.Schedule.Timezone.IsNull() {
+	if !scheduleEnabled && !config.schedule.Timezone.IsNull() {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("schedule"),
 			"Invalid schedule block: timezone provided",
@@ -912,7 +882,7 @@ func (r *sensorUpdatePolicyResource) ValidateConfig(
 		return
 	}
 
-	if !scheduleEnabled && len(config.Schedule.TimeBlocks) > 0 {
+	if !scheduleEnabled && len(config.schedule.TimeBlocks) > 0 {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("schedule"),
 			"Invalid schedule block: time_blocks provided",
@@ -923,7 +893,7 @@ func (r *sensorUpdatePolicyResource) ValidateConfig(
 	}
 
 	if scheduleEnabled {
-		if config.Schedule.Timezone.IsUnknown() || config.Schedule.Timezone.IsNull() {
+		if config.schedule.Timezone.IsUnknown() || config.schedule.Timezone.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("schedule"),
 				"missing required attribute",
@@ -932,7 +902,7 @@ func (r *sensorUpdatePolicyResource) ValidateConfig(
 			return
 		}
 
-		if len(config.Schedule.TimeBlocks) == 0 {
+		if len(config.schedule.TimeBlocks) == 0 {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("schedule"),
 				"missing required attribute",
@@ -942,7 +912,7 @@ func (r *sensorUpdatePolicyResource) ValidateConfig(
 		}
 		usedDays := make(map[string]interface{})
 
-		for _, b := range config.Schedule.TimeBlocks {
+		for _, b := range config.schedule.TimeBlocks {
 			ok, err := validTime(b.StartTime.ValueString(), b.EndTime.ValueString())
 
 			if err != nil {
@@ -982,22 +952,6 @@ func (r *sensorUpdatePolicyResource) ValidateConfig(
 			}
 		}
 	}
-}
-
-// validTime checks if the start and end time are atleast 1 hour apart.
-func validTime(startTimeStr string, endTimeStr string) (bool, error) {
-	startTime, err := time.Parse("15:04", startTimeStr)
-	if err != nil {
-		return false, err
-	}
-	endTime, err := time.Parse("15:04", endTimeStr)
-	if err != nil {
-		return false, err
-	}
-
-	duration := endTime.Sub(startTime)
-
-	return duration >= time.Hour, nil
 }
 
 // updatePolicyEnabledState enables or disables a sensor update policy.
@@ -1059,44 +1013,9 @@ func (r *sensorUpdatePolicyResource) updateHostGroups(
 	return err
 }
 
-// createUpdateSchedules handles the logic to create a models.PolicySensorUpdateSchedule.
-func createUpdateSchedules(
-	ctx context.Context,
-	timeBlocks []timeBlock,
-) ([]*models.PolicySensorUpdateSchedule, diag.Diagnostics) {
-	updateSchedules := []*models.PolicySensorUpdateSchedule{}
-	diags := diag.Diagnostics{}
-
-	for _, b := range timeBlocks {
-		bCopy := b
-		days := []string{}
-		daysInt64 := []int64{}
-
-		diags = bCopy.Days.ElementsAs(ctx, &days, false)
-
-		if diags.HasError() {
-			return updateSchedules, diags
-		}
-
-		for _, d := range days {
-			dCopy := d
-			daysInt64 = append(daysInt64, dayToInt64[strings.ToLower(dCopy)])
-		}
-
-		updateSchedules = append(updateSchedules, &models.PolicySensorUpdateSchedule{
-			Start: bCopy.StartTime.ValueStringPointer(),
-			End:   bCopy.EndTime.ValueStringPointer(),
-			Days:  daysInt64,
-		})
-	}
-
-	return updateSchedules, diags
-}
-
 // assignHostGroups assigns the host groups returned from the api into the resource model.
-func (r *sensorUpdatePolicyResource) assignHostGroups(
+func (r *sensorUpdatePolicyResourceModel) assignHostGroups(
 	ctx context.Context,
-	config *sensorUpdatePolicyResourceModel,
 	groups []*models.HostGroupsHostGroupV1,
 ) diag.Diagnostics {
 
@@ -1108,11 +1027,11 @@ func (r *sensorUpdatePolicyResource) assignHostGroups(
 	hostGroupIDs, diags := types.SetValueFrom(ctx, types.StringType, hostGroups)
 
 	// allow host_groups to stay null instead of defaulting to an empty set when there are no host groups
-	if config.HostGroups.IsNull() && len(hostGroupIDs.Elements()) == 0 {
+	if r.HostGroups.IsNull() && len(hostGroupIDs.Elements()) == 0 {
 		return diags
 	}
 
-	config.HostGroups = hostGroupIDs
+	r.HostGroups = hostGroupIDs
 
 	return diags
 }

--- a/internal/sensor_update_policy/sensor_update_policy_resource_test.go
+++ b/internal/sensor_update_policy/sensor_update_policy_resource_test.go
@@ -1,23 +1,98 @@
-package provider
+package sensorupdatepolicy_test
 
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/acctest"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestAccSensorUpdatePolicyResource(t *testing.T) {
-	rName := acctest.RandomWithPrefix("tf-acceptance-test")
+func TestAccSensorUpdatePolicyResourceBadBuildUpdate(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix("tf-acceptance-test")
 	resource.ParallelTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderConfig + fmt.Sprintf(`
+resource "crowdstrike_sensor_update_policy" "test" {
+  name                 = "%s"
+  enabled              = true
+  description          = "made with terraform"
+  host_groups          = []
+  platform_name        = "Windows"
+  build                = "18721"
+  uninstall_protection = false 
+  schedule = {
+    enabled = false
+  }
+}
+`, rName),
+			},
+			{
+				Config: acctest.ProviderConfig + fmt.Sprintf(`
+resource "crowdstrike_sensor_update_policy" "test" {
+  name                 = "%s"
+  enabled              = true
+  description          = "made with terraform"
+  host_groups          = []
+  platform_name        = "Windows"
+  build                = "invalid"
+  uninstall_protection = false 
+  schedule = {
+    enabled = false
+  }
+}
+`, rName),
+				ExpectError: regexp.MustCompile(
+					"The API returned a build that did not match the build in plan: \"invalid\"",
+				),
+			},
+		},
+	})
+}
+
+func TestAccSensorUpdatePolicyResourceBadHostGroup(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix("tf-acceptance-test")
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderConfig + fmt.Sprintf(`
+resource "crowdstrike_sensor_update_policy" "test" {
+  name                 = "%s"
+  enabled              = true
+  description          = "made with terraform"
+  host_groups          = ["invalid"]
+  platform_name        = "Windows"
+  build                = "18721"
+  uninstall_protection = false 
+  schedule = {
+    enabled = false
+  }
+}
+`, rName),
+				ExpectError: regexp.MustCompile("Error: Host group mismatch"),
+			},
+		},
+	})
+}
+
+func TestAccSensorUpdatePolicyResource(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix("tf-acceptance-test")
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: providerConfig + fmt.Sprintf(`
+				Config: acctest.ProviderConfig + fmt.Sprintf(`
 resource "crowdstrike_sensor_update_policy" "test" {
   name                 = "%s"
   enabled              = true
@@ -87,7 +162,7 @@ resource "crowdstrike_sensor_update_policy" "test" {
 			},
 			// Update and Read testing
 			{
-				Config: providerConfig + fmt.Sprintf(`
+				Config: acctest.ProviderConfig + fmt.Sprintf(`
 resource "crowdstrike_sensor_update_policy" "test" {
   name                 = "%s-updated"
   enabled              = false
@@ -154,15 +229,15 @@ resource "crowdstrike_sensor_update_policy" "test" {
 }
 
 func TestAccSensorUpdatePolicyResourceWithHostGroup(t *testing.T) {
-	rName := acctest.RandomWithPrefix("tf-acceptance-test")
+	rName := sdkacctest.RandomWithPrefix("tf-acceptance-test")
 	hostGroupID, _ := os.LookupEnv("HOST_GROUP_ID")
 	resource.ParallelTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: providerConfig + fmt.Sprintf(`
+				Config: acctest.ProviderConfig + fmt.Sprintf(`
 resource "crowdstrike_sensor_update_policy" "test" {
   name                 = "%s"
   enabled              = true
@@ -240,7 +315,7 @@ resource "crowdstrike_sensor_update_policy" "test" {
 			},
 			// Update and Read testing
 			{
-				Config: providerConfig + fmt.Sprintf(`
+				Config: acctest.ProviderConfig + fmt.Sprintf(`
 resource "crowdstrike_sensor_update_policy" "test" {
   name                 = "%s-updated"
   enabled              = false
@@ -313,14 +388,14 @@ resource "crowdstrike_sensor_update_policy" "test" {
 }
 
 func TestAccSensorUpdatePolicyResourceWithSchedule(t *testing.T) {
-	rName := acctest.RandomWithPrefix("tf-acceptance-test")
+	rName := sdkacctest.RandomWithPrefix("tf-acceptance-test")
 	resource.ParallelTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: providerConfig + fmt.Sprintf(`
+				Config: acctest.ProviderConfig + fmt.Sprintf(`
 resource "crowdstrike_sensor_update_policy" "test" {
   name                 = "%s"
   enabled              = true
@@ -382,7 +457,7 @@ resource "crowdstrike_sensor_update_policy" "test" {
 			},
 			// Update and Read testing
 			{
-				Config: providerConfig + fmt.Sprintf(`
+				Config: acctest.ProviderConfig + fmt.Sprintf(`
 resource "crowdstrike_sensor_update_policy" "test" {
   name                 = "%s-updated"
   enabled              = false

--- a/internal/sensor_update_policy/shared.go
+++ b/internal/sensor_update_policy/shared.go
@@ -1,0 +1,233 @@
+package sensorupdatepolicy
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/crowdstrike/gofalcon/falcon/client"
+	"github.com/crowdstrike/gofalcon/falcon/client/sensor_update_policies"
+	"github.com/crowdstrike/gofalcon/falcon/models"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// int64ToDay maps numbers used by api to a string representation of the day.
+var int64ToDay = map[int64]string{
+	0: "sunday",
+	1: "monday",
+	2: "tuesday",
+	3: "wednesday",
+	4: "thursday",
+	5: "friday",
+	6: "saturday",
+}
+
+// dayToInt64 maps a string representation of the day to the numbers used by the api.
+var dayToInt64 = map[string]int64{
+	"sunday":    0,
+	"monday":    1,
+	"tuesday":   2,
+	"wednesday": 3,
+	"thursday":  4,
+	"friday":    5,
+	"saturday":  6,
+}
+
+// timezones a slice of supported timezones for sensor update policy.
+var timezones = []string{
+	"Etc/GMT-2",
+	"Etc/UTC",
+	"Etc/GMT+7",
+	"Etc/GMT+12",
+	"Atlantic/Cape_Verde",
+	"America/Noronha",
+	"America/Sao_Paulo",
+	"America/St_Johns",
+	"America/Santo_Domingo",
+	"America/Caracas",
+	"America/New_York",
+	"America/Lima",
+	"America/Havana",
+	"America/Mexico_City",
+	"America/Phoenix",
+	"America/Los_Angeles",
+	"America/Anchorage",
+	"Pacific/Kiritimati",
+	"Pacific/Marquesas",
+	"Pacific/Honolulu",
+	"Pacific/Tahiti",
+	"Pacific/Niue",
+	"Pacific/Pago_Pago",
+	"Pacific/Gambier",
+	"Pacific/Pitcairn",
+	"Pacific/Chatham",
+	"Pacific/Auckland",
+	"Pacific/Guam",
+	"Pacific/Fiji",
+	"Pacific/Norfolk",
+	"Pacific/Galapagos",
+	"Asia/Sakhalin",
+	"Asia/Chita",
+	"Asia/Jayapura",
+	"Asia/Seoul",
+	"Asia/Tokyo",
+	"Asia/Kuala_Lumpur",
+	"Asia/Vladivostok",
+	"Asia/Shanghai",
+	"Asia/Hong_Kong",
+	"Asia/Makassar",
+	"Asia/Manila",
+	"Asia/Bangkok",
+	"Asia/Jakarta",
+	"Asia/Rangoon",
+	"Asia/Dhaka",
+	"Asia/Kathmandu",
+	"Asia/Kolkata",
+	"Asia/Colombo",
+	"Asia/Tashkent",
+	"Asia/Karachi",
+	"Asia/Kabul",
+	"Asia/Dubai",
+	"Asia/Tehran",
+	"Asia/Jerusalem",
+	"Australia/Sydney",
+	"Australia/Adelaide",
+	"Australia/Brisbane",
+	"Australia/Darwin",
+	"Australia/Eucla",
+	"Australia/Perth",
+	"Africa/Nairobi",
+	"Africa/Khartoum",
+	"Africa/Cairo",
+	"Africa/Johannesburg",
+	"Africa/Lagos",
+	"Africa/Casablanca",
+	"Europe/Istanbul",
+	"Europe/Moscow",
+	"Europe/Paris",
+	"Europe/London",
+	"Europe/Lisbon",
+	"Antartica/Troll",
+	"MET",
+}
+
+var linuxArm64Varient = "LinuxArm64"
+
+// policySchedule the schedule for a sensor update policy.
+type policySchedule struct {
+	Enabled    types.Bool   `tfsdk:"enabled"`
+	Timezone   types.String `tfsdk:"timezone"`
+	TimeBlocks []timeBlock  `tfsdk:"time_blocks"`
+}
+
+func (p policySchedule) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"enabled":  types.BoolType,
+		"timezone": types.StringType,
+		"time_blocks": types.SetType{
+			ElemType: types.ObjectType{AttrTypes: timeBlock{}.AttributeTypes()},
+		},
+	}
+}
+
+// timeBlock a time block for a sensor update policy schedule.
+type timeBlock struct {
+	Days      types.Set    `tfsdk:"days"`
+	StartTime types.String `tfsdk:"start_time"`
+	EndTime   types.String `tfsdk:"end_time"`
+}
+
+func (t timeBlock) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"days":       types.SetType{ElemType: types.StringType},
+		"start_time": types.StringType,
+		"end_time":   types.StringType,
+	}
+}
+
+// validTime checks if the start and end time are atleast 1 hour apart.
+func validTime(startTimeStr string, endTimeStr string) (bool, error) {
+	startTime, err := time.Parse("15:04", startTimeStr)
+	if err != nil {
+		return false, err
+	}
+	endTime, err := time.Parse("15:04", endTimeStr)
+	if err != nil {
+		return false, err
+	}
+
+	duration := endTime.Sub(startTime)
+
+	return duration >= time.Hour, nil
+}
+
+// createUpdateSchedules handles the logic to create a models.PolicySensorUpdateSchedule.
+func createUpdateSchedules(
+	ctx context.Context,
+	timeBlocks []timeBlock,
+) ([]*models.PolicySensorUpdateSchedule, diag.Diagnostics) {
+	updateSchedules := []*models.PolicySensorUpdateSchedule{}
+	diags := diag.Diagnostics{}
+
+	for _, b := range timeBlocks {
+		bCopy := b
+		days := []string{}
+		daysInt64 := []int64{}
+
+		diags = bCopy.Days.ElementsAs(ctx, &days, false)
+
+		if diags.HasError() {
+			return updateSchedules, diags
+		}
+
+		for _, d := range days {
+			dCopy := d
+			daysInt64 = append(daysInt64, dayToInt64[strings.ToLower(dCopy)])
+		}
+
+		updateSchedules = append(updateSchedules, &models.PolicySensorUpdateSchedule{
+			Start: bCopy.StartTime.ValueStringPointer(),
+			End:   bCopy.EndTime.ValueStringPointer(),
+			Days:  daysInt64,
+		})
+	}
+
+	return updateSchedules, diags
+}
+
+// getSensorUpdatePolicy gets a sensor update policy based on ID.
+func getSensorUpdatePolicy(
+	ctx context.Context,
+	client *client.CrowdStrikeAPISpecification,
+	id string,
+) (*models.SensorUpdatePolicyV2, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	res, err := client.SensorUpdatePolicies.GetSensorUpdatePoliciesV2(
+		&sensor_update_policies.GetSensorUpdatePoliciesV2Params{
+			Context: ctx,
+			Ids:     []string{id},
+		},
+	)
+
+	if err != nil {
+		diags.AddError(
+			"Error reading CrowdStrike sensor update policy",
+			"Could not read CrowdStrike sensor update policy: "+id+": "+err.Error(),
+		)
+	}
+
+	if res == nil || res.Payload == nil || len(res.Payload.Resources) == 0 {
+		diags.AddError(
+			"Error reading CrowdStrike sensor update policy",
+			"API return successful status code, but no resources were returned.",
+		)
+		return nil, diags
+	}
+
+	policy := res.Payload.Resources[0]
+
+	return policy, diags
+}

--- a/internal/utils/debug.go
+++ b/internal/utils/debug.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 )
 
-// PancicPrettyPrint converts the interface into a json string and panics
+// PancicPrettyPrint converts the interface into a json string and panics.
 func PancicPrettyPrint(v interface{}) {
 	s, _ := json.MarshalIndent(v, "", "    ")
 	panic(string(s))

--- a/internal/utils/debug.go
+++ b/internal/utils/debug.go
@@ -1,0 +1,11 @@
+package utils
+
+import (
+	"encoding/json"
+)
+
+// PancicPrettyPrint converts the interface into a json string and panics
+func PancicPrettyPrint(v interface{}) {
+	s, _ := json.MarshalIndent(v, "", "    ")
+	panic(string(s))
+}

--- a/internal/utils/schema.go
+++ b/internal/utils/schema.go
@@ -1,8 +1,63 @@
 package utils
 
-import "github.com/hashicorp/terraform-plugin-framework/attr"
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
 
 // IsKnown returns true if an attribute value is known and not null.
 func IsKnown(value attr.Value) bool {
 	return !value.IsNull() && !value.IsUnknown()
+}
+
+// ListTypeAs converts a types.List into a known []T.
+func ListTypeAs[T any](
+	ctx context.Context,
+	list types.List,
+	diags *diag.Diagnostics,
+) []T {
+	if !IsKnown(list) {
+		return nil
+	}
+
+	var elements []T
+
+	diags.Append(list.ElementsAs(ctx, &elements, false)...)
+	return elements
+}
+
+// ValidateEmptyIDs checks if a set contains empty IDs. Returns a attribute error at path.
+func ValidateEmptyIDs(ctx context.Context, checkSet types.Set, attrPath string) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if checkSet.IsNull() {
+		return diags
+	}
+
+	if checkSet.IsUnknown() {
+		return diags
+	}
+
+	ids := make([]types.String, 0, len(checkSet.Elements()))
+	diags.Append(checkSet.ElementsAs(ctx, &ids, false)...)
+	if diags.HasError() {
+		return diags
+	}
+
+	for _, id := range ids {
+		if !id.IsUnknown() && len(id.ValueString()) == 0 {
+			diags.AddAttributeError(
+				path.Root(attrPath),
+				fmt.Sprintf("Error validating %s", attrPath),
+				"List of IDs can not contain a empty \"\" value",
+			)
+		}
+	}
+
+	return diags
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -103,19 +103,3 @@ func ListIDsToModify(
 
 	return
 }
-
-// ListTypeAs converts a types.List into a known []T.
-func ListTypeAs[T any](
-	ctx context.Context,
-	list types.List,
-	diags *diag.Diagnostics,
-) []T {
-	if !IsKnown(list) {
-		return nil
-	}
-
-	var elements []T
-
-	diags.Append(list.ElementsAs(ctx, &elements, false)...)
-	return elements
-}


### PR DESCRIPTION
this pr does the following:

- creates a new resource `crowdstrike_default_sensor_update_policy`
- moves sensor_update_policy resources to its own package
- fixes a bug with importing schedule
- raises an error when invalid host groups are provided
- raises an error when invalid build numbers are provided