### PR TITLE
fix: pin pre-commit hooks to commit SHA

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.64.4
+    rev: 04aec4f787c25a737641f3d434059880d2af0f53  # v1.64.4
     hooks:
       - id: golangci-lint
 
@@ -21,7 +21,7 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.100.0
+    rev: 9a790d2bbf52124eecb5a71a4bab4884804ffa2a  # v1.100.0
     hooks:
       - id: terraform_fmt
         args:
@@ -33,7 +33,7 @@ repos:
         exclude: ^examples/provider/
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b  # v5.0.0
     hooks:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]


### PR DESCRIPTION
## Description

Pin pre-commit hook revisions to full commit SHAs instead of mutable version tags to mitigate supply chain attacks via tag tampering.

Git tags are mutable. An attacker who compromises a hook repository or its maintainer's account could force-push a malicious commit to an existing tag. Pinning to the immutable commit SHA prevents this attack vector.

### Changes

| Hook | Version | SHA |
|------|---------|-----|
| `golangci/golangci-lint` | v1.64.4 | `04aec4f787c25a737641f3d434059880d2af0f53` |
| `antonbabenko/pre-commit-terraform` | v1.100.0 | `9a790d2bbf52124eecb5a71a4bab4884804ffa2a` |
| `pre-commit/pre-commit-hooks` | v5.0.0 | `cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b` |

### Verification

SHAs were resolved via `git ls-remote`:

```bash
git ls-remote https://github.com/golangci/golangci-lint refs/tags/v1.64.4
git ls-remote https://github.com/antonbabenko/pre-commit-terraform refs/tags/v1.100.0
git ls-remote https://github.com/pre-commit/pre-commit-hooks refs/tags/v5.0.0
```

Version tags are preserved as inline comments for readability.

Signed-off-by: James Barrios