### PR TITLE
AWS registration: Send prefix/suffix strings to cloudreg provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/docs/data-sources/cloud_aws_account.md
+++ b/docs/data-sources/cloud_aws_account.md
@@ -64,6 +64,11 @@ data "crowdstrike_cloud_aws_account" "org" {
 <a id="nestedatt--accounts"></a>
 ### Nested Schema for `accounts`
 
+Optional:
+
+- `resource_name_prefix` (String) The prefix to be added to all resource names
+- `resource_name_suffix` (String) The suffix to be added to all resource names
+
 Read-Only:
 
 - `account_id` (String) The AWS Account ID

--- a/docs/resources/cloud_aws_account.md
+++ b/docs/resources/cloud_aws_account.md
@@ -74,6 +74,8 @@ resource "crowdstrike_cloud_aws_account" "org" {
 - `idp` (Attributes) (see [below for nested schema](#nestedatt--idp))
 - `organization_id` (String) The AWS Organization ID (starts with `o-`). When specified, accounts within the organization will be registered. If `target_ous` is empty, all accounts in the organization will be registered. The `account_id` must be the organization's management account ID.
 - `realtime_visibility` (Attributes) (see [below for nested schema](#nestedatt--realtime_visibility))
+- `resource_name_prefix` (String) The prefix to be added to all resource names
+- `resource_name_suffix` (String) The suffix to be added to all resource names
 - `sensor_management` (Attributes) (see [below for nested schema](#nestedatt--sensor_management))
 - `target_ous` (List of String) The list of target Organizational Units
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/crowdstrike/terraform-provider-crowdstrike
 go 1.24.0
 
 require (
-	github.com/crowdstrike/gofalcon v0.13.4
+	github.com/crowdstrike/gofalcon v0.14.2
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/terraform-plugin-docs v0.19.1

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZ
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
-github.com/crowdstrike/gofalcon v0.13.4 h1:yTlH6OS7q9hM8+MzXFhWevBFs8EPQ/fbcB3x/viJoks=
-github.com/crowdstrike/gofalcon v0.13.4/go.mod h1:zZ/+TAeXRC4CgweoGIEF6VkxUQEn0wDxLbI+Au86zBY=
+github.com/crowdstrike/gofalcon v0.14.2 h1:M5I6mPs7A87AUZN5zqeZM0TZr2NvGEoFM+tEysIIXOc=
+github.com/crowdstrike/gofalcon v0.14.2/go.mod h1:zKtGtkiNyxlY1mVdGY0/fRWb1AlCdGi8Z50AjfGAtvg=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/fcs/cloud_aws_account_data_source.go
+++ b/internal/fcs/cloud_aws_account_data_source.go
@@ -33,6 +33,8 @@ type cloudAWSAccountDataModel struct {
 	OrganizationID            types.String `tfsdk:"organization_id"`
 	TargetOUs                 types.List   `tfsdk:"target_ous"`
 	IsOrgManagementAccount    types.Bool   `tfsdk:"is_organization_management_account"`
+	ResourceNamePrefix        types.String `tfsdk:"resource_name_prefix"`
+	ResourceNameSuffix        types.String `tfsdk:"resource_name_suffix"`
 	AccountType               types.String `tfsdk:"account_type"`
 	ExternalID                types.String `tfsdk:"external_id"`
 	IntermediateRoleArn       types.String `tfsdk:"intermediate_role_arn"`
@@ -177,6 +179,16 @@ func (d *cloudAwsAccountsDataSource) Schema(
 						"dspm_enabled": schema.BoolAttribute{
 							Computed:    true,
 							Description: "Whether Data Security Posture Management is enabled",
+						},
+						"resource_name_prefix": schema.StringAttribute{
+							Optional:    true,
+							Computed:    true,
+							Description: "The prefix to be added to all resource names",
+						},
+						"resource_name_suffix": schema.StringAttribute{
+							Optional:    true,
+							Computed:    true,
+							Description: "The suffix to be added to all resource names",
 						},
 					},
 				},


### PR DESCRIPTION
When prefix/suffix strings are currently set, it is only getting propagated to the resource names. They need to be sent to provider (and to CrowdStrike)