### PR TITLE
feat(sensor_update_policy): improve error message for invalid build errors

### DIFF
--- a/internal/sensor_update_policy/default_sensor_update_policy_resource.go
+++ b/internal/sensor_update_policy/default_sensor_update_policy_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/crowdstrike/gofalcon/falcon/models"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/config"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/scopes"
+	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/tferrors"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -679,10 +680,7 @@ func (r *defaultSensorUpdatePolicyResource) updateDefaultPolicy(
 
 	res, err := r.client.SensorUpdatePolicies.UpdateSensorUpdatePoliciesV2(&policyParams)
 	if err != nil {
-		diags.AddError(
-			"Error updating CrowdStrike sensor update policy",
-			"Could not update sensor update policy with ID: "+config.ID.ValueString()+": "+err.Error(),
-		)
+		diags.Append(newAPIError(tferrors.Update, err, apiScopesReadWrite))
 		return nil, diags
 	}
 

--- a/internal/sensor_update_policy/errors.go
+++ b/internal/sensor_update_policy/errors.go
@@ -1,9 +1,29 @@
 package sensorupdatepolicy
 
-import "github.com/hashicorp/terraform-plugin-framework/diag"
+import (
+	"strings"
+
+	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/scopes"
+	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/tferrors"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
 
 const notFoundErrorSummary = "Sensor Update Policy not found"
 
 func newNotFoundError(detail string) diag.ErrorDiagnostic {
 	return diag.NewErrorDiagnostic(notFoundErrorSummary, detail)
+}
+
+const invalidBuildPrefix = "invalid build"
+
+func newAPIError(
+	operation tferrors.Operation,
+	err error,
+	apiScopes []scopes.Scope,
+) diag.Diagnostic {
+	var opts []tferrors.ErrorOption
+	if err != nil && strings.Contains(strings.ToLower(err.Error()), invalidBuildPrefix) {
+		opts = append(opts, tferrors.WithBadRequestDetail("The build value may be incorrect or no longer supported by the CrowdStrike API. Use the crowdstrike_sensor_update_policy_builds data source to find valid build values for your platform."))
+	}
+	return tferrors.NewDiagnosticFromAPIError(operation, err, apiScopes, opts...)
 }

--- a/internal/sensor_update_policy/errors_test.go
+++ b/internal/sensor_update_policy/errors_test.go
@@ -1,0 +1,76 @@
+package sensorupdatepolicy
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/crowdstrike/gofalcon/falcon/client/sensor_update_policies"
+	"github.com/crowdstrike/gofalcon/falcon/models"
+	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/tferrors"
+	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewAPIError(t *testing.T) {
+	t.Parallel()
+
+	var code int32 = 400
+	const guidanceMsg = "build value may be incorrect or no longer supported"
+
+	tests := []struct {
+		name         string
+		err          error
+		wantGuidance bool
+	}{
+		{
+			name: "invalid build on create",
+			err: &sensor_update_policies.CreateSensorUpdatePoliciesV2BadRequest{
+				Payload: &models.SensorUpdateRespV2{
+					Errors: []*models.MsaAPIError{
+						{Code: &code, Message: utils.Addr("invalid build 99999")},
+					},
+				},
+			},
+			wantGuidance: true,
+		},
+		{
+			name: "invalid build on update",
+			err: &sensor_update_policies.UpdateSensorUpdatePoliciesV2BadRequest{
+				Payload: &models.SensorUpdateRespV2{
+					Errors: []*models.MsaAPIError{
+						{Code: &code, Message: utils.Addr("invalid build 99999")},
+					},
+				},
+			},
+			wantGuidance: true,
+		},
+		{
+			name: "non-build bad request",
+			err: &sensor_update_policies.CreateSensorUpdatePoliciesV2BadRequest{
+				Payload: &models.SensorUpdateRespV2{
+					Errors: []*models.MsaAPIError{
+						{Code: &code, Message: utils.Addr("some other error")},
+					},
+				},
+			},
+			wantGuidance: false,
+		},
+		{
+			name:         "generic error",
+			err:          errors.New("connection refused"),
+			wantGuidance: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			d := newAPIError(tferrors.Create, tt.err, apiScopesReadWrite)
+			if tt.wantGuidance {
+				assert.Contains(t, d.Detail(), guidanceMsg)
+			} else {
+				assert.NotContains(t, d.Detail(), guidanceMsg)
+			}
+		})
+	}
+}

