### PR TITLE
fix(ioa_rule_group): add DMG to file_type allowed values

### DIFF
--- a/internal/ioa_rule_group/ioa_rule_group_resource.go
+++ b/internal/ioa_rule_group/ioa_rule_group_resource.go
@@ -157,6 +157,7 @@ var fileTypeLabelMap = map[string]string{
 	"BMP":    "Bitmap image format",
 	"CRX":    "CRX Chrome Extension file",
 	"DEB":    "Debian Package",
+	"DMG":    "Apple Disk Image",
 	"EARC":   "Email Archive format",
 	"EML":    "Email file format",
 	"GIF":    "GIF image format",
@@ -527,7 +528,7 @@ func (r *ioaRuleGroupResource) Schema(
 							Description: "File types to match. Only valid for File Creation rules.",
 							Validators: []validator.Set{
 								setvalidator.ValueStringsAre(
-									stringvalidator.OneOf("7ZIP", "ARC", "ARJ", "BMP", "BZIP2", "CAB", "CRX", "DEB", "DMP", "DOCX", "DWG", "DXF", "EARC", "EML", "ESE", "GIF", "HIVE", "IDW", "JAR", "JCLASS", "JPG", "LNK", "MACHO", "MSI", "OLE", "OOXML", "PDF", "PE", "PNG", "PPTX", "PYTHON", "RAR", "RPM", "RTF", "SCRIPT", "SLD", "TAR", "TIFF", "VDI", "VMDK", "VSDX", "XAR", "XLSX", "ZIP", "OTHER"),
+									stringvalidator.OneOf("7ZIP", "ARC", "ARJ", "BMP", "BZIP2", "CAB", "CRX", "DEB", "DMG", "DMP", "DOCX", "DWG", "DXF", "EARC", "EML", "ESE", "GIF", "HIVE", "IDW", "JAR", "JCLASS", "JPG", "LNK", "MACHO", "MSI", "OLE", "OOXML", "PDF", "PE", "PNG", "PPTX", "PYTHON", "RAR", "RPM", "RTF", "SCRIPT", "SLD", "TAR", "TIFF", "VDI", "VMDK", "VSDX", "XAR", "XLSX", "ZIP", "OTHER"),
 								),
 							},
 						},


### PR DESCRIPTION
## Summary

Add "DMG" (Apple Disk Image) to the file_type validator's allowed values in the crowdstrike_ioa_rule_group resource. Also add "DMG" to the fileTypeDescriptions map used for documentation.

Closes #330

## Problem

When importing existing macOS IOA rules created in the Falcon console with all file types selected, tofu plan / terraform plan fails with:

file_type[Value("DMG")] value must be one of: ["7ZIP" "ARC" ... "OTHER"], got: "DMG"

The CrowdStrike API supports "DMG"; only the Terraform side validation was missing it.

## Test plan

Verify go build ./... passes
Import a macOS IOA rule group with DMG file type and confirm plan succeeds