### PR TITLE
handle 404 errors in content update policy resources

### DIFF
--- a/internal/tferrors/diags.go
+++ b/internal/tferrors/diags.go
@@ -1,0 +1,12 @@
+package tferrors
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+func NewResourceNotFoundWarningDiagnostic() diag.Diagnostic {
+	return diag.NewWarningDiagnostic(
+		"CrowdStrike resource not found during refresh",
+		"Automatically removing from Terraform State instead of returning the error, which may trigger resource recreation. This usually indicates the remote resource was deleted outside of Terraform.",
+	)
+}


### PR DESCRIPTION
fixes #239 

- Improved error for `crowdstrike_prevention_policy_attachment` resource to make it clear an existing content update policy is needed. 

<img width="1075" height="150" alt="image" src="https://github.com/user-attachments/assets/46123e8a-15a5-41f0-8a92-a50bd238e679" />

- The `Read` method was updated to display an warning diagnostic and mark the resource to be removed from state when encountering a 404 error. This is the same behavior other resources use. This prevents the resource from getting in a permanent failure loop when running terraform apply & destroy. Instead on apply the terraform will call `Create` and on destroy terraform will mark the resource as deleted.

<img width="1084" height="172" alt="image" src="https://github.com/user-attachments/assets/aabdea59-d9e3-4376-bed3-a0d02ab0c7c3" />