--- a/internal/sensor_update_policy/sensor_update_policy_resource.go
+++ b/internal/sensor_update_policy/sensor_update_policy_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/config"
 	hostgroups "github.com/crowdstrike/terraform-provider-crowdstrike/internal/host_groups"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/scopes"
+	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/tferrors"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/utils"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -481,10 +482,7 @@ func (r *sensorUpdatePolicyResource) Create(
 
 	res, err := r.client.SensorUpdatePolicies.CreateSensorUpdatePoliciesV2(&policyParams)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error creating sensor update policy",
-			"Could not create sensor update policy, unexpected error: "+err.Error(),
-		)
+		resp.Diagnostics.Append(newAPIError(tferrors.Create, err, apiScopesReadWrite))
 		return
 	}
 
@@ -736,10 +734,7 @@ func (r *sensorUpdatePolicyResource) Update(
 
 	res, err := r.client.SensorUpdatePolicies.UpdateSensorUpdatePoliciesV2(&policyParams)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error updating CrowdStrike sensor update policy",
-			"Could not update sensor update policy with ID: "+plan.ID.ValueString()+": "+err.Error(),
-		)
+		resp.Diagnostics.Append(newAPIError(tferrors.Update, err, apiScopesReadWrite))
 		return
 	}
 

--- a/internal/sensor_update_policy/sensor_update_policy_resource_test.go
+++ b/internal/sensor_update_policy/sensor_update_policy_resource_test.go
@@ -335,6 +335,35 @@ func (config sensorUpdatePolicyConfig) TestChecks() resource.TestCheckFunc {
 	return resource.ComposeAggregateTestCheckFunc(checks...)
 }
 
+func TestAccSensorUpdatePolicyResourceBadBuildCreate(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderConfig + fmt.Sprintf(`
+resource "crowdstrike_sensor_update_policy" "test" {
+  name                 = "%s"
+  enabled              = true
+  description          = "made with terraform"
+  host_groups          = []
+  platform_name        = "Windows"
+  build                = "99999"
+  uninstall_protection = false
+  schedule = {
+    enabled = false
+  }
+}
+`, rName),
+				ExpectError: regexp.MustCompile(
+					"build value may be incorrect or no longer supported",
+				),
+			},
+		},
+	})
+}
+
 func TestAccSensorUpdatePolicyResourceBadBuildUpdate(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resource.ParallelTest(t, resource.TestCase{
@@ -366,7 +395,7 @@ resource "crowdstrike_sensor_update_policy" "test" {
   description          = "made with terraform"
   host_groups          = []
   platform_name        = "Windows"
-  build                = "invalid"
+  build                = "99999"
   uninstall_protection = false
   schedule = {
     enabled = false
@@ -374,7 +403,7 @@ resource "crowdstrike_sensor_update_policy" "test" {
 }
 `, rName),
 				ExpectError: regexp.MustCompile(
-					"(?i)(?s).*invalid(?s).*build invalid.*",
+					"build value may be incorrect or no longer supported",
 				),
 			},
 		},


### PR DESCRIPTION
## Summary
- Detect 400 "invalid build" errors from the CrowdStrike API and return a helpful error message explaining the build value may be incorrect or no longer supported, directing users to the `crowdstrike_sensor_update_policy_builds` data source.
- Migrate Create/Update error handling in `sensor_update_policy` and `default_sensor_update_policy` resources to use `tferrors.NewDiagnosticFromAPIError`.
- Add unit tests for invalid build error detection and an acceptance test for invalid build on create.

Refs #338

## Test plan
- [x] Unit tests pass (`TestNewAPIError`)
- [x] Acceptance tests pass (`TestAccSensorUpdatePolicyResourceBadBuildCreate`, `TestAccSensorUpdatePolicyResourceBadBuildUpdate`)
- [x] `make fmt` clean
- [x] `make gen` clean