### PR TITLE
feat(prevention_policy): add cloud_data_protection_visibility to linux policies

### DIFF
--- a/docs/resources/default_prevention_policy_linux.md
+++ b/docs/resources/default_prevention_policy_linux.md
@@ -67,6 +67,10 @@ resource "crowdstrike_default_prevention_policy_linux" "default" {
   enhance_php_visibility                       = true
   enhance_environment_variable_visibility      = true
   suspicious_file_analysis                     = true
+  cloud_data_protection_visibility             = true
+  ssh_visibility                               = true
+  enhance_systemd_visibility                   = true
+  php_script_optimization                      = true
 }
 
 output "default_prevention_policy_linux" {
@@ -84,6 +88,7 @@ output "default_prevention_policy_linux" {
 ### Optional
 
 - `cloud_anti_malware` (Attributes) Use cloud-based machine learning informed by global analysis of executables to detect and prevent known malware for your online hosts. (see [below for nested schema](#nestedatt--cloud_anti_malware))
+- `cloud_data_protection_visibility` (Boolean) Whether to enable the setting. Allows the sensor to monitor and analyze data flows for protection against data breaches and leaks, and to improve data-related detections.
 - `custom_blocking` (Boolean) Whether to enable the setting. Block processes matching hashes that you add to IOC Management with the action set to "Block" or "Block, hide detection".
 - `dbus_visibility` (Boolean) Whether to enable the setting. Allows the sensor to monitor local D-Bus traffic for malicious patterns and improved detections.
 - `description` (String) Description of the prevention policy.

--- a/docs/resources/prevention_policy_linux.md
+++ b/docs/resources/prevention_policy_linux.md
@@ -70,6 +70,10 @@ resource "crowdstrike_prevention_policy_linux" "example" {
   enhance_php_visibility                       = true
   enhance_environment_variable_visibility      = true
   suspicious_file_analysis                     = true
+  cloud_data_protection_visibility             = true
+  ssh_visibility                               = true
+  enhance_systemd_visibility                   = true
+  php_script_optimization                      = true
 }
 
 output "prevention_policy_linux" {
@@ -89,6 +93,7 @@ output "prevention_policy_linux" {
 ### Optional
 
 - `cloud_anti_malware` (Attributes) Use cloud-based machine learning informed by global analysis of executables to detect and prevent known malware for your online hosts. (see [below for nested schema](#nestedatt--cloud_anti_malware))
+- `cloud_data_protection_visibility` (Boolean) Whether to enable the setting. Allows the sensor to monitor and analyze data flows for protection against data breaches and leaks, and to improve data-related detections.
 - `custom_blocking` (Boolean) Whether to enable the setting. Block processes matching hashes that you add to IOC Management with the action set to "Block" or "Block, hide detection".
 - `dbus_visibility` (Boolean) Whether to enable the setting. Allows the sensor to monitor local D-Bus traffic for malicious patterns and improved detections.
 - `description` (String) Description of the prevention policy.

--- a/examples/resources/crowdstrike_default_prevention_policy_linux/resource.tf
+++ b/examples/resources/crowdstrike_default_prevention_policy_linux/resource.tf
@@ -43,6 +43,10 @@ resource "crowdstrike_default_prevention_policy_linux" "default" {
   enhance_php_visibility                       = true
   enhance_environment_variable_visibility      = true
   suspicious_file_analysis                     = true
+  cloud_data_protection_visibility             = true
+  ssh_visibility                               = true
+  enhance_systemd_visibility                   = true
+  php_script_optimization                      = true
 }
 
 output "default_prevention_policy_linux" {

--- a/examples/resources/crowdstrike_prevention_policy_linux/resource.tf
+++ b/examples/resources/crowdstrike_prevention_policy_linux/resource.tf
@@ -46,6 +46,10 @@ resource "crowdstrike_prevention_policy_linux" "example" {
   enhance_php_visibility                       = true
   enhance_environment_variable_visibility      = true
   suspicious_file_analysis                     = true
+  cloud_data_protection_visibility             = true
+  ssh_visibility                               = true
+  enhance_systemd_visibility                   = true
+  php_script_optimization                      = true
 }
 
 output "prevention_policy_linux" {

--- a/internal/prevention_policy/default_linux_policy.go
+++ b/internal/prevention_policy/default_linux_policy.go
@@ -62,6 +62,7 @@ type defaultPreventionPolicyLinuxResourceModel struct {
 	EnhancePHPVisibility                 types.Bool   `tfsdk:"enhance_php_visibility"`
 	EnhanceEnvironmentVariableVisibility types.Bool   `tfsdk:"enhance_environment_variable_visibility"`
 	SuspiciousFileAnalysis               types.Bool   `tfsdk:"suspicious_file_analysis"`
+	CloudDataProtectionVisibility        types.Bool   `tfsdk:"cloud_data_protection_visibility"`
 	SSHVisibility                        types.Bool   `tfsdk:"ssh_visibility"`
 	EnhanceSystemdVisibility             types.Bool   `tfsdk:"enhance_systemd_visibility"`
 	PHPScriptOptimization                types.Bool   `tfsdk:"php_script_optimization"`
@@ -112,6 +113,7 @@ func (m *defaultPreventionPolicyLinuxResourceModel) generatePreventionSettings(c
 		"EnhancePHPVisibility":                 m.EnhancePHPVisibility,
 		"EnhanceEnvironmentVariableVisibility": m.EnhanceEnvironmentVariableVisibility,
 		"SuspiciousFileAnalysis":               m.SuspiciousFileAnalysis,
+		"CloudDataProtectionVisibility":        m.CloudDataProtectionVisibility,
 		"SSHVisibility":                        m.SSHVisibility,
 		"EnhanceSystemdVisibility":             m.EnhanceSystemdVisibility,
 		"PHPScriptOptimization":                m.PHPScriptOptimization,
@@ -205,6 +207,9 @@ func (m *defaultPreventionPolicyLinuxResourceModel) assignPreventionSettings(
 		toggleSettings["EnhanceEnvironmentVariableVisibility"],
 	)
 	m.SuspiciousFileAnalysis = defaultBoolFalse(toggleSettings["SuspiciousFileAnalysis"])
+	m.CloudDataProtectionVisibility = defaultBoolFalse(
+		toggleSettings["CloudDataProtectionVisibility"],
+	)
 	m.SSHVisibility = defaultBoolFalse(toggleSettings["SSHVisibility"])
 	m.EnhanceSystemdVisibility = defaultBoolFalse(toggleSettings["EnhanceSystemdVisibility"])
 	m.PHPScriptOptimization = defaultBoolFalse(toggleSettings["PHPScriptOptimization"])

--- a/internal/prevention_policy/linux.go
+++ b/internal/prevention_policy/linux.go
@@ -68,6 +68,7 @@ type preventionPolicyLinuxResourceModel struct {
 	EnhancePHPVisibility                 types.Bool   `tfsdk:"enhance_php_visibility"`
 	EnhanceEnvironmentVariableVisibility types.Bool   `tfsdk:"enhance_environment_variable_visibility"`
 	SuspiciousFileAnalysis               types.Bool   `tfsdk:"suspicious_file_analysis"`
+	CloudDataProtectionVisibility        types.Bool   `tfsdk:"cloud_data_protection_visibility"`
 	SSHVisibility                        types.Bool   `tfsdk:"ssh_visibility"`
 	EnhanceSystemdVisibility             types.Bool   `tfsdk:"enhance_systemd_visibility"`
 	PHPScriptOptimization                types.Bool   `tfsdk:"php_script_optimization"`
@@ -516,6 +517,9 @@ func (r *preventionPolicyLinuxResource) assignPreventionSettings(
 		toggleSettings["EnhanceEnvironmentVariableVisibility"],
 	)
 	state.SuspiciousFileAnalysis = defaultBoolFalse(toggleSettings["SuspiciousFileAnalysis"])
+	state.CloudDataProtectionVisibility = defaultBoolFalse(
+		toggleSettings["CloudDataProtectionVisibility"],
+	)
 	state.SSHVisibility = defaultBoolFalse(toggleSettings["SSHVisibility"])
 	state.EnhanceSystemdVisibility = defaultBoolFalse(toggleSettings["EnhanceSystemdVisibility"])
 	state.PHPScriptOptimization = defaultBoolFalse(toggleSettings["PHPScriptOptimization"])
@@ -572,6 +576,7 @@ func (r *preventionPolicyLinuxResource) generatePreventionSettings(
 		"EnhancePHPVisibility":                 config.EnhancePHPVisibility,
 		"EnhanceEnvironmentVariableVisibility": config.EnhanceEnvironmentVariableVisibility,
 		"SuspiciousFileAnalysis":               config.SuspiciousFileAnalysis,
+		"CloudDataProtectionVisibility":        config.CloudDataProtectionVisibility,
 		"SSHVisibility":                        config.SSHVisibility,
 		"EnhanceSystemdVisibility":             config.EnhanceSystemdVisibility,
 		"PHPScriptOptimization":                config.PHPScriptOptimization,

--- a/internal/prevention_policy/linux_test.go
+++ b/internal/prevention_policy/linux_test.go
@@ -81,6 +81,7 @@ func TestAccPreventionPolicyLinux_update(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enhance_php_visibility"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enhance_environment_variable_visibility"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("suspicious_file_analysis"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("cloud_data_protection_visibility"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("ssh_visibility"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enhance_systemd_visibility"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("php_script_optimization"), knownvalue.Bool(false)),
@@ -123,6 +124,7 @@ func TestAccPreventionPolicyLinux_update(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enhance_php_visibility"), knownvalue.Bool(true)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enhance_environment_variable_visibility"), knownvalue.Bool(true)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("suspicious_file_analysis"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("cloud_data_protection_visibility"), knownvalue.Bool(true)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("ssh_visibility"), knownvalue.Bool(true)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enhance_systemd_visibility"), knownvalue.Bool(true)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("php_script_optimization"), knownvalue.Bool(true)),
@@ -165,6 +167,7 @@ func TestAccPreventionPolicyLinux_update(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enhance_php_visibility"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enhance_environment_variable_visibility"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("suspicious_file_analysis"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("cloud_data_protection_visibility"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("ssh_visibility"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enhance_systemd_visibility"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("php_script_optimization"), knownvalue.Bool(false)),
@@ -239,6 +242,7 @@ resource "crowdstrike_prevention_policy_linux" "test" {
   enhance_php_visibility                       = true
   enhance_environment_variable_visibility      = true
   suspicious_file_analysis                     = true
+  cloud_data_protection_visibility             = true
   ssh_visibility                               = true
   enhance_systemd_visibility                   = true
   php_script_optimization                      = true

--- a/internal/prevention_policy/schema.go
+++ b/internal/prevention_policy/schema.go
@@ -678,6 +678,9 @@ func generateLinuxSchema(defaultPolicy bool) schema.Schema {
 			"suspicious_file_analysis": toggleAttribute(
 				"Upload suspicious files for advanced threat analysis with QuickScan Pro.",
 			),
+			"cloud_data_protection_visibility": toggleAttribute(
+				"Allows the sensor to monitor and analyze data flows for protection against data breaches and leaks, and to improve data-related detections.",
+			),
 			"ssh_visibility": toggleAttribute(
 				"Enable monitoring of activities performed by SSH servers.",
 			),


### PR DESCRIPTION
Add the CloudDataProtectionVisibility toggle setting to both crowdstrike_prevention_policy_linux and crowdstrike_default_prevention_policy_linux resources.

Closes #358