### PR TITLE
fix spelling of documentationSection in resource generation and resou…

### DIFF
--- a/internal/prevention_policy/prevention_policy_attachment.go
+++ b/internal/prevention_policy/prevention_policy_attachment.go
@@ -28,7 +28,7 @@ var (
 )
 
 var (
-	docuementationSection       string         = "Prevention Policy"
+	documentationSection        string         = "Prevention Policy"
 	resourceMarkdownDescription string         = "This resource allows managing the host groups and ioa rule groups attached to a prevention policy. This resource takes exclusive ownership over the host groups and ioa rule groups assigned to a prevention policy. If you want to fully create or manage a prevention policy please use the `prevention_policy_*` resource for the platform you want to manage."
 	requiredScopes              []scopes.Scope = apiScopes
 )
@@ -118,7 +118,7 @@ func (r *preventionPolicyAttachmentResource) Schema(
 ) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: utils.MarkdownDescription(
-			docuementationSection,
+			documentationSection,
 			resourceMarkdownDescription,
 			requiredScopes,
 		),

--- a/internal/sensor_update_policy/sensor_update_policy_host_group_attachment.go
+++ b/internal/sensor_update_policy/sensor_update_policy_host_group_attachment.go
@@ -26,7 +26,7 @@ var (
 )
 
 var (
-	docuementationSection       string         = "Sensor Update Policy"
+	documentationSection        string         = "Sensor Update Policy"
 	resourceMarkdownDescription string         = "This resource allows managing the host groups attached to a sensor update policy. This resource takes exclusive ownership over the host groups assigned to a sensor update policy. If you want to fully create or manage a sensor update policy please use the `sensor_update_policy` resource."
 	requiredScopes              []scopes.Scope = []scopes.Scope{
 		{
@@ -115,7 +115,7 @@ func (r *sensorUpdatePolicyHostGroupAttachmentResource) Schema(
 ) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: utils.MarkdownDescription(
-			docuementationSection,
+			documentationSection,
 			resourceMarkdownDescription,
 			requiredScopes,
 		),

--- a/tools/resource/resource.tpl
+++ b/tools/resource/resource.tpl
@@ -24,7 +24,7 @@ var (
 )
 
 var (
-  docuementationSection       string         = "section" 
+  documentationSection       string         = "section" 
   resourceMarkdownDescription string         = "<description>"
   requiredScopes              []scopes.Scope = []scopes.Scope{}
 )
@@ -95,7 +95,7 @@ func (r *{{.CamelCaseName}}Resource) Schema(
 	resp *resource.SchemaResponse,
 ) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: utils.MarkdownDescription(docuementationSection, resourceMarkdownDescription, requiredScopes),
+		MarkdownDescription: utils.MarkdownDescription(documentationSection, resourceMarkdownDescription, requiredScopes),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:    true,


### PR DESCRIPTION
…rce files

Correct the misspelling of 'docuementationSection' to 'documentationSection' in:
- tools/resource/resource.tpl
- internal/prevention_policy/prevention_policy_attachment.go
- internal/sensor_update_policy/sensor_update_policy_host_group_attachment.go

This ensures consistency and avoids confusion in variable naming.