### PR TITLE
docs(cid_group): correct subcategory to "Host Setup and Management"

### DIFF
--- a/docs/resources/cid_group.md
+++ b/docs/resources/cid_group.md
@@ -1,6 +1,6 @@
 ---
 page_title: "crowdstrike_cid_group Resource - crowdstrike"
-subcategory: "Host Management and Setup"
+subcategory: "Host Setup and Management"
 description: |-
   Manages CID groups in CrowdStrike Falcon Flight Control. CID groups allow MSPs to organize and manage child CIDs for multi-tenant environments.
   API Scopes

--- a/internal/cid_group/cid_group_resource.go
+++ b/internal/cid_group/cid_group_resource.go
@@ -95,7 +95,7 @@ func (r *cidGroupResource) Schema(
 ) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: utils.MarkdownDescription(
-			"Host Management and Setup",
+			"Host Setup and Management",
 			"Manages CID groups in CrowdStrike Falcon Flight Control. CID groups allow MSPs to organize and manage child CIDs for multi-tenant environments.",
 			apiScopes,
 		),


### PR DESCRIPTION
The cid_group resource had its subcategory set to "Host Management and
Setup" instead of "Host Setup and Management", placing it in the wrong
documentation section.