### PR TITLE
chore: enable goreleaser changelog generation from conventional commits (#292)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,7 +55,31 @@ release:
   extra_files:
     - glob: 'terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
-  # If you want to manually examine the release before its live, uncomment this line:
-  # draft: true
+  draft: true
 changelog:
-  disable: true
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - "^test:"
+      - "^chore"
+      - "merge conflict"
+      - Merge pull request
+      - Merge remote-tracking branch
+      - Merge branch
+      - go mod tidy
+  groups:
+    - title: "Features"
+      regexp: "^.*feat[(\\w)]*:+.*$"
+      order: 100
+    - title: "Bug Fixes"
+      regexp: "^.*fix[(\\w)]*:+.*$"
+      order: 200
+    - title: "Dependencies"
+      regexp: "^.*\\(deps\\)*:+.*$"
+      order: 300
+    - title: "Documentation"
+      regexp: "^.*docs[(\\w)]*:+.*$"
+      order: 400
+    - title: "Other Work"
+      order: 9999

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,0 @@
-## 0.1.0 (Unreleased)
-
-FEATURES:


### PR DESCRIPTION
## Summary

- Enable GoReleaser changelog generation from conventional commits, grouping into Features, Bug Fixes, Dependencies, Documentation, and Other Work
- Enable draft releases so changelogs can be reviewed before publishing
- Remove empty `CHANGELOG.md` placeholder

## Release Workflow

1. Create tag in GitHub UI (or `git tag` + `git push --tags`)
2. `git pull` to get the tag locally
3. Run `goreleaser release --clean` — creates a **draft** GitHub release with generated changelog + signed binaries
4. Review the draft in GitHub, edit if needed, then publish

Closes #292