### PR TITLE
feat: add reusable framework validators package

### DIFF
--- a/internal/framework/validators/doc.go
+++ b/internal/framework/validators/doc.go
@@ -1,0 +1,7 @@
+// Package validators provides reusable Terraform schema validators and utilities
+// for the CrowdStrike Terraform Provider.
+//
+// This package contains custom validators that extend the Terraform Plugin Framework's
+// built-in validation capabilities with common validation patterns used throughout
+// the provider.
+package validators

--- a/internal/framework/validators/string_validators.go
+++ b/internal/framework/validators/string_validators.go
@@ -1,0 +1,38 @@
+package validators
+
+import (
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+// StringNotWhitespace returns a validator that ensures a string attribute is not
+// empty or composed only of whitespace characters.
+//
+// The validator uses a regex pattern (\S) to check that the string contains at least
+// one non-whitespace character. Null (unconfigured) and unknown (known after apply) values are skipped.
+//
+// Valid values: "test", "test value", "a"
+// Invalid values: "", " ", "   ", "\t", "\n", " \t\n "
+func StringNotWhitespace() validator.String {
+	return stringvalidator.RegexMatches(
+		regexp.MustCompile(`\S`),
+		"must not be empty or contain only whitespace",
+	)
+}
+
+// StringIsEmailAddress returns a validator that ensures a string attribute is a
+// valid email address format.
+//
+// The validator uses a regex pattern to check that the string conforms to a basic
+// email address format. Null (unconfigured) and unknown (known after apply) values are skipped.
+//
+// Valid values: "user@example.com", "test.user+tag@domain.co.uk"
+// Invalid values: "notanemail", "missing@domain", "@example.com", "user@"
+func StringIsEmailAddress() validator.String {
+	return stringvalidator.RegexMatches(
+		regexp.MustCompile(`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`),
+		"must be a valid email address",
+	)
+}

--- a/internal/framework/validators/string_validators_test.go
+++ b/internal/framework/validators/string_validators_test.go
@@ -1,0 +1,220 @@
+package validators
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStringNotWhitespaceValidator(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		value       types.String
+		expectError bool
+	}{
+		{
+			name:        "valid string",
+			value:       types.StringValue("test"),
+			expectError: false,
+		},
+		{
+			name:        "valid string with spaces",
+			value:       types.StringValue("test value"),
+			expectError: false,
+		},
+		{
+			name:        "empty string",
+			value:       types.StringValue(""),
+			expectError: true,
+		},
+		{
+			name:        "single space",
+			value:       types.StringValue(" "),
+			expectError: true,
+		},
+		{
+			name:        "multiple spaces",
+			value:       types.StringValue("   "),
+			expectError: true,
+		},
+		{
+			name:        "tabs only",
+			value:       types.StringValue("\t\t"),
+			expectError: true,
+		},
+		{
+			name:        "newlines only",
+			value:       types.StringValue("\n\n"),
+			expectError: true,
+		},
+		{
+			name:        "mixed whitespace",
+			value:       types.StringValue(" \t\n "),
+			expectError: true,
+		},
+		{
+			name:        "null value",
+			value:       types.StringNull(),
+			expectError: false,
+		},
+		{
+			name:        "unknown value",
+			value:       types.StringUnknown(),
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := validator.StringRequest{
+				Path:           path.Root("test"),
+				PathExpression: path.MatchRoot("test"),
+				ConfigValue:    tt.value,
+			}
+			resp := &validator.StringResponse{}
+
+			StringNotWhitespace().ValidateString(context.Background(), req, resp)
+
+			if tt.expectError {
+				assert.True(t, resp.Diagnostics.HasError(), "Expected error but got none for value: %q", tt.value.ValueString())
+			} else {
+				assert.False(t, resp.Diagnostics.HasError(), "Unexpected error for value: %q", tt.value.ValueString())
+			}
+		})
+	}
+}
+
+func TestStringIsEmailAddressValidator(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		value       types.String
+		expectError bool
+	}{
+		{
+			name:        "valid simple email",
+			value:       types.StringValue("user@example.com"),
+			expectError: false,
+		},
+		{
+			name:        "valid email with subdomain",
+			value:       types.StringValue("test@mail.example.com"),
+			expectError: false,
+		},
+		{
+			name:        "valid email with plus",
+			value:       types.StringValue("user+tag@example.com"),
+			expectError: false,
+		},
+		{
+			name:        "valid email with dots",
+			value:       types.StringValue("first.last@example.com"),
+			expectError: false,
+		},
+		{
+			name:        "valid email with numbers",
+			value:       types.StringValue("user123@example456.com"),
+			expectError: false,
+		},
+		{
+			name:        "valid email with underscore",
+			value:       types.StringValue("user_name@example.com"),
+			expectError: false,
+		},
+		{
+			name:        "valid email with percent",
+			value:       types.StringValue("user%test@example.com"),
+			expectError: false,
+		},
+		{
+			name:        "valid email with hyphen in domain",
+			value:       types.StringValue("user@my-domain.com"),
+			expectError: false,
+		},
+		{
+			name:        "invalid - no at symbol",
+			value:       types.StringValue("userexample.com"),
+			expectError: true,
+		},
+		{
+			name:        "invalid - missing domain",
+			value:       types.StringValue("user@"),
+			expectError: true,
+		},
+		{
+			name:        "invalid - missing username",
+			value:       types.StringValue("@example.com"),
+			expectError: true,
+		},
+		{
+			name:        "invalid - missing TLD",
+			value:       types.StringValue("user@example"),
+			expectError: true,
+		},
+		{
+			name:        "invalid - double at",
+			value:       types.StringValue("user@@example.com"),
+			expectError: true,
+		},
+		{
+			name:        "invalid - spaces",
+			value:       types.StringValue("user @example.com"),
+			expectError: true,
+		},
+		{
+			name:        "invalid - just text",
+			value:       types.StringValue("notanemail"),
+			expectError: true,
+		},
+		{
+			name:        "invalid - TLD too short",
+			value:       types.StringValue("user@example.c"),
+			expectError: true,
+		},
+		{
+			name:        "null value",
+			value:       types.StringNull(),
+			expectError: false,
+		},
+		{
+			name:        "unknown value",
+			value:       types.StringUnknown(),
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := validator.StringRequest{
+				Path:           path.Root("test"),
+				PathExpression: path.MatchRoot("test"),
+				ConfigValue:    tt.value,
+			}
+			resp := &validator.StringResponse{}
+
+			StringIsEmailAddress().ValidateString(context.Background(), req, resp)
+
+			if tt.expectError {
+				assert.True(t, resp.Diagnostics.HasError(), "Expected error but got none for value: %q", tt.value.ValueString())
+			} else {
+				assert.False(t, resp.Diagnostics.HasError(), "Unexpected error for value: %q", tt.value.ValueString())
+			}
+		})
+	}
+}
+
+func TestStringIsEmailAddressValidator_Description(t *testing.T) {
+	v := StringIsEmailAddress()
+	desc := v.Description(context.Background())
+	markdownDesc := v.MarkdownDescription(context.Background())
+
+	assert.NotEmpty(t, desc, "Description should not be empty")
+	assert.NotEmpty(t, markdownDesc, "MarkdownDescription should not be empty")
+}


### PR DESCRIPTION
Add a new internal/framework/validators package that provides reusable Terraform schema validators for common validation patterns.

Validators included:
- StringNotWhitespace(): Ensures strings are not empty or whitespace-only
- StringIsEmailAddress(): Validates email address format