### PR TITLE
feat(it_automation_task): adding task parameter support

### DIFF
--- a/docs/resources/it_automation_task.md
+++ b/docs/resources/it_automation_task.md
@@ -166,6 +166,27 @@ resource "crowdstrike_it_automation_task" "osquery_example" {
   ]
 }
 
+resource "crowdstrike_it_automation_task" "osquery_with_params_exmaple" {
+  name        = "OSQuery Params Example"
+  access_type = "Public"
+  description = "Example task using OSQuery with parameters"
+  type        = "query"
+
+  os_query = "SELECT * FROM file WHERE directory = '{{.dir}}';"
+
+  task_parameters = [
+    {
+      input_type      = "text"
+      validation_type = "filepath"
+      key             = "dir"
+      label           = "Directory to Query"
+      purpose         = "Get all files from a directory"
+      default_value   = "C:\\Windows\\Temp"
+      format_hint     = "Example: C:\\Windows\\Temp"
+    },
+  ]
+}
+
 output "script_content_task" {
   value = crowdstrike_it_automation_task.script_content_example
 }
@@ -184,6 +205,10 @@ output "windows_script_task" {
 
 output "osquery_task" {
   value = crowdstrike_it_automation_task.osquery_example
+}
+
+output "osquery_with_params_example" {
+  value = crowdstrike_it_automation_task.osquery_with_params_exmaple
 }
 ```
 
@@ -210,6 +235,7 @@ output "osquery_task" {
 - `os_query` (String) OSQuery string. This option will disable the task script options. See https://osquery.readthedocs.io/en/stable for syntax.
 - `script_columns` (Attributes) Column configuration for the script output. (see [below for nested schema](#nestedatt--script_columns))
 - `target` (String) Target of the task in FQL string syntax. See https://falconpy.io/Usage/Falcon-Query-Language.html.
+- `task_parameters` (Attributes List) Input parameters to pass into the query or action task. (see [below for nested schema](#nestedatt--task_parameters))
 - `verification_condition` (Attributes List) Verification conditions for action tasks to determine success (only valid for action tasks). (see [below for nested schema](#nestedatt--verification_condition))
 - `windows_script_content` (String) Windows script content.
 - `windows_script_file_id` (String) Windows RTR Response script ID (65 characters) to be used by the task. This option disables windows_script_content.
@@ -241,6 +267,36 @@ Optional:
 Required:
 
 - `name` (String) Name of the column.
+
+
+
+<a id="nestedatt--task_parameters"></a>
+### Nested Schema for `task_parameters`
+
+Required:
+
+- `input_type` (String) Type of input field (text, option).
+- `key` (String) Unique identifier for the parameter, corresponds to placeholder used in task content.
+- `label` (String) Human readable label for the parameter.
+
+Optional:
+
+- `default_value` (String) Default value for the parameter when input_type is text.
+- `format_hint` (String) Provide format requirements or example when input_type is text (shows when running the task).
+- `optional` (Boolean) Whether the parameter is optional.
+- `options` (Attributes List) Available options for dropdown inputs. Used only if input_type is option. (see [below for nested schema](#nestedatt--task_parameters--options))
+- `purpose` (String) Describe parameter purpose (shows when running the task).
+- `validation_message` (String) Message to show on failure of custom validation regex.
+- `validation_regex` (String) Custom regex pattern to apply when input_type is text.
+- `validation_type` (String) Type of validation to apply when input_type is text (alphanumeric, text, filepath, filepathunix, semver, uuid, winhost, integer, filepathwin, datetime,macaddress, port, dnshost, float, ip)
+
+<a id="nestedatt--task_parameters--options"></a>
+### Nested Schema for `task_parameters.options`
+
+Required:
+
+- `key` (String) Unique identifier for the option.
+- `value` (String) Value for the option.
 
 
 

--- a/examples/resources/crowdstrike_it_automation_task/resource.tf
+++ b/examples/resources/crowdstrike_it_automation_task/resource.tf
@@ -137,6 +137,27 @@ resource "crowdstrike_it_automation_task" "osquery_example" {
   ]
 }
 
+resource "crowdstrike_it_automation_task" "osquery_with_params_exmaple" {
+  name        = "OSQuery Params Example"
+  access_type = "Public"
+  description = "Example task using OSQuery with parameters"
+  type        = "query"
+
+  os_query = "SELECT * FROM file WHERE directory = '{{.dir}}';"
+
+  task_parameters = [
+    {
+      input_type      = "text"
+      validation_type = "filepath"
+      key             = "dir"
+      label           = "Directory to Query"
+      purpose         = "Get all files from a directory"
+      default_value   = "C:\\Windows\\Temp"
+      format_hint     = "Example: C:\\Windows\\Temp"
+    },
+  ]
+}
+
 output "script_content_task" {
   value = crowdstrike_it_automation_task.script_content_example
 }
@@ -155,4 +176,8 @@ output "windows_script_task" {
 
 output "osquery_task" {
   value = crowdstrike_it_automation_task.osquery_example
+}
+
+output "osquery_with_params_example" {
+  value = crowdstrike_it_automation_task.osquery_with_params_exmaple
 }

--- a/internal/it_automation/it_automation_task_resource.go
+++ b/internal/it_automation/it_automation_task_resource.go
@@ -324,7 +324,7 @@ func (r *itAutomationTaskResource) constructUpdatePayload(
 			body.TaskParameters = taskParams
 		}
 	} else if len(currentTask.TaskParameters) > 0 {
-		body.TaskParameters = currentTask.TaskParameters
+		body.TaskParameters = []*models.ItautomationTaskParameter{}
 	}
 
 	switch apiType {
@@ -745,6 +745,7 @@ func (r *itAutomationTaskResource) Schema(
 			},
 			"task_parameters": schema.ListNestedAttribute{
 				Optional:    true,
+				Computed:    true,
 				Description: "Input parameters to pass into the query or action task.",
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{

--- a/internal/it_automation/it_automation_task_resource.go
+++ b/internal/it_automation/it_automation_task_resource.go
@@ -53,6 +53,25 @@ type itAutomationTaskResource struct {
 	client *client.CrowdStrikeAPISpecification
 }
 
+type taskParameterModel struct {
+	DefaultValue      types.String `tfsdk:"default_value"`
+	FormatHint        types.String `tfsdk:"format_hint"`
+	InputType         types.String `tfsdk:"input_type"`
+	Key               types.String `tfsdk:"key"`
+	Label             types.String `tfsdk:"label"`
+	Optional          types.Bool   `tfsdk:"optional"`
+	Options           types.List   `tfsdk:"options"`
+	Purpose           types.String `tfsdk:"purpose"`
+	ValidationMessage types.String `tfsdk:"validation_message"`
+	ValidationRegex   types.String `tfsdk:"validation_regex"`
+	ValidationType    types.String `tfsdk:"validation_type"`
+}
+
+type taskParameterOptionsModel struct {
+	Key   types.String `tfsdk:"key"`
+	Value types.String `tfsdk:"value"`
+}
+
 type scriptColumnModel struct {
 	Name types.String `tfsdk:"name"`
 }
@@ -94,6 +113,7 @@ type itAutomationTaskResourceModel struct {
 	MacScriptFileId          types.String `tfsdk:"mac_script_file_id"`
 	MacScriptLanguage        types.String `tfsdk:"mac_script_language"`
 	OsQuery                  types.String `tfsdk:"os_query"`
+	TaskParameters           types.List   `tfsdk:"task_parameters"`
 	ScriptColumns            types.Object `tfsdk:"script_columns"`
 	Target                   types.String `tfsdk:"target"`
 	TaskGroupID              types.String `tfsdk:"task_group_id"`
@@ -282,6 +302,20 @@ func (r *itAutomationTaskResource) constructUpdatePayload(
 		body.OutputParserConfig = outputParser
 	}
 
+	if !plan.TaskParameters.IsNull() && len(plan.TaskParameters.Elements()) > 0 {
+		taskParams, taskParamDiags := createTaskParams(
+			ctx,
+			plan.TaskParameters,
+		)
+
+		diags.Append(taskParamDiags...)
+		if !diags.HasError() {
+			body.TaskParameters = taskParams
+		}
+	} else if len(currentTask.TaskParameters) > 0 {
+		body.TaskParameters = currentTask.TaskParameters
+	}
+
 	switch apiType {
 	case "query":
 		if plan.OsQuery.IsNull() {
@@ -363,6 +397,16 @@ func (t *itAutomationTaskResourceModel) wrap(
 		}
 	} else {
 		t.VerificationCondition = types.ListNull(types.ObjectType{AttrTypes: verificationConditionAttrTypes()})
+	}
+
+	if task.HasTaskParameters {
+		taskParams, pDiags := extractTaskParams(ctx, task.TaskParameters)
+		diags.Append(pDiags...)
+		if !diags.HasError() {
+			t.TaskParameters = taskParams
+		}
+	} else {
+		t.TaskParameters = types.ListNull(types.ObjectType{AttrTypes: taskParametersAttrTypes()})
 	}
 
 	if task.OutputParserConfig != nil {
@@ -688,6 +732,116 @@ func (r *itAutomationTaskResource) Schema(
 					},
 				},
 			},
+			"task_parameters": schema.ListNestedAttribute{
+				Optional:    true,
+				Description: "Input parameters to pass into the query or action task.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						// TODO: how to make this use dropdown instead of option
+						"input_type": schema.StringAttribute{
+							Required:    true,
+							Description: "Type of input field (text, option).",
+							Validators: []validator.String{
+								stringvalidator.OneOf("text", "option"),
+							},
+						},
+						"key": schema.StringAttribute{
+							Required:    true,
+							Description: "Unique identifier for the parameter, corresponds to placeholder used in task content.",
+							Validators: []validator.String{
+								stringvalidator.LengthAtLeast(1),
+								stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_]+$`), "key can only contain letters, numbers and underscores."),
+							},
+						},
+						"label": schema.StringAttribute{
+							Required:    true,
+							Description: "Human readable label for the parameter.",
+							Validators: []validator.String{
+								stringvalidator.LengthAtLeast(2),
+							},
+						},
+						// Optional Types are also computed because gofalcon returns empty values for them
+						"purpose": schema.StringAttribute{
+							Optional:    true,
+							Computed:    true,
+							Description: "Describe parameter purpose (shows when running the task).",
+							Validators: []validator.String{
+								stringvalidator.LengthBetween(2, 200),
+							},
+						},
+						"optional": schema.BoolAttribute{
+							Optional:    true,
+							Computed:    true,
+							Description: "Whether the parameter is optional.",
+						},
+						"validation_type": schema.StringAttribute{
+							Optional:    true,
+							Computed:    true,
+							Description: "Type of validation to apply when input_type is text (alphanumeric, text, filepath, filepathunix, semver, uuid, winhost, integer, filepathwin, datetime,macaddress, port, dnshost, float, ip)",
+							Validators: []validator.String{
+								stringvalidator.OneOf("alphanumeric", "text", "filepath", "filepathunix", "semver", "uuid", "winhost", "integer", "filepathwin", "datetime", "macaddress", "port", "dnshost", "float", "ip"),
+							},
+						},
+						// TODO: does this work as default option as well?
+						"default_value": schema.StringAttribute{
+							Optional:    true,
+							Computed:    true,
+							Description: "Default value for the parameter when input_type is text.",
+							Validators: []validator.String{
+								stringvalidator.LengthAtLeast(2),
+							},
+						},
+						"format_hint": schema.StringAttribute{
+							Optional:    true,
+							Computed:    true,
+							Description: "Provide format requirements or example when input_type is text (shows when running the task).",
+							Validators: []validator.String{
+								stringvalidator.LengthAtLeast(2),
+							},
+						},
+						"options": schema.ListNestedAttribute{
+							Optional:    true,
+							Computed:    true,
+							Description: "Available options for dropdown inputs. Used only if input_type is option.",
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"key": schema.StringAttribute{
+										Required:    true,
+										Description: "Unique identifier for the option.",
+										Validators: []validator.String{
+											stringvalidator.LengthAtLeast(1),
+											stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_]+$`), "key can only contain letters, numbers and underscores."),
+										},
+									},
+									"value": schema.StringAttribute{
+										Required:    true,
+										Description: "Value for the option.",
+										Validators: []validator.String{
+											stringvalidator.LengthAtLeast(1),
+										},
+									},
+								},
+							},
+						},
+						"validation_message": schema.StringAttribute{
+							Optional:    true,
+							Computed:    true,
+							Description: "Message to show on failure of custom validation regex.",
+							Validators: []validator.String{
+								stringvalidator.LengthAtLeast(2),
+							},
+						},
+						"validation_regex": schema.StringAttribute{
+							Optional:    true,
+							Computed:    true,
+							Description: "Custom regex pattern to apply when input_type is text.",
+							Validators: []validator.String{
+								stringvalidator.LengthAtLeast(1),
+							},
+						},
+					},
+				},
+			},
 			"verification_condition": schema.ListNestedAttribute{
 				Optional:    true,
 				Description: "Verification conditions for action tasks to determine success (only valid for action tasks).",
@@ -892,6 +1046,16 @@ func (r *itAutomationTaskResource) Create(
 		}
 
 		body.OutputParserConfig = outputParser
+	}
+
+	if !plan.TaskParameters.IsNull() && len(plan.TaskParameters.Elements()) > 0 {
+		taskParams, taskParamDiags := createTaskParams(ctx, plan.TaskParameters)
+
+		resp.Diagnostics.Append(taskParamDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		body.TaskParameters = taskParams
 	}
 
 	switch apiType {
@@ -1246,6 +1410,72 @@ func (r *itAutomationTaskResource) ValidateConfig(
 			"Invalid argument", "script_columns cannot be used with os_query")
 	}
 
+	if !config.TaskParameters.IsNull() && !config.TaskParameters.IsUnknown() {
+		var taskParams []taskParameterModel
+		resp.Diagnostics.Append(config.TaskParameters.ElementsAs(ctx, &taskParams, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		for i, p := range taskParams {
+			paramPath := path.Root("task_parameters").AtListIndex(i)
+
+			switch p.InputType.ValueString() {
+			case "text":
+
+				if p.ValidationType.ValueString() != "text" {
+
+					if hasValue(p.ValidationRegex) {
+						resp.Diagnostics.AddAttributeError(paramPath.AtName("param"),
+							"Invalid argument", "validation_regex can only be used when validation type is \"text\"")
+					}
+
+					if hasValue(p.ValidationMessage) {
+						resp.Diagnostics.AddAttributeError(paramPath.AtName("param"),
+							"Invalid argument", "validation_message can only be used when validation type is \"text\"")
+					}
+
+				}
+
+				if !p.Options.IsNull() && !p.Options.IsUnknown() && len(p.Options.Elements()) > 0 {
+					resp.Diagnostics.AddAttributeError(
+						paramPath.AtName("options"),
+						"Invalid argument",
+						"options cannot be used when input_type is \"text\".",
+					)
+				}
+			case "option":
+				if p.Options.IsNull() || p.Options.IsUnknown() || len(p.Options.Elements()) == 0 {
+					resp.Diagnostics.AddAttributeError(
+						paramPath.AtName("options"),
+						"Missing required argument",
+						"options must be provided and non-empty when input_type is \"option\".",
+					)
+					return
+				}
+
+				for _, field := range []struct {
+					name  string
+					value types.String
+				}{
+					{name: "validation_type", value: p.ValidationType},
+					// {name: "default_value", value: p.DefaultValue},
+					{name: "validation_regex", value: p.ValidationRegex},
+					{name: "validation_message", value: p.ValidationMessage},
+					{name: "format_hint", value: p.FormatHint},
+				} {
+					if !field.value.IsNull() && !field.value.IsUnknown() && field.value.ValueString() != "" {
+						resp.Diagnostics.AddAttributeError(
+							paramPath.AtName(field.name),
+							"Invalid argument",
+							fmt.Sprintf("%s cannot be used when input_type is \"option\".", field.name),
+						)
+					}
+				}
+			}
+		}
+	}
+
 	switch config.Type.ValueString() {
 	case TaskTypeQuery:
 		if !config.AdditionalFileIds.IsNull() {
@@ -1290,6 +1520,59 @@ func (r *itAutomationTaskResource) ValidateConfig(
 				"Action tasks can only have scripts for one platform. Please specify scripts for only one of: Linux, Windows, or Mac.")
 		}
 	}
+}
+
+func createTaskParams(ctx context.Context, paramsList types.List) ([]*models.ItautomationTaskParameter, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// return early if no parameters are provided
+	if paramsList.IsNull() || paramsList.IsUnknown() || len(paramsList.Elements()) == 0 {
+		return nil, diags
+	}
+
+	var params []taskParameterModel
+	diags.Append(paramsList.ElementsAs(ctx, &params, false)...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	result := make([]*models.ItautomationTaskParameter, 0, len(params))
+	for _, p := range params {
+		var opts []taskParameterOptionsModel
+		if !p.Options.IsNull() && !p.Options.IsUnknown() && len(p.Options.Elements()) > 0 {
+			diags.Append(p.Options.ElementsAs(ctx, &opts, false)...)
+			if diags.HasError() {
+				return nil, diags
+			}
+		}
+
+		apiOpts := make([]*models.ItautomationParameterOption, 0, len(opts))
+		for _, opt := range opts {
+			apiOpt := &models.ItautomationParameterOption{
+				Key:   opt.Key.ValueStringPointer(),
+				Value: opt.Value.ValueStringPointer(),
+			}
+			apiOpts = append(apiOpts, apiOpt)
+		}
+
+		apiParam := &models.ItautomationTaskParameter{
+			CustomValidationMessage: p.ValidationMessage.ValueStringPointer(),
+			CustomValidationRegex:   p.ValidationRegex.ValueStringPointer(),
+			DefaultValue:            p.DefaultValue.ValueStringPointer(),
+			FormatHint:              p.FormatHint.ValueString(),
+			InputType:               p.InputType.ValueStringPointer(),
+			IsOptional:              p.Optional.ValueBool(),
+			Key:                     p.Key.ValueStringPointer(),
+			Label:                   p.Label.ValueStringPointer(),
+			Options:                 apiOpts,
+			Purpose:                 p.Purpose.ValueString(),
+			ValidationType:          p.ValidationType.ValueStringPointer(),
+		}
+
+		result = append(result, apiParam)
+	}
+
+	return result, diags
 }
 
 func createVerificationConditions(
@@ -1356,6 +1639,29 @@ func scriptColumnsAttrTypes() map[string]attr.Type {
 	}
 }
 
+func taskParametersOptionsAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"key":   types.StringType,
+		"value": types.StringType,
+	}
+}
+
+func taskParametersAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"default_value":      types.StringType,
+		"format_hint":        types.StringType,
+		"input_type":         types.StringType,
+		"key":                types.StringType,
+		"label":              types.StringType,
+		"optional":           types.BoolType,
+		"options":            types.ListType{ElemType: types.ObjectType{AttrTypes: taskParametersOptionsAttrTypes()}},
+		"purpose":            types.StringType,
+		"validation_message": types.StringType,
+		"validation_regex":   types.StringType,
+		"validation_type":    types.StringType,
+	}
+}
+
 func verificationStatementAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
 		"data_comparator": types.StringType,
@@ -1371,6 +1677,54 @@ func verificationConditionAttrTypes() map[string]attr.Type {
 		"operator":   types.StringType,
 		"statements": types.ListType{ElemType: types.ObjectType{AttrTypes: verificationStatementAttrTypes()}},
 	}
+}
+
+func extractTaskParams(ctx context.Context, taskParams []*models.ItautomationTaskParameter) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	paramObjType := types.ObjectType{AttrTypes: taskParametersAttrTypes()}
+
+	if len(taskParams) == 0 {
+		emptyList, listDiags := types.ListValueFrom(ctx, paramObjType, []taskParameterModel{})
+		diags.Append(listDiags...)
+		return emptyList, diags
+	}
+
+	result := make([]taskParameterModel, 0, len(taskParams))
+	optsObjType := types.ObjectType{AttrTypes: taskParametersOptionsAttrTypes()}
+
+	for _, apiParam := range taskParams {
+		opts := make([]taskParameterOptionsModel, 0, len(apiParam.Options))
+		for _, apiOpt := range apiParam.Options {
+			opts = append(opts, taskParameterOptionsModel{
+				Key:   types.StringPointerValue(apiOpt.Key),
+				Value: types.StringPointerValue(apiOpt.Value),
+			})
+		}
+
+		optsList, listDiags := types.ListValueFrom(ctx, optsObjType, opts)
+		diags.Append(listDiags...)
+		if diags.HasError() {
+			return types.ListNull(paramObjType), diags
+		}
+
+		result = append(result, taskParameterModel{
+			ValidationMessage: types.StringPointerValue(apiParam.CustomValidationMessage),
+			ValidationRegex:   types.StringPointerValue(apiParam.CustomValidationRegex),
+			DefaultValue:      types.StringPointerValue(apiParam.DefaultValue),
+			FormatHint:        types.StringValue(apiParam.FormatHint),
+			InputType:         types.StringPointerValue(apiParam.InputType),
+			Optional:          types.BoolValue(apiParam.IsOptional),
+			Key:               types.StringPointerValue(apiParam.Key),
+			Label:             types.StringPointerValue(apiParam.Label),
+			Options:           optsList,
+			Purpose:           types.StringValue(apiParam.Purpose),
+			ValidationType:    types.StringPointerValue(apiParam.ValidationType),
+		})
+	}
+
+	resultList, listDiags := types.ListValueFrom(ctx, paramObjType, result)
+	diags.Append(listDiags...)
+	return resultList, diags
 }
 
 func extractVerificationConditions(

--- a/internal/it_automation/it_automation_task_resource.go
+++ b/internal/it_automation/it_automation_task_resource.go
@@ -1435,12 +1435,12 @@ func (r *itAutomationTaskResource) ValidateConfig(
 				if p.ValidationType.ValueString() != "text" {
 
 					if hasValue(p.ValidationRegex) {
-						resp.Diagnostics.AddAttributeError(paramPath.AtName("param"),
+						resp.Diagnostics.AddAttributeError(paramPath.AtName("validation_regex"),
 							"Invalid argument", "validation_regex can only be used when validation type is \"text\"")
 					}
 
 					if hasValue(p.ValidationMessage) {
-						resp.Diagnostics.AddAttributeError(paramPath.AtName("param"),
+						resp.Diagnostics.AddAttributeError(paramPath.AtName("validation_message"),
 							"Invalid argument", "validation_message can only be used when validation type is \"text\"")
 					}
 

--- a/internal/it_automation/it_automation_task_resource.go
+++ b/internal/it_automation/it_automation_task_resource.go
@@ -126,10 +126,21 @@ type itAutomationTaskResourceModel struct {
 
 // convertType converts the type value to the Terraform or API expected values.
 func convertType(typeValue, dest string) string {
-	if dest == "terraform" && typeValue == TaskTypeRemediation {
-		typeValue = TaskTypeAction
-	} else if dest == "api" && typeValue == TaskTypeAction {
-		typeValue = TaskTypeRemediation
+	switch dest {
+	case "terraform":
+		switch typeValue {
+		case TaskTypeRemediation:
+			typeValue = TaskTypeAction
+		case ParamsTypeOption:
+			typeValue = ParamsTypeDropdown
+		}
+	case "api":
+		switch typeValue {
+		case TaskTypeAction:
+			typeValue = TaskTypeRemediation
+		case ParamsTypeDropdown:
+			typeValue = ParamsTypeOption
+		}
 	}
 	return typeValue
 }
@@ -737,12 +748,11 @@ func (r *itAutomationTaskResource) Schema(
 				Description: "Input parameters to pass into the query or action task.",
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
-						// TODO: how to make this use dropdown instead of option
 						"input_type": schema.StringAttribute{
 							Required:    true,
 							Description: "Type of input field (text, option).",
 							Validators: []validator.String{
-								stringvalidator.OneOf("text", "option"),
+								stringvalidator.OneOf("text", "dropdown"),
 							},
 						},
 						"key": schema.StringAttribute{
@@ -782,7 +792,6 @@ func (r *itAutomationTaskResource) Schema(
 								stringvalidator.OneOf("alphanumeric", "text", "filepath", "filepathunix", "semver", "uuid", "winhost", "integer", "filepathwin", "datetime", "macaddress", "port", "dnshost", "float", "ip"),
 							},
 						},
-						// TODO: does this work as default option as well?
 						"default_value": schema.StringAttribute{
 							Optional:    true,
 							Computed:    true,
@@ -1444,7 +1453,7 @@ func (r *itAutomationTaskResource) ValidateConfig(
 						"options cannot be used when input_type is \"text\".",
 					)
 				}
-			case "option":
+			case "dropdown":
 				if p.Options.IsNull() || p.Options.IsUnknown() || len(p.Options.Elements()) == 0 {
 					resp.Diagnostics.AddAttributeError(
 						paramPath.AtName("options"),
@@ -1459,7 +1468,6 @@ func (r *itAutomationTaskResource) ValidateConfig(
 					value types.String
 				}{
 					{name: "validation_type", value: p.ValidationType},
-					// {name: "default_value", value: p.DefaultValue},
 					{name: "validation_regex", value: p.ValidationRegex},
 					{name: "validation_message", value: p.ValidationMessage},
 					{name: "format_hint", value: p.FormatHint},
@@ -1555,12 +1563,17 @@ func createTaskParams(ctx context.Context, paramsList types.List) ([]*models.Ita
 			apiOpts = append(apiOpts, apiOpt)
 		}
 
+		inputType := p.InputType.ValueString()
+		if inputType == ParamsTypeDropdown {
+			inputType = convertType(ParamsTypeDropdown, "api")
+		}
+
 		apiParam := &models.ItautomationTaskParameter{
 			CustomValidationMessage: p.ValidationMessage.ValueStringPointer(),
 			CustomValidationRegex:   p.ValidationRegex.ValueStringPointer(),
 			DefaultValue:            p.DefaultValue.ValueStringPointer(),
 			FormatHint:              p.FormatHint.ValueString(),
-			InputType:               p.InputType.ValueStringPointer(),
+			InputType:               &inputType,
 			IsOptional:              p.Optional.ValueBool(),
 			Key:                     p.Key.ValueStringPointer(),
 			Label:                   p.Label.ValueStringPointer(),
@@ -1707,12 +1720,17 @@ func extractTaskParams(ctx context.Context, taskParams []*models.ItautomationTas
 			return types.ListNull(paramObjType), diags
 		}
 
+		inputType := *apiParam.InputType
+		if inputType == ParamsTypeOption {
+			inputType = convertType(ParamsTypeOption, "terraform")
+		}
+
 		result = append(result, taskParameterModel{
 			ValidationMessage: types.StringPointerValue(apiParam.CustomValidationMessage),
 			ValidationRegex:   types.StringPointerValue(apiParam.CustomValidationRegex),
 			DefaultValue:      types.StringPointerValue(apiParam.DefaultValue),
 			FormatHint:        types.StringValue(apiParam.FormatHint),
-			InputType:         types.StringPointerValue(apiParam.InputType),
+			InputType:         types.StringPointerValue(&inputType),
 			Optional:          types.BoolValue(apiParam.IsOptional),
 			Key:               types.StringPointerValue(apiParam.Key),
 			Label:             types.StringPointerValue(apiParam.Label),

--- a/internal/it_automation/it_automation_task_resource.go
+++ b/internal/it_automation/it_automation_task_resource.go
@@ -750,7 +750,7 @@ func (r *itAutomationTaskResource) Schema(
 					Attributes: map[string]schema.Attribute{
 						"input_type": schema.StringAttribute{
 							Required:    true,
-							Description: "Type of input field (text, option).",
+							Description: "Type of input field (text, dropdown).",
 							Validators: []validator.String{
 								stringvalidator.OneOf("text", "dropdown"),
 							},
@@ -1458,7 +1458,7 @@ func (r *itAutomationTaskResource) ValidateConfig(
 					resp.Diagnostics.AddAttributeError(
 						paramPath.AtName("options"),
 						"Missing required argument",
-						"options must be provided and non-empty when input_type is \"option\".",
+						"options must be provided and non-empty when input_type is \"dropdown\".",
 					)
 					return
 				}
@@ -1564,9 +1564,7 @@ func createTaskParams(ctx context.Context, paramsList types.List) ([]*models.Ita
 		}
 
 		inputType := p.InputType.ValueString()
-		if inputType == ParamsTypeDropdown {
-			inputType = convertType(ParamsTypeDropdown, "api")
-		}
+		inputType = convertType(inputType, "api")
 
 		apiParam := &models.ItautomationTaskParameter{
 			CustomValidationMessage: p.ValidationMessage.ValueStringPointer(),
@@ -1721,9 +1719,7 @@ func extractTaskParams(ctx context.Context, taskParams []*models.ItautomationTas
 		}
 
 		inputType := *apiParam.InputType
-		if inputType == ParamsTypeOption {
-			inputType = convertType(ParamsTypeOption, "terraform")
-		}
+		inputType = convertType(inputType, "terraform")
 
 		result = append(result, taskParameterModel{
 			ValidationMessage: types.StringPointerValue(apiParam.CustomValidationMessage),

--- a/internal/it_automation/it_automation_task_resource_test.go
+++ b/internal/it_automation/it_automation_task_resource_test.go
@@ -1064,7 +1064,6 @@ resource "crowdstrike_it_automation_task_group" "test" {
 func TestAccITAutomationTaskResource_AddRemoveUsers(t *testing.T) {
 	sdk := createSDKFixtures(t)
 	defer sdk.Cleanup(t)
-	defer sdk.Cleanup(t)
 
 	// Ensure we have at least 3 users to test with
 	if len(sdk.UserIDs) < 3 {
@@ -1252,7 +1251,6 @@ func TestAccITAutomationTaskResource_TaskParameters(t *testing.T) {
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	isOptional := true
-	isRequired := false
 
 	testCases := []struct {
 		name         string
@@ -1298,7 +1296,7 @@ echo "$TARGET_PATH"`),
 echo "$TARGET_ENV"`),
 				TaskParameters: []taskParameterConfig{
 					{
-						InputType: "option",
+						InputType: "dropdown",
 						Key:       "TARGET_ENV",
 						Label:     "Target Environment",
 						Purpose:   ptrString("Environment selector"),
@@ -1311,113 +1309,6 @@ echo "$TARGET_ENV"`),
 							{
 								Key:   "dev",
 								Value: "Development",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name:         "task_parameters_action_initial",
-			configPrefix: "verification",
-			config: taskConfig{
-				Name:                rName + "-action",
-				AccessType:          "Public",
-				Description:         "Action task with mixed task parameters",
-				Type:                "action",
-				LinuxScriptFileId:   ptrString(sdk.ScriptFileIDs["linux"]),
-				LinuxScriptLanguage: ptrString("bash"),
-				FileIds:             []string{sdk.FileIDs["linux"]},
-				VerificationCondition: &verificationConditionConfig{
-					Operator: "AND",
-					Statements: []verificationStatementConfig{
-						{
-							DataComparator: "Equals",
-							DataType:       "StringType",
-							Key:            "script_output",
-							TaskID:         "placeholder",
-							Value:          "Success",
-						},
-					},
-				},
-				TaskParameters: []taskParameterConfig{
-					{
-						InputType:      "text",
-						Key:            "RETRY_COUNT",
-						Label:          "Retry Count",
-						Purpose:        ptrString("Retries before failure"),
-						Optional:       &isRequired,
-						ValidationType: ptrString("integer"),
-						DefaultValue:   ptrString("03"),
-						FormatHint:     ptrString("Integer value"),
-					},
-					{
-						InputType: "option",
-						Key:       "RESTART_SERVICE",
-						Label:     "Restart Service",
-						Optional:  &isOptional,
-						Options: []taskParameterOptionConfig{
-							{
-								Key:   "yes",
-								Value: "Yes",
-							},
-							{
-								Key:   "no",
-								Value: "No",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name:         "task_parameters_action_updated",
-			configPrefix: "verification",
-			config: taskConfig{
-				Name:                rName + "-action-updated",
-				AccessType:          "Shared",
-				Description:         "Action task with updated task parameters",
-				Type:                "action",
-				LinuxScriptFileId:   ptrString(sdk.ScriptFileIDs["linux"]),
-				LinuxScriptLanguage: ptrString("bash"),
-				FileIds:             []string{sdk.FileIDs["linux"]},
-				AssignedUserIds:     sdk.UserIDs,
-				VerificationCondition: &verificationConditionConfig{
-					Operator: "OR",
-					Statements: []verificationStatementConfig{
-						{
-							DataComparator: "Contains",
-							DataType:       "StringType",
-							Key:            "script_output",
-							TaskID:         "placeholder",
-							Value:          "Complete",
-						},
-					},
-				},
-				TaskParameters: []taskParameterConfig{
-					{
-						InputType:      "text",
-						Key:            "RETRY_COUNT",
-						Label:          "Retry Count",
-						Purpose:        ptrString("Retries before failure"),
-						Optional:       &isRequired,
-						ValidationType: ptrString("integer"),
-						DefaultValue:   ptrString("05"),
-						FormatHint:     ptrString("Integer value"),
-					},
-					{
-						InputType: "option",
-						Key:       "RESTART_SERVICE",
-						Label:     "Restart Service",
-						Optional:  &isRequired,
-						Options: []taskParameterOptionConfig{
-							{
-								Key:   "force",
-								Value: "Force Restart",
-							},
-							{
-								Key:   "graceful",
-								Value: "Graceful Restart",
 							},
 						},
 					},

--- a/internal/it_automation/it_automation_task_resource_test.go
+++ b/internal/it_automation/it_automation_task_resource_test.go
@@ -1325,12 +1325,8 @@ echo "$TARGET_ENV"`),
 		},
 		Steps: func() []resource.TestStep {
 			var steps []resource.TestStep
-			fixtures := getTestFixtures()
 			for _, tc := range testCases {
 				config := acctest.ProviderConfig + tc.config.String()
-				if tc.configPrefix == "verification" {
-					config = acctest.ProviderConfig + fixtures.VerificationTasksOnly() + tc.config.String()
-				}
 
 				steps = append(steps, resource.TestStep{
 					Config: config,

--- a/internal/it_automation/it_automation_task_resource_test.go
+++ b/internal/it_automation/it_automation_task_resource_test.go
@@ -19,6 +19,7 @@ type taskConfig struct {
 	AccessType            string
 	Description           string
 	Type                  string
+	TaskParameters        []taskParameterConfig
 	AssignedUserIds       []string
 	LinuxScriptLanguage   *string
 	LinuxScriptContent    *string
@@ -58,6 +59,25 @@ type verificationStatementConfig struct {
 	Value          string
 }
 
+type taskParameterConfig struct {
+	InputType         string
+	Key               string
+	Label             string
+	Purpose           *string
+	Optional          *bool
+	ValidationType    *string
+	DefaultValue      *string
+	FormatHint        *string
+	Options           []taskParameterOptionConfig
+	ValidationMessage *string
+	ValidationRegex   *string
+}
+
+type taskParameterOptionConfig struct {
+	Key   string
+	Value string
+}
+
 func ptrString(s string) *string {
 	return &s
 }
@@ -70,6 +90,65 @@ resource "crowdstrike_it_automation_task" "test" {
   description = %q
   type        = %q
 `, config.Name, config.AccessType, config.Description, config.Type)
+
+	if len(config.TaskParameters) > 0 {
+		result += "\n  task_parameters = ["
+		for _, param := range config.TaskParameters {
+			result += fmt.Sprintf(`
+    {
+      input_type = %q
+      key        = %q
+      label      = %q`, param.InputType, param.Key, param.Label)
+
+			if param.Purpose != nil {
+				result += fmt.Sprintf(`
+      purpose    = %q`, *param.Purpose)
+			}
+			if param.Optional != nil {
+				result += fmt.Sprintf(`
+      optional   = %t`, *param.Optional)
+			}
+			if param.ValidationType != nil {
+				result += fmt.Sprintf(`
+      validation_type = %q`, *param.ValidationType)
+			}
+			if param.DefaultValue != nil {
+				result += fmt.Sprintf(`
+      default_value = %q`, *param.DefaultValue)
+			}
+			if param.FormatHint != nil {
+				result += fmt.Sprintf(`
+      format_hint = %q`, *param.FormatHint)
+			}
+			if len(param.Options) > 0 {
+				result += `
+      options = [`
+				for _, opt := range param.Options {
+					result += fmt.Sprintf(`
+        {
+          key   = %q
+          value = %q
+        },`, opt.Key, opt.Value)
+				}
+				result += `
+      ]`
+			}
+			if param.ValidationMessage != nil {
+				result += fmt.Sprintf(`
+      validation_message = %q`, *param.ValidationMessage)
+			}
+			if param.ValidationRegex != nil {
+				result += fmt.Sprintf(`
+      validation_regex = %q`, *param.ValidationRegex)
+			}
+
+			result += `
+    },`
+		}
+		result += `
+  ]
+`
+	}
 
 	if len(config.AssignedUserIds) > 0 {
 		result += "\n  assigned_user_ids = [\n"
@@ -244,6 +323,12 @@ func (config *taskConfig) TestChecks() resource.TestCheckFunc {
 	if len(config.FileIds) > 0 {
 		checks = append(checks,
 			resource.TestCheckResourceAttr(taskResourceName, "additional_file_ids.#", fmt.Sprintf("%d", len(config.FileIds))),
+		)
+	}
+
+	if len(config.TaskParameters) > 0 {
+		checks = append(checks,
+			resource.TestCheckResourceAttr(taskResourceName, "task_parameters.#", fmt.Sprintf("%d", len(config.TaskParameters))),
 		)
 	}
 
@@ -1158,5 +1243,218 @@ resource "crowdstrike_it_automation_task" "test" {
 				),
 			},
 		},
+	})
+}
+
+func TestAccITAutomationTaskResource_TaskParameters(t *testing.T) {
+	sdk := createSDKFixtures(t)
+	defer sdk.Cleanup(t)
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	isOptional := true
+	isRequired := false
+
+	testCases := []struct {
+		name         string
+		config       taskConfig
+		configPrefix string
+	}{
+		{
+			name:         "task_parameters_query_initial",
+			configPrefix: "",
+			config: taskConfig{
+				Name:                rName + "-query",
+				AccessType:          "Shared",
+				Description:         "Query task with text task parameter",
+				Type:                "query",
+				LinuxScriptLanguage: ptrString("bash"),
+				LinuxScriptContent: ptrString(`#!/bin/bash
+echo "$TARGET_PATH"`),
+				AssignedUserIds: sdk.UserIDs,
+				TaskParameters: []taskParameterConfig{
+					{
+						InputType:      "text",
+						Key:            "TARGET_PATH",
+						Label:          "Target Path",
+						Purpose:        ptrString("Path to query"),
+						Optional:       &isOptional,
+						ValidationType: ptrString("text"),
+						DefaultValue:   ptrString("/tmp"),
+						FormatHint:     ptrString("Use an absolute path"),
+					},
+				},
+			},
+		},
+		{
+			name:         "task_parameters_query_updated",
+			configPrefix: "",
+			config: taskConfig{
+				Name:                rName + "-query-updated",
+				AccessType:          "Public",
+				Description:         "Query task with updated option task parameter",
+				Type:                "query",
+				LinuxScriptLanguage: ptrString("bash"),
+				LinuxScriptContent: ptrString(`#!/bin/bash
+echo "$TARGET_ENV"`),
+				TaskParameters: []taskParameterConfig{
+					{
+						InputType: "option",
+						Key:       "TARGET_ENV",
+						Label:     "Target Environment",
+						Purpose:   ptrString("Environment selector"),
+						Optional:  &isOptional,
+						Options: []taskParameterOptionConfig{
+							{
+								Key:   "prod",
+								Value: "Production",
+							},
+							{
+								Key:   "dev",
+								Value: "Development",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:         "task_parameters_action_initial",
+			configPrefix: "verification",
+			config: taskConfig{
+				Name:                rName + "-action",
+				AccessType:          "Public",
+				Description:         "Action task with mixed task parameters",
+				Type:                "action",
+				LinuxScriptFileId:   ptrString(sdk.ScriptFileIDs["linux"]),
+				LinuxScriptLanguage: ptrString("bash"),
+				FileIds:             []string{sdk.FileIDs["linux"]},
+				VerificationCondition: &verificationConditionConfig{
+					Operator: "AND",
+					Statements: []verificationStatementConfig{
+						{
+							DataComparator: "Equals",
+							DataType:       "StringType",
+							Key:            "script_output",
+							TaskID:         "placeholder",
+							Value:          "Success",
+						},
+					},
+				},
+				TaskParameters: []taskParameterConfig{
+					{
+						InputType:      "text",
+						Key:            "RETRY_COUNT",
+						Label:          "Retry Count",
+						Purpose:        ptrString("Retries before failure"),
+						Optional:       &isRequired,
+						ValidationType: ptrString("integer"),
+						DefaultValue:   ptrString("03"),
+						FormatHint:     ptrString("Integer value"),
+					},
+					{
+						InputType: "option",
+						Key:       "RESTART_SERVICE",
+						Label:     "Restart Service",
+						Optional:  &isOptional,
+						Options: []taskParameterOptionConfig{
+							{
+								Key:   "yes",
+								Value: "Yes",
+							},
+							{
+								Key:   "no",
+								Value: "No",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:         "task_parameters_action_updated",
+			configPrefix: "verification",
+			config: taskConfig{
+				Name:                rName + "-action-updated",
+				AccessType:          "Shared",
+				Description:         "Action task with updated task parameters",
+				Type:                "action",
+				LinuxScriptFileId:   ptrString(sdk.ScriptFileIDs["linux"]),
+				LinuxScriptLanguage: ptrString("bash"),
+				FileIds:             []string{sdk.FileIDs["linux"]},
+				AssignedUserIds:     sdk.UserIDs,
+				VerificationCondition: &verificationConditionConfig{
+					Operator: "OR",
+					Statements: []verificationStatementConfig{
+						{
+							DataComparator: "Contains",
+							DataType:       "StringType",
+							Key:            "script_output",
+							TaskID:         "placeholder",
+							Value:          "Complete",
+						},
+					},
+				},
+				TaskParameters: []taskParameterConfig{
+					{
+						InputType:      "text",
+						Key:            "RETRY_COUNT",
+						Label:          "Retry Count",
+						Purpose:        ptrString("Retries before failure"),
+						Optional:       &isRequired,
+						ValidationType: ptrString("integer"),
+						DefaultValue:   ptrString("05"),
+						FormatHint:     ptrString("Integer value"),
+					},
+					{
+						InputType: "option",
+						Key:       "RESTART_SERVICE",
+						Label:     "Restart Service",
+						Optional:  &isRequired,
+						Options: []taskParameterOptionConfig{
+							{
+								Key:   "force",
+								Value: "Force Restart",
+							},
+							{
+								Key:   "graceful",
+								Value: "Graceful Restart",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0"))),
+		},
+		Steps: func() []resource.TestStep {
+			var steps []resource.TestStep
+			fixtures := getTestFixtures()
+			for _, tc := range testCases {
+				config := acctest.ProviderConfig + tc.config.String()
+				if tc.configPrefix == "verification" {
+					config = acctest.ProviderConfig + fixtures.VerificationTasksOnly() + tc.config.String()
+				}
+
+				steps = append(steps, resource.TestStep{
+					Config: config,
+					Check:  tc.config.TestChecks(),
+				})
+			}
+			steps = append(steps, resource.TestStep{
+				ResourceName:      taskResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"last_updated",
+				},
+			})
+			return steps
+		}(),
 	})
 }

--- a/internal/it_automation/shared.go
+++ b/internal/it_automation/shared.go
@@ -22,6 +22,8 @@ const (
 	TaskTypeQuery       = "query"
 	TaskTypeAction      = "action"
 	TaskTypeRemediation = "remediation"
+	ParamsTypeOption    = "option"
+	ParamsTypeDropdown  = "dropdown"
 )
 
 // stringSliceToSet converts a Go string slice to a Terraform Framework Set.


### PR DESCRIPTION
Add `task_parameters` to the `crowdstrike_it_automation_task` resource to support setting parameters on queries and actions.