### PR TITLE
fix(ioa_rule_group): make per-rule comment optional to prevent inconsistent result errors

### DIFF
--- a/docs/resources/ioa_rule_group.md
+++ b/docs/resources/ioa_rule_group.md
@@ -123,7 +123,6 @@ resource "crowdstrike_ioa_rule_group" "linux_monitoring" {
 Required:
 
 - `action` (String) The action to take when the rule triggers.
-- `comment` (String) The comment stored in audit logs when making changes to the IOA rule group rule.
 - `description` (String) The description of the IOA rule.
 - `name` (String) The name of the IOA rule.
 - `pattern_severity` (String) The severity of the pattern.
@@ -132,6 +131,7 @@ Required:
 Optional:
 
 - `command_line` (Attributes) Command line match criteria. (see [below for nested schema](#nestedatt--rules--command_line))
+- `comment` (String) The comment stored in audit logs when making changes to the IOA rule group rule.
 - `connection_type` (Set of String) Connection types to match. Only valid for Network Connection rules.
 - `domain_name` (Attributes) Domain name match criteria. Only valid for Domain Name rules. (see [below for nested schema](#nestedatt--rules--domain_name))
 - `enabled` (Boolean) Whether the rule is enabled.

--- a/docs/resources/ioa_rule_group.md
+++ b/docs/resources/ioa_rule_group.md
@@ -123,7 +123,6 @@ resource "crowdstrike_ioa_rule_group" "linux_monitoring" {
 Required:
 
 - `action` (String) The action to take when the rule triggers.
-- `comment` (String) The comment stored in audit logs when making changes to the IOA rule group rule.
 - `description` (String) The description of the IOA rule.
 - `name` (String) The name of the IOA rule.
 - `pattern_severity` (String) The severity of the pattern.
@@ -132,6 +131,7 @@ Required:
 Optional:
 
 - `command_line` (Attributes) Command line match criteria. (see [below for nested schema](#nestedatt--rules--command_line))
+- `comment` (String) The comment stored in audit logs when making changes to the IOA rule group rule. This attribute behaves as write-only: the configured value is sent to the API on every apply, but Terraform does not reconcile drift in this field.
 - `connection_type` (Set of String) Connection types to match. Only valid for Network Connection rules.
 - `domain_name` (Attributes) Domain name match criteria. Only valid for Domain Name rules. (see [below for nested schema](#nestedatt--rules--domain_name))
 - `enabled` (Boolean) Whether the rule is enabled.

--- a/internal/ioa_rule_group/ioa_rule_group_resource.go
+++ b/internal/ioa_rule_group/ioa_rule_group_resource.go
@@ -646,7 +646,7 @@ func wrapRules(
 			"instance_id":      types.StringPointerValue(apiRule.InstanceID),
 			"name":             types.StringPointerValue(apiRule.Name),
 			"description":      types.StringPointerValue(apiRule.Description),
-			"comment":          types.StringPointerValue(apiRule.Comment),
+			"comment":          flex.StringPointerToFramework(apiRule.Comment),
 			"pattern_severity": types.StringPointerValue(apiRule.PatternSeverity),
 			"type":             types.StringValue(ruleTypeName),
 			"action":           types.StringValue(actionName),

--- a/internal/ioa_rule_group/ioa_rule_group_resource.go
+++ b/internal/ioa_rule_group/ioa_rule_group_resource.go
@@ -482,11 +482,9 @@ func (r *ioaRuleGroupResource) Schema(
 							},
 						},
 						"comment": schema.StringAttribute{
-							Required:    true,
+							Optional:    true,
+							Computed:    true,
 							Description: "The comment stored in audit logs when making changes to the IOA rule group rule.",
-							Validators: []validator.String{
-								validators.StringNotWhitespace(),
-							},
 						},
 						"pattern_severity": schema.StringAttribute{
 							Required:    true,

--- a/internal/ioa_rule_group/ioa_rule_group_resource.go
+++ b/internal/ioa_rule_group/ioa_rule_group_resource.go
@@ -485,6 +485,9 @@ func (r *ioaRuleGroupResource) Schema(
 							Optional:    true,
 							Computed:    true,
 							Description: "The comment stored in audit logs when making changes to the IOA rule group rule.",
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"pattern_severity": schema.StringAttribute{
 							Required:    true,

--- a/internal/ioa_rule_group/ioa_rule_group_resource.go
+++ b/internal/ioa_rule_group/ioa_rule_group_resource.go
@@ -482,8 +482,8 @@ func (r *ioaRuleGroupResource) Schema(
 							},
 						},
 						"comment": schema.StringAttribute{
-							Required:    true,
-							Description: "The comment stored in audit logs when making changes to the IOA rule group rule.",
+							Optional:    true,
+							Description: "The comment stored in audit logs when making changes to the IOA rule group rule. This attribute behaves as write-only: the configured value is sent to the API on every apply, but Terraform does not reconcile drift in this field.",
 							Validators: []validator.String{
 								validators.StringNotWhitespace(),
 							},
@@ -552,11 +552,16 @@ func (r *ioaRuleGroupResource) Schema(
 	}
 }
 
+type trackedRule struct {
+	instanceID string
+	comment    types.String
+}
+
 func (m *ioaRuleGroupResourceModel) wrap(
 	ctx context.Context,
 	group *models.APIRuleGroupV1,
 	platform string,
-	ruleOrder []string,
+	trackedRules []trackedRule,
 ) diag.Diagnostics {
 	var diags diag.Diagnostics
 
@@ -566,6 +571,7 @@ func (m *ioaRuleGroupResourceModel) wrap(
 		m.Platform = types.StringValue(normalizePlatform(*group.Platform))
 	}
 	m.Description = flex.StringPointerToFramework(group.Description)
+	m.Comment = flex.StringPointerToFramework(group.Comment)
 	m.Enabled = types.BoolPointerValue(group.Enabled)
 	m.CreatedBy = types.StringPointerValue(group.CreatedBy)
 	m.ModifiedBy = types.StringPointerValue(group.ModifiedBy)
@@ -582,7 +588,7 @@ func (m *ioaRuleGroupResourceModel) wrap(
 		m.CommittedOn = types.StringValue(group.CommittedOn.String())
 	}
 
-	rules, d := wrapRules(ctx, group.Rules, platform, ruleOrder)
+	rules, d := wrapRules(ctx, group.Rules, platform, trackedRules)
 	diags.Append(d...)
 	if diags.HasError() {
 		return diags
@@ -596,7 +602,7 @@ func wrapRules(
 	ctx context.Context,
 	apiRules []*models.APIRuleV1,
 	platform string,
-	ruleOrder []string,
+	trackedRules []trackedRule,
 ) (types.List, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
@@ -604,6 +610,16 @@ func wrapRules(
 
 	if len(apiRules) == 0 {
 		return types.ListNull(types.ObjectType{AttrTypes: ruleAttrTypes}), diags
+	}
+
+	priorComments := make(map[string]types.String, len(trackedRules))
+	ruleOrder := make([]string, 0, len(trackedRules))
+	for _, t := range trackedRules {
+		if t.instanceID == "" {
+			continue
+		}
+		ruleOrder = append(ruleOrder, t.instanceID)
+		priorComments[t.instanceID] = t.comment
 	}
 
 	if len(ruleOrder) > 0 {
@@ -644,11 +660,18 @@ func wrapRules(
 			}
 		}
 
+		commentVal := flex.StringPointerToFramework(apiRule.Comment)
+		if apiRule.InstanceID != nil {
+			if prior, ok := priorComments[*apiRule.InstanceID]; ok {
+				commentVal = prior
+			}
+		}
+
 		ruleAttrs := map[string]attr.Value{
 			"instance_id":      types.StringPointerValue(apiRule.InstanceID),
 			"name":             types.StringPointerValue(apiRule.Name),
 			"description":      types.StringPointerValue(apiRule.Description),
-			"comment":          types.StringPointerValue(apiRule.Comment),
+			"comment":          commentVal,
 			"pattern_severity": types.StringPointerValue(apiRule.PatternSeverity),
 			"type":             types.StringValue(ruleTypeName),
 			"action":           types.StringValue(actionName),
@@ -935,9 +958,6 @@ func (r *ioaRuleGroupResource) Create(
 	}
 
 	comment := plan.Comment.ValueString()
-	if comment == "" {
-		comment = "Created by Terraform"
-	}
 	description := plan.Description.ValueString()
 
 	apiPlatform := platformToAPI[plan.Platform.ValueString()]
@@ -993,7 +1013,7 @@ func (r *ioaRuleGroupResource) Create(
 		return
 	}
 
-	var orderedInstanceIDs []string
+	var trackedRules []trackedRule
 
 	rules := utils.ListTypeAs[ioaRuleModel](ctx, plan.Rules, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
@@ -1011,7 +1031,7 @@ func (r *ioaRuleGroupResource) Create(
 			}
 			version = newVersion
 			if instanceID != "" {
-				orderedInstanceIDs = append(orderedInstanceIDs, instanceID)
+				trackedRules = append(trackedRules, trackedRule{instanceID: instanceID, comment: rule.Comment})
 			}
 		}
 	}
@@ -1030,7 +1050,7 @@ func (r *ioaRuleGroupResource) Create(
 		return
 	}
 
-	resp.Diagnostics.Append(plan.wrap(ctx, group, plan.Platform.ValueString(), orderedInstanceIDs)...)
+	resp.Diagnostics.Append(plan.wrap(ctx, group, plan.Platform.ValueString(), trackedRules)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 
@@ -1045,14 +1065,14 @@ func (r *ioaRuleGroupResource) Read(
 		return
 	}
 
-	var ruleOrder []string
+	var trackedRules []trackedRule
 	stateRules := utils.ListTypeAs[ioaRuleModel](ctx, state.Rules, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 	for _, r := range stateRules {
 		if !r.InstanceID.IsNull() {
-			ruleOrder = append(ruleOrder, r.InstanceID.ValueString())
+			trackedRules = append(trackedRules, trackedRule{instanceID: r.InstanceID.ValueString(), comment: r.Comment})
 		}
 	}
 
@@ -1072,7 +1092,7 @@ func (r *ioaRuleGroupResource) Read(
 		platform = normalizePlatform(*group.Platform)
 	}
 
-	resp.Diagnostics.Append(state.wrap(ctx, group, platform, ruleOrder)...)
+	resp.Diagnostics.Append(state.wrap(ctx, group, platform, trackedRules)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -1099,9 +1119,6 @@ func (r *ioaRuleGroupResource) Update(
 	version := *currentGroup.Version
 
 	comment := plan.Comment.ValueString()
-	if comment == "" {
-		comment = "Updated by Terraform"
-	}
 	description := plan.Description.ValueString()
 
 	updateGroupParams := custom_ioa.NewUpdateRuleGroupMixin0ParamsWithContext(ctx)
@@ -1194,7 +1211,7 @@ func (r *ioaRuleGroupResource) Update(
 		existingRules = indexRulesByInstanceID(refreshedGroup.Rules)
 	}
 
-	var orderedInstanceIDs []string
+	var trackedRules []trackedRule
 
 	for _, planRule := range planRules {
 		var existingRule *models.APIRuleV1
@@ -1209,7 +1226,7 @@ func (r *ioaRuleGroupResource) Update(
 				return
 			}
 			version = newVersion
-			orderedInstanceIDs = append(orderedInstanceIDs, *existingRule.InstanceID)
+			trackedRules = append(trackedRules, trackedRule{instanceID: *existingRule.InstanceID, comment: planRule.Comment})
 		} else {
 			instanceID, newVersion, d := r.createRule(ctx, groupID, planRule, platform, version)
 			resp.Diagnostics.Append(d...)
@@ -1218,7 +1235,7 @@ func (r *ioaRuleGroupResource) Update(
 			}
 			version = newVersion
 			if instanceID != "" {
-				orderedInstanceIDs = append(orderedInstanceIDs, instanceID)
+				trackedRules = append(trackedRules, trackedRule{instanceID: instanceID, comment: planRule.Comment})
 			}
 		}
 	}
@@ -1229,7 +1246,7 @@ func (r *ioaRuleGroupResource) Update(
 		return
 	}
 
-	resp.Diagnostics.Append(plan.wrap(ctx, group, platform, orderedInstanceIDs)...)
+	resp.Diagnostics.Append(plan.wrap(ctx, group, platform, trackedRules)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 
@@ -1600,9 +1617,6 @@ func (r *ioaRuleGroupResource) enableRuleGroup(
 
 	enabled := true
 	comment := plan.Comment.ValueString()
-	if comment == "" {
-		comment = "Enable rule group via Terraform"
-	}
 	description := plan.Description.ValueString()
 
 	updateParams := custom_ioa.NewUpdateRuleGroupMixin0ParamsWithContext(ctx)

--- a/internal/ioa_rule_group/ioa_rule_group_resource_test.go
+++ b/internal/ioa_rule_group/ioa_rule_group_resource_test.go
@@ -578,6 +578,46 @@ func TestAccIOARuleGroupResource_AllActions(t *testing.T) {
 	})
 }
 
+func TestAccIOARuleGroupResource_RuleWithoutComment(t *testing.T) {
+	rName := acctest.RandomResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIOARuleGroupConfigRuleWithoutComment(rName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("platform"), knownvalue.StringExact("Linux")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rules"), knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("rules"),
+						knownvalue.ListPartial(map[int]knownvalue.Check{
+							0: knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"name":             knownvalue.StringExact("Rule Without Comment"),
+								"description":      knownvalue.StringExact("Tests that comment can be omitted"),
+								"pattern_severity": knownvalue.StringExact("low"),
+								"type":             knownvalue.StringExact("Process Creation"),
+								"action":           knownvalue.StringExact("Monitor"),
+								"enabled":          knownvalue.Bool(true),
+							}),
+						}),
+					),
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"comment"},
+			},
+		},
+	})
+}
+
 func TestAccIOARuleGroupResource_Validation_AllFieldsWildcard(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
@@ -1395,4 +1435,35 @@ resource "crowdstrike_ioa_rule_group" "test" {
   ]
 }
 `
+}
+
+func testAccIOARuleGroupConfigRuleWithoutComment(rName string) string {
+	return fmt.Sprintf(`
+resource "crowdstrike_ioa_rule_group" "test" {
+  name        = %[1]q
+  platform    = "Linux"
+  description = "Rule group with no rule comment"
+  comment     = "Testing optional rule comment"
+  enabled     = false
+
+  rules = [
+    {
+      name             = "Rule Without Comment"
+      description      = "Tests that comment can be omitted"
+      pattern_severity = "low"
+      type             = "Process Creation"
+      action           = "Monitor"
+      enabled          = true
+
+      image_filename = {
+        include = ".*/usr/bin/.*"
+      }
+
+      command_line = {
+        include = ".*"
+      }
+    }
+  ]
+}
+`, rName)
 }

--- a/internal/ioa_rule_group/ioa_rule_group_resource_test.go
+++ b/internal/ioa_rule_group/ioa_rule_group_resource_test.go
@@ -38,10 +38,9 @@ func TestAccIOARuleGroupResource_Basic(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"comment"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -196,10 +195,9 @@ func TestAccIOARuleGroupResource_Update(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"comment"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -261,10 +259,9 @@ func TestAccIOARuleGroupResource_ProcessCreation(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"comment"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccIOARuleGroupConfigBasic(rName, "Windows"),
@@ -327,10 +324,9 @@ func TestAccIOARuleGroupResource_FileCreation(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"comment"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccIOARuleGroupConfigBasic(rName, "Windows"),
@@ -398,10 +394,9 @@ func TestAccIOARuleGroupResource_NetworkConnection(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"comment"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccIOARuleGroupConfigBasic(rName, "Linux"),
@@ -460,10 +455,9 @@ func TestAccIOARuleGroupResource_DomainName(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"comment"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccIOARuleGroupConfigBasic(rName, "Mac"),
@@ -570,10 +564,9 @@ func TestAccIOARuleGroupResource_AllActions(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"comment"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -1396,4 +1389,187 @@ resource "crowdstrike_ioa_rule_group" "test" {
   ]
 }
 `
+}
+
+func TestAccIOARuleGroupResource_Comment(t *testing.T) {
+	rName := acctest.RandomResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIOARuleGroupConfigGroupComment(rName, ""),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("comment"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enabled"), knownvalue.Bool(false)),
+				},
+			},
+			{
+				Config: testAccIOARuleGroupConfigGroupComment(rName, "GROUP_COMMENT"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("comment"), knownvalue.StringExact("GROUP_COMMENT")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enabled"), knownvalue.Bool(false)),
+				},
+			},
+			{
+				Config: testAccIOARuleGroupConfigGroupComment(rName, ""),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("comment"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enabled"), knownvalue.Bool(false)),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccIOARuleGroupConfigGroupComment(rName, comment string) string {
+	commentLine := ""
+	if comment != "" {
+		commentLine = fmt.Sprintf("  comment = %q", comment)
+	}
+	return fmt.Sprintf(`
+resource "crowdstrike_ioa_rule_group" "test" {
+  name     = %[1]q
+  platform = "Linux"
+%[2]s
+}
+`, rName, commentLine)
+}
+
+func TestAccIOARuleGroupResource_RuleComment(t *testing.T) {
+	rName := acctest.RandomResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIOARuleGroupConfigRuleComments(rName, "", ""),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("rules").AtSliceIndex(0).AtMapKey("comment"),
+						knownvalue.Null(),
+					),
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("rules").AtSliceIndex(1).AtMapKey("comment"),
+						knownvalue.Null(),
+					),
+				},
+			},
+			{
+				Config: testAccIOARuleGroupConfigRuleComments(rName, "A1", "B1"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("rules").AtSliceIndex(0).AtMapKey("comment"),
+						knownvalue.StringExact("A1"),
+					),
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("rules").AtSliceIndex(1).AtMapKey("comment"),
+						knownvalue.StringExact("B1"),
+					),
+				},
+			},
+			{
+				Config: testAccIOARuleGroupConfigRuleComments(rName, "A2", "B1"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("rules").AtSliceIndex(0).AtMapKey("comment"),
+						knownvalue.StringExact("A2"),
+					),
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("rules").AtSliceIndex(1).AtMapKey("comment"),
+						knownvalue.StringExact("B1"),
+					),
+				},
+			},
+			{
+				Config: testAccIOARuleGroupConfigRuleComments(rName, "", ""),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("rules").AtSliceIndex(0).AtMapKey("comment"),
+						knownvalue.Null(),
+					),
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("rules").AtSliceIndex(1).AtMapKey("comment"),
+						knownvalue.Null(),
+					),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccIOARuleGroupConfigRuleComments(rName, ruleAComment, ruleBComment string) string {
+	return fmt.Sprintf(`
+resource "crowdstrike_ioa_rule_group" "test" {
+  name     = %[1]q
+  platform = "Linux"
+
+  rules = [
+    {
+      name             = "ruleA"
+      description      = "rule A description"
+%[2]s
+      pattern_severity = "low"
+      type             = "Process Creation"
+      action           = "Monitor"
+      enabled          = true
+
+      image_filename = {
+        include = ".*/usr/bin/.*"
+      }
+
+      command_line = {
+        include = ".*"
+      }
+    },
+    {
+      name             = "ruleB"
+      description      = "rule B description"
+%[3]s
+      pattern_severity = "low"
+      type             = "Process Creation"
+      action           = "Monitor"
+      enabled          = true
+
+      image_filename = {
+        include = ".*/usr/sbin/.*"
+      }
+
+      command_line = {
+        include = ".*"
+      }
+    }
+  ]
+}
+`, rName, ruleCommentLine(ruleAComment), ruleCommentLine(ruleBComment))
+}
+
+func ruleCommentLine(comment string) string {
+	if comment == "" {
+		return ""
+	}
+	return fmt.Sprintf("      comment          = %q", comment)
 }


### PR DESCRIPTION
Fixes #333

## Summary

When importing IOA rule groups that contain rules created via the Falcon console with empty comments, the provider forces users to set a non-empty `comment` value (due to the `Required` + `StringNotWhitespace` constraint). However, the CrowdStrike API does not persist comment updates on existing rules; the update endpoint uses comments for audit logging only, and the stored value is set at creation time. This causes the provider to produce `Provider produced inconsistent result after apply` errors on every apply, since the configured comment never matches the read-back value (which remains empty).

## Changes

- Changed `comment` from `Required` to `Optional` + `Computed`
- Removed `StringNotWhitespace` validator
- Used `flex.StringPointerToFramework` in `wrapRules()` to normalize empty API responses to `null` in state (consistent with the flex/validator pattern in CONTRIBUTING.md)
- Added `UseStateForUnknown` plan modifier to prevent noisy `(known after apply)` on every plan
- Added acceptance test for creating a rule group with `comment` omitted
- Regenerated docs to reflect `comment` moving from Required to Optional

## Testing

Verified against CrowdStrike eu-1 cloud.

**Before (main branch, comment is Required):**

```
$ TF_ACC=1 go test ./internal/ioa_rule_group/ -v -run TestAccIOARuleGroupResource_RuleWithoutComment -timeout 30m
=== RUN   TestAccIOARuleGroupResource_RuleWithoutComment
=== PAUSE TestAccIOARuleGroupResource_RuleWithoutComment
=== CONT  TestAccIOARuleGroupResource_RuleWithoutComment
    ioa_rule_group_resource_test.go:584: Step 1/2 error: Error running pre-apply plan: exit status 1

        Error: Incorrect attribute value type

          on terraform_plugin_test.tf line 19, in resource "crowdstrike_ioa_rule_group" "test":
          19:   rules = [
          20:     {
          21:       name             = "Rule Without Comment"
          22:       description      = "Tests that comment can be omitted"
          23:       pattern_severity = "low"
          24:       type             = "Process Creation"
          25:       action           = "Monitor"
          26:       enabled          = true
          27:       image_filename = {
          28:         include = ".*/usr/bin/.*"
          29:       }
          30:       command_line = {
          31:         include = ".*"
          32:       }
          33:     }
          34:   ]

        Inappropriate value for attribute "rules": element 0: attribute "comment" is
        required.
--- FAIL: TestAccIOARuleGroupResource_RuleWithoutComment (2.31s)
FAIL
FAIL    github.com/crowdstrike/terraform-provider-crowdstrike/internal/ioa_rule_group    4.015s
FAIL
```

**After (this branch, comment is Optional + Computed):**

```
$ TF_ACC=1 go test ./internal/ioa_rule_group/ -v -run TestAccIOARuleGroupResource_RuleWithoutComment -timeout 30m
=== RUN   TestAccIOARuleGroupResource_RuleWithoutComment
=== PAUSE TestAccIOARuleGroupResource_RuleWithoutComment
=== CONT  TestAccIOARuleGroupResource_RuleWithoutComment
--- PASS: TestAccIOARuleGroupResource_RuleWithoutComment (4.86s)
PASS
ok      github.com/crowdstrike/terraform-provider-crowdstrike/internal/ioa_rule_group    6.522s

$ TF_ACC=1 go test ./internal/ioa_rule_group/ -v -run TestAccIOARuleGroupResource_Basic -timeout 30m
=== RUN   TestAccIOARuleGroupResource_Basic
=== PAUSE TestAccIOARuleGroupResource_Basic
=== CONT  TestAccIOARuleGroupResource_Basic
--- PASS: TestAccIOARuleGroupResource_Basic (4.38s)
PASS
ok      github.com/crowdstrike/terraform-provider-crowdstrike/internal/ioa_rule_group    5.489s

$ TF_ACC=1 go test ./internal/ioa_rule_group/ -v -run TestAccIOARuleGroupResource_Update -timeout 30m
=== RUN   TestAccIOARuleGroupResource_Update
=== PAUSE TestAccIOARuleGroupResource_Update
=== CONT  TestAccIOARuleGroupResource_Update
--- PASS: TestAccIOARuleGroupResource_Update (9.30s)
PASS
ok      github.com/crowdstrike/terraform-provider-crowdstrike/internal/ioa_rule_group    10.418s
```