### PR TITLE
fix(cloud_aws_account): nil pointer dereference in wrap() on provider upgrade (#297)

### DIFF
--- a/internal/fcs/cloud_aws_account.go
+++ b/internal/fcs/cloud_aws_account.go
@@ -1023,7 +1023,6 @@ func (m *cloudAWSAccountModel) wrap(ctx context.Context, cloudAccount *models.Do
 		m.IsOrgManagementAccount = types.BoolValue(false)
 	}
 
-	// Set computed values from cloudAccount
 	m.ExternalID = types.StringValue(cloudAccount.ResourceMetadata.ExternalID)
 	m.IntermediateRoleArn = types.StringValue(cloudAccount.ResourceMetadata.IntermediateRoleArn)
 	m.IamRoleArn = types.StringValue(cloudAccount.ResourceMetadata.IamRoleArn)
@@ -1061,7 +1060,9 @@ func (m *cloudAWSAccountModel) wrap(ctx context.Context, cloudAccount *models.Do
 	}
 	m.DspmRoleName = types.StringValue(dspmRoleName)
 	m.DspmRoleArn = types.StringValue(dspmRoleArn)
-	m.DSPM.RoleName = types.StringValue(dspmRoleName)
+	if m.DSPM != nil {
+		m.DSPM.RoleName = types.StringValue(dspmRoleName)
+	}
 
 	var vulnScanningRoleArn string
 	vulnScanningRoleNameFromSettings := settings.VulnerabilityScanningRoleName.ValueString()
@@ -1077,11 +1078,15 @@ func (m *cloudAWSAccountModel) wrap(ctx context.Context, cloudAccount *models.Do
 	}
 	m.VulnerabilityScanningRoleName = types.StringValue(vulnScanningRoleName)
 	m.VulnerabilityScanningRoleArn = types.StringValue(vulnScanningRoleArn)
-	m.VulnerabilityScanning.RoleName = types.StringValue(vulnScanningRoleName)
+	if m.VulnerabilityScanning != nil {
+		m.VulnerabilityScanning.RoleName = types.StringValue(vulnScanningRoleName)
+	}
 
 	agentlessScanningRoleName := dspmRoleName
-	if !m.DSPM.Enabled.ValueBool() && m.VulnerabilityScanning.Enabled.ValueBool() {
-		agentlessScanningRoleName = vulnScanningRoleName
+	if m.DSPM != nil && m.VulnerabilityScanning != nil {
+		if !m.DSPM.Enabled.ValueBool() && m.VulnerabilityScanning.Enabled.ValueBool() {
+			agentlessScanningRoleName = vulnScanningRoleName
+		}
 	}
 	m.AgentlessScanningRoleName = types.StringValue(agentlessScanningRoleName)
 


### PR DESCRIPTION
## Summary

When upgrading from a provider version before v0.0.44 (which added `vulnerability_scanning` to the schema) to v0.0.58+ (which introduced the `wrap()` method), `terraform plan` panics with a nil pointer dereference. The old state does not contain `vulnerability_scanning` or other newer fields, so `m.DSPM` and `m.VulnerabilityScanning` are nil when `wrap()` dereferences them.

Add nil guards for `m.DSPM` and `m.VulnerabilityScanning` before accessing their fields, matching the pattern already used by `updateFeatureStatesFromProducts` in the same file.

Closes #297