### PR TITLE
feat: trigger FCS Azure health check scan in event hub settings resource

### DIFF
--- a/internal/fcs/cloud_azure_tenant_eventhub_settings.go
+++ b/internal/fcs/cloud_azure_tenant_eventhub_settings.go
@@ -189,17 +189,8 @@ func (r *cloudAzureTenantEventhubSettingsResource) Create(
 		return
 	}
 
-	err := r.triggerHealthCheck(ctx, data.TenantId.ValueString())
-	if len(err) > 0 {
-		tflog.Warn(
-			ctx,
-			fmt.Sprintf(
-				"failed to trigger health check scan for tenant %s, error: %+v",
-				data.TenantId.ValueString(),
-				err,
-			),
-		)
-	}
+	diags = r.triggerHealthCheck(ctx, data.TenantId.ValueString())
+	resp.Diagnostics.Append(diags...)
 
 	resp.Diagnostics.Append(data.wrap(ctx, *registration)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -257,17 +248,8 @@ func (r *cloudAzureTenantEventhubSettingsResource) Update(
 		return
 	}
 
-	err = r.triggerHealthCheck(ctx, data.TenantId.ValueString())
-	if len(err) > 0 {
-		tflog.Warn(
-			ctx,
-			fmt.Sprintf(
-				"failed to trigger health check scan for tenant %s, error: %+v",
-				data.TenantId.ValueString(),
-				err,
-			),
-		)
-	}
+	diags := r.triggerHealthCheck(ctx, data.TenantId.ValueString())
+	resp.Diagnostics.Append(diags...)
 
 	resp.Diagnostics.Append(data.wrap(ctx, *registration)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -456,8 +438,8 @@ func (r *cloudAzureTenantEventhubSettingsResource) triggerHealthCheck(
 	_, err := r.client.CloudAzureRegistration.CloudRegistrationAzureTriggerHealthCheck(&params)
 
 	if err != nil {
-		diags.AddError(
-			"Failed to trigger health check scan",
+		diags.AddWarning(
+			"Failed to trigger health check scan. Please go to the Falcon console and trigger health check scan manually to reflect the latest state.",
 			fmt.Sprintf("Failed to trigger health check scan for Azure tenant registration: %s", falcon.ErrorExplain(err)),
 		)
 	}


### PR DESCRIPTION
## Summary
- Updated gofalcon dependency from v0.16.1 to v0.17.0
- Added automatic health check scan triggering for Azure tenant event hub settings
- Implemented `triggerHealthCheck` function that calls `CloudRegistrationAzureTriggerHealthCheck` API
- Health check is triggered after `Create` and `Update` operations on event hub settings
- Health check failures are logged as warnings without blocking operations

## Test plan
- [ v ] Test Create operation triggers health check
- [ v ] Test Update operation triggers health check
- [ v ] Verify health check failures are logged as warnings
<img width="1185" height="133" alt="image" src="https://github.com/user-attachments/assets/98825874-482a-4e42-9825-f1b1aeefd46f" />

- [ v ] Confirm operations complete successfully even if health check fails