### PR TITLE
AWS registration: Fix update to prefix/suffix strings

### DIFF
--- a/internal/fcs/cloud_aws_account.go
+++ b/internal/fcs/cloud_aws_account.go
@@ -921,6 +921,8 @@ func (r *cloudAWSAccountResource) Read(
 				break
 			}
 		}
+		state.ResourceNamePrefix = types.StringValue(cloudAccount.ResourceNamePrefix)
+		state.ResourceNameSuffix = types.StringValue(cloudAccount.ResourceNameSuffix)
 	}
 
 	cloudAccPrivateState, err := json.Marshal(cloudAccState)


### PR DESCRIPTION
The previous commit missed reading prefix/suffix strings while reading account