### PR TITLE
feat(sensor_update_policy): accept full version strings in build field

### DIFF
--- a/docs/resources/default_sensor_update_policy.md
+++ b/docs/resources/default_sensor_update_policy.md
@@ -65,13 +65,13 @@ output "sensor_policy" {
 
 ### Required
 
-- `build` (String) Sensor build to use for the default sensor update policy. Use an empty string to turn off sensor version updates.
+- `build` (String) Sensor build to use for the default sensor update policy. Accepts a build number (e.g. "17407") or a full version string (e.g. "7.22.17407"); the version prefix is stripped automatically. Use an empty string to turn off sensor version updates.
 - `platform_name` (String) Chooses which default sensor update policy to manage. (Windows, Mac, Linux). Changing this value will require replacing the resource.
 - `schedule` (Attributes) Prohibit sensor updates during a set of time blocks. (see [below for nested schema](#nestedatt--schedule))
 
 ### Optional
 
-- `build_arm64` (String) Sensor arm64 build to use for the default sensor update policy (Linux only). Required if platform_name is Linux. Use an empty string to turn off sensor version updates.
+- `build_arm64` (String) Sensor arm64 build to use for the default sensor update policy (Linux only). Required if platform_name is Linux. Accepts a build number (e.g. "17407") or a full version string (e.g. "7.22.17407"); the version prefix is stripped automatically. Use an empty string to turn off sensor version updates.
 - `bulk_maintenance_mode` (Boolean) Enable bulk maintenance mode. When enabled, uninstall_protection must be set to true and build must be set to an empty string ("") to turn off sensor version updates.
 - `uninstall_protection` (Boolean) Enable uninstall protection.
 

--- a/docs/resources/sensor_update_policy.md
+++ b/docs/resources/sensor_update_policy.md
@@ -68,14 +68,14 @@ output "sensor_policy" {
 
 ### Required
 
-- `build` (String) Sensor build to use for the sensor update policy. Use an empty string to turn off sensor version updates.
+- `build` (String) Sensor build to use for the sensor update policy. Accepts a build number (e.g. "17407") or a full version string (e.g. "7.22.17407"); the version prefix is stripped automatically. Use an empty string to turn off sensor version updates.
 - `name` (String) Name of the sensor update policy.
 - `platform_name` (String) Platform for the sensor update policy to manage. (Windows, Mac, Linux). Changing this value will require replacing the resource.
 - `schedule` (Attributes) Prohibit sensor updates during a set of time blocks. (see [below for nested schema](#nestedatt--schedule))
 
 ### Optional
 
-- `build_arm64` (String) Sensor arm64 build to use for the sensor update policy (Linux only). Required if platform_name is Linux. Use an empty string to turn off sensor version updates.
+- `build_arm64` (String) Sensor arm64 build to use for the sensor update policy (Linux only). Required if platform_name is Linux. Accepts a build number (e.g. "17407") or a full version string (e.g. "7.22.17407"); the version prefix is stripped automatically. Use an empty string to turn off sensor version updates.
 - `bulk_maintenance_mode` (Boolean) Enable bulk maintenance mode. When enabled, uninstall_protection must be set to true and build must be set to an empty string ("") to turn off sensor version updates.
 - `description` (String) Description of the sensor update policy.
 - `enabled` (Boolean) Enable the sensor update policy.

--- a/internal/sensor_update_policy/default_sensor_update_policy_resource.go
+++ b/internal/sensor_update_policy/default_sensor_update_policy_resource.go
@@ -83,7 +83,7 @@ func (d *defaultSensorUpdatePolicyResourceModel) wrap(
 	var diags diag.Diagnostics
 
 	d.ID = types.StringValue(*policy.ID)
-	if validateBuilds && d.Build.ValueString() != *policy.Settings.Build {
+	if validateBuilds && stripBuildPrefix(d.Build.ValueString()) != *policy.Settings.Build {
 		diags.AddError(
 			"Inconsistent build returned",
 			fmt.Sprintf(
@@ -119,7 +119,7 @@ func (d *defaultSensorUpdatePolicyResourceModel) wrap(
 			}
 
 			if strings.EqualFold(*vCopy.Platform, linuxArm64Varient) {
-				if validateBuilds && d.BuildArm64.ValueString() != *vCopy.Build {
+				if validateBuilds && stripBuildPrefix(d.BuildArm64.ValueString()) != *vCopy.Build {
 					diags.AddError(
 						"Inconsistent build_arm64 returned",
 						fmt.Sprintf(
@@ -268,11 +268,11 @@ func (r *defaultSensorUpdatePolicyResource) Schema(
 			},
 			"build": schema.StringAttribute{
 				Required:    true,
-				Description: "Sensor build to use for the default sensor update policy. Use an empty string to turn off sensor version updates.",
+				Description: "Sensor build to use for the default sensor update policy. Accepts a build number (e.g. \"17407\") or a full version string (e.g. \"7.22.17407\"); the version prefix is stripped automatically. Use an empty string to turn off sensor version updates.",
 			},
 			"build_arm64": schema.StringAttribute{
 				Optional:    true,
-				Description: "Sensor arm64 build to use for the default sensor update policy (Linux only). Required if platform_name is Linux. Use an empty string to turn off sensor version updates.",
+				Description: "Sensor arm64 build to use for the default sensor update policy (Linux only). Required if platform_name is Linux. Accepts a build number (e.g. \"17407\") or a full version string (e.g. \"7.22.17407\"); the version prefix is stripped automatically. Use an empty string to turn off sensor version updates.",
 			},
 			"platform_name": schema.StringAttribute{
 				Required:    true,
@@ -622,7 +622,7 @@ func (r *defaultSensorUpdatePolicyResource) updateDefaultPolicy(
 				{
 					ID: config.ID.ValueStringPointer(),
 					Settings: &models.SensorUpdateSettingsReqV2{
-						Build: config.Build.ValueString(),
+						Build: stripBuildPrefix(config.Build.ValueString()),
 					},
 				},
 			},
@@ -630,9 +630,10 @@ func (r *defaultSensorUpdatePolicyResource) updateDefaultPolicy(
 	}
 
 	if strings.ToLower(config.PlatformName.ValueString()) == "linux" {
+		arm64Build := stripBuildPrefix(config.BuildArm64.ValueString())
 		variants := []*models.SensorUpdateBuildReqV1{
 			{
-				Build:    config.BuildArm64.ValueStringPointer(),
+				Build:    &arm64Build,
 				Platform: &linuxArm64Varient,
 			},
 		}

--- a/internal/sensor_update_policy/sensor_update_policy_resource.go
+++ b/internal/sensor_update_policy/sensor_update_policy_resource.go
@@ -140,7 +140,7 @@ func (d *sensorUpdatePolicyResourceModel) wrap(
 		d.HostGroups = hostGroupSet
 	}
 
-	if validateBuilds && d.Build.ValueString() != *policy.Settings.Build {
+	if validateBuilds && stripBuildPrefix(d.Build.ValueString()) != *policy.Settings.Build {
 		diags.AddError(
 			"Inconsistent build returned",
 			fmt.Sprintf(
@@ -165,7 +165,7 @@ func (d *sensorUpdatePolicyResourceModel) wrap(
 			}
 
 			if strings.EqualFold(*vCopy.Platform, linuxArm64Varient) {
-				if validateBuilds && d.BuildArm64.ValueString() != *vCopy.Build {
+				if validateBuilds && stripBuildPrefix(d.BuildArm64.ValueString()) != *vCopy.Build {
 					diags.AddError(
 						"Inconsistent build_arm64 returned",
 						fmt.Sprintf(
@@ -318,11 +318,11 @@ func (r *sensorUpdatePolicyResource) Schema(
 			},
 			"build": schema.StringAttribute{
 				Required:    true,
-				Description: "Sensor build to use for the sensor update policy. Use an empty string to turn off sensor version updates.",
+				Description: "Sensor build to use for the sensor update policy. Accepts a build number (e.g. \"17407\") or a full version string (e.g. \"7.22.17407\"); the version prefix is stripped automatically. Use an empty string to turn off sensor version updates.",
 			},
 			"build_arm64": schema.StringAttribute{
 				Optional:    true,
-				Description: "Sensor arm64 build to use for the sensor update policy (Linux only). Required if platform_name is Linux. Use an empty string to turn off sensor version updates.",
+				Description: "Sensor arm64 build to use for the sensor update policy (Linux only). Required if platform_name is Linux. Accepts a build number (e.g. \"17407\") or a full version string (e.g. \"7.22.17407\"); the version prefix is stripped automatically. Use an empty string to turn off sensor version updates.",
 			},
 			// todo: make this case insensitive
 			"platform_name": schema.StringAttribute{
@@ -433,7 +433,7 @@ func (r *sensorUpdatePolicyResource) Create(
 					PlatformName: plan.PlatformName.ValueStringPointer(),
 					Description:  plan.Description.ValueString(),
 					Settings: &models.SensorUpdateSettingsReqV2{
-						Build: plan.Build.ValueString(),
+						Build: stripBuildPrefix(plan.Build.ValueString()),
 					},
 				},
 			},
@@ -442,9 +442,10 @@ func (r *sensorUpdatePolicyResource) Create(
 
 	if strings.ToLower(plan.PlatformName.ValueString()) == "linux" &&
 		plan.BuildArm64.ValueString() != "" {
+		arm64Build := stripBuildPrefix(plan.BuildArm64.ValueString())
 		variants := []*models.SensorUpdateBuildReqV1{
 			{
-				Build:    plan.BuildArm64.ValueStringPointer(),
+				Build:    &arm64Build,
 				Platform: &linuxArm64Varient,
 			},
 		}
@@ -681,7 +682,7 @@ func (r *sensorUpdatePolicyResource) Update(
 					ID:          plan.ID.ValueStringPointer(),
 					Description: plan.Description.ValueString(),
 					Settings: &models.SensorUpdateSettingsReqV2{
-						Build: plan.Build.ValueString(),
+						Build: stripBuildPrefix(plan.Build.ValueString()),
 					},
 				},
 			},
@@ -689,9 +690,10 @@ func (r *sensorUpdatePolicyResource) Update(
 	}
 
 	if strings.ToLower(plan.PlatformName.ValueString()) == "linux" {
+		arm64Build := stripBuildPrefix(plan.BuildArm64.ValueString())
 		variants := []*models.SensorUpdateBuildReqV1{
 			{
-				Build:    plan.BuildArm64.ValueStringPointer(),
+				Build:    &arm64Build,
 				Platform: &linuxArm64Varient,
 			},
 		}

--- a/internal/sensor_update_policy/shared.go
+++ b/internal/sensor_update_policy/shared.go
@@ -402,3 +402,16 @@ func syncHostGroups(
 
 	return diags
 }
+
+// stripBuildPrefix strips a version prefix from a build string so users can
+// pass either the full version string (e.g. "7.22.17407") or just the build
+// number ("17407"). The API only accepts the build number portion.
+func stripBuildPrefix(build string) string {
+	if build == "" {
+		return build
+	}
+	if i := strings.LastIndex(build, "."); i != -1 {
+		return build[i+1:]
+	}
+	return build
+}

--- a/internal/sensor_update_policy/shared_test.go
+++ b/internal/sensor_update_policy/shared_test.go
@@ -1,0 +1,52 @@
+package sensorupdatepolicy
+
+import "testing"
+
+func TestStripBuildPrefix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "build number only",
+			input: "17407",
+			want:  "17407",
+		},
+		{
+			name:  "full version string",
+			input: "7.22.17407",
+			want:  "17407",
+		},
+		{
+			name:  "two part version",
+			input: "22.17407",
+			want:  "17407",
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "pipe-delimited build tag",
+			input: "20709|n|tagged|17",
+			want:  "20709|n|tagged|17",
+		},
+		{
+			name:  "pipe-delimited n-1 build tag",
+			input: "20610|n-1|tagged|1",
+			want:  "20610|n-1|tagged|1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := stripBuildPrefix(tt.input); got != tt.want {
+				t.Errorf("stripBuildPrefix(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `stripBuildPrefix` helper that extracts the build number from a full version string (e.g. `7.22.17407` → `17407`) so users can pass either format
- Apply stripping in Create, Update, and build validation for both `sensor_update_policy` and `default_sensor_update_policy` resources
- Update schema descriptions for `build` and `build_arm64` to document accepted formats
- Regenerate docs via `make gen`

Ref #338

## Test plan
- [x] Unit tests for `stripBuildPrefix` covering: plain build number, full version string, two-part version, empty string, pipe-delimited build tags
- [x] All acceptance tests in `internal/sensor_update_policy/` pass
- [x] `make fmt` — 0 issues
- [x] `make gen` — docs regenerated