### PR TITLE
fix wrong feature option check

### DIFF
--- a/internal/fcs/cloud_aws_account.go
+++ b/internal/fcs/cloud_aws_account.go
@@ -645,7 +645,7 @@ func (r *cloudAWSAccountResource) createCloudAccount(
 		IsMaster:       model.OrganizationID.ValueString() != "",
 		AccountType:    model.AccountType.ValueString(),
 	}
-	if model.AssetInventory != nil && model.AssetInventory.Enabled.ValueBool() {
+	if model.RealtimeVisibility != nil && model.RealtimeVisibility.Enabled.ValueBool() {
 		createAccount.CspEvents = true
 	}
 	if model.IDP != nil && model.IDP.Enabled.ValueBool() {


### PR DESCRIPTION
## Problem
The `createAccount.CspEvents` field is related to real-time visibility and detection feature, not asset inventory

## Solution
Check if realtime visibility is enabled when enabling `CspEvents` for CloudRegistration account