### PR TITLE
fix(it_automation_task): resource validates correctly when `os_query` is `<unknown>`

### DIFF
--- a/internal/it_automation/it_automation_task_resource.go
+++ b/internal/it_automation/it_automation_task_resource.go
@@ -1234,6 +1234,7 @@ func (r *itAutomationTaskResource) ValidateConfig(
 	}
 
 	if !hasValue(config.OsQuery) &&
+		!config.OsQuery.IsUnknown() &&
 		!scriptProvided &&
 		!hasUnknownFileIds &&
 		config.Type.ValueString() != "" {


### PR DESCRIPTION
This situation came up when attempting to generate multiple `it_automation_task` resources using a `for_each` mapping, and having the `os_query` parameter set.

When using `${each.key}` inside the `os_query` parameter, the provider would error with `You must provide one of the script_content or script_file_id fields`, due to the `os_query` parameter being unknown during validation and before a plan.

This commit fixes that issue by ensuring that `<unknown>` `os_query` values are correctly interpreted as valid.

I was unable to write any tests for this as I don't have full access to a CrowdStrike instance, but the change is very minor and should not have much more of an effect.