### PR TITLE
add NewDiagnosticFromAPIError to handle gofalcon API errors

### DIFF
--- a/internal/tferrors/errors.go
+++ b/internal/tferrors/errors.go
@@ -74,7 +74,7 @@ func NewConflictError(operation Operation, detail string) diag.ErrorDiagnostic {
 	)
 }
 
-// ErrorOption configures optional behavior for HandleAPIError.
+// ErrorOption configures optional behavior for NewDiagnosticFromAPIError.
 type ErrorOption func(*errorConfig)
 
 // errorConfig holds optional configuration for error handling.
@@ -122,8 +122,8 @@ func WithDetail(detail string) ErrorOption {
 	}
 }
 
-// HandleAPIError converts a gofalcon API error into a Terraform diagnostic.
-func HandleAPIError(operation Operation, err error, apiScopes []scopes.Scope, options ...ErrorOption) diag.Diagnostic {
+// NewDiagnosticFromAPIError converts a gofalcon API error into a Terraform diagnostic.
+func NewDiagnosticFromAPIError(operation Operation, err error, apiScopes []scopes.Scope, options ...ErrorOption) diag.Diagnostic {
 	if err == nil {
 		return nil
 	}

--- a/internal/tferrors/errors_test.go
+++ b/internal/tferrors/errors_test.go
@@ -11,25 +11,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestHandleAPIError(t *testing.T) {
+func TestNewDiagnosticFromAPIError(t *testing.T) {
 	testScopes := []scopes.Scope{{Name: "test", Read: true}}
 
 	tests := []struct {
-		name     string
-		err      error
+		name      string
+		err       error
 		operation Operation
-		options  []ErrorOption
-		wantDiag diag.Diagnostic
+		options   []ErrorOption
+		wantDiag  diag.Diagnostic
 	}{
 		{
-			name:     "nil error",
-			err:      nil,
+			name:      "nil error",
+			err:       nil,
 			operation: Read,
-			wantDiag: nil,
+			wantDiag:  nil,
 		},
 		{
-			name:     "forbidden error",
-			err:      host_group.NewGetHostGroupsForbidden(),
+			name:      "forbidden error",
+			err:       host_group.NewGetHostGroupsForbidden(),
 			operation: Read,
 			wantDiag: diag.NewErrorDiagnostic(
 				"Failed to read: 403 Forbidden",
@@ -37,34 +37,34 @@ func TestHandleAPIError(t *testing.T) {
 			),
 		},
 		{
-			name:     "not found error with custom detail",
-			err:      host_group.NewGetHostGroupsNotFound(),
+			name:      "not found error with custom detail",
+			err:       host_group.NewGetHostGroupsNotFound(),
 			operation: Read,
-			options:  []ErrorOption{WithNotFoundDetail("Custom not found message")},
-			wantDiag: NewNotFoundError("Custom not found message"),
+			options:   []ErrorOption{WithNotFoundDetail("Custom not found message")},
+			wantDiag:  NewNotFoundError("Custom not found message"),
 		},
 		{
-			name:     "not found error with default detail",
-			err:      host_group.NewGetHostGroupsNotFound(),
+			name:      "not found error with default detail",
+			err:       host_group.NewGetHostGroupsNotFound(),
 			operation: Read,
-			wantDiag: NewNotFoundError(host_group.NewGetHostGroupsNotFound().Error()),
+			wantDiag:  NewNotFoundError(host_group.NewGetHostGroupsNotFound().Error()),
 		},
 		{
-			name:     "conflict error with custom detail",
-			err:      d4c_registration.NewCreateDiscoverCloudAzureAccountConflict(),
+			name:      "conflict error with custom detail",
+			err:       d4c_registration.NewCreateDiscoverCloudAzureAccountConflict(),
 			operation: Create,
-			options:  []ErrorOption{WithConflictDetail("Custom conflict message")},
-			wantDiag: NewConflictError(Create, "Custom conflict message"),
+			options:   []ErrorOption{WithConflictDetail("Custom conflict message")},
+			wantDiag:  NewConflictError(Create, "Custom conflict message"),
 		},
 		{
-			name:     "conflict error with default detail",
-			err:      d4c_registration.NewCreateDiscoverCloudAzureAccountConflict(),
+			name:      "conflict error with default detail",
+			err:       d4c_registration.NewCreateDiscoverCloudAzureAccountConflict(),
 			operation: Create,
-			wantDiag: NewConflictError(Create, d4c_registration.NewCreateDiscoverCloudAzureAccountConflict().Error()),
+			wantDiag:  NewConflictError(Create, d4c_registration.NewCreateDiscoverCloudAzureAccountConflict().Error()),
 		},
 		{
-			name:     "server error",
-			err:      host_group.NewGetHostGroupsInternalServerError(),
+			name:      "server error",
+			err:       host_group.NewGetHostGroupsInternalServerError(),
 			operation: Update,
 			wantDiag: diag.NewErrorDiagnostic(
 				"Failed to update",
@@ -72,8 +72,8 @@ func TestHandleAPIError(t *testing.T) {
 			),
 		},
 		{
-			name:     "standard go error",
-			err:      errors.New("standard go error"),
+			name:      "standard go error",
+			err:       errors.New("standard go error"),
 			operation: Read,
 			wantDiag: diag.NewErrorDiagnostic(
 				"Failed to read",
@@ -81,8 +81,8 @@ func TestHandleAPIError(t *testing.T) {
 			),
 		},
 		{
-			name:     "multiple options uses relevant one",
-			err:      d4c_registration.NewCreateDiscoverCloudAzureAccountConflict(),
+			name:      "multiple options uses relevant one",
+			err:       d4c_registration.NewCreateDiscoverCloudAzureAccountConflict(),
 			operation: Create,
 			options: []ErrorOption{
 				WithNotFoundDetail("Not found detail"),
@@ -94,7 +94,7 @@ func TestHandleAPIError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotDiag := HandleAPIError(tt.operation, tt.err, testScopes, tt.options...)
+			gotDiag := NewDiagnosticFromAPIError(tt.operation, tt.err, testScopes, tt.options...)
 			assert.Equal(t, tt.wantDiag, gotDiag)
 		})
 	}


### PR DESCRIPTION
General helper for handling common api errors reducing duplication and ensuring consistent error messages.

```Go
	res, err := r.client.ServiceCollection.SomeGetEndpoint(params)

	diags := tferrors.NewDiagnosticFromAPIError(tferrors.Read, err, apiScopes)
	if diags.HasError() {
		if tferrors.HasNotFoundError(diags) {
			resp.Diagnostics.Append(tferrors.NewResourceNotFoundWarningDiagnostic())
			resp.State.RemoveResource(ctx)
			return
		}

		resp.Diagnostics.Append(diags...)
		return
	}
```