### PR TITLE
fix(cloud_azure_tenant): convert id list attributes to sets

### DIFF
--- a/docs/resources/cloud_azure_tenant.md
+++ b/docs/resources/cloud_azure_tenant.md
@@ -61,7 +61,7 @@ output "tenant_registration" {
 
 ### Required
 
-- `microsoft_graph_permission_ids` (List of String) A list of Microsoft Graph permission IDs to assign to the service principal.
+- `microsoft_graph_permission_ids` (Set of String) A list of Microsoft Graph permission IDs to assign to the service principal.
 - `tenant_id` (String) The Azure Tenant ID to register into Falcon Cloud Security. If subscription_ids and management_group_ids are not provided, then all subscriptions in the tenant are targeted.
 
 ### Optional
@@ -71,11 +71,11 @@ output "tenant_registration" {
 - `cs_infra_subscription_id` (String) Azure subscription ID where CrowdStrike infrastructure resources (such as Event Hubs) were deployed.
 - `dspm` (Attributes) (see [below for nested schema](#nestedatt--dspm))
 - `environment` (String) The environment added to resources created during onboarding. It will be used if you generate new .tfvars from the UI.
-- `management_group_ids` (List of String) A list of Azure management group IDs to monitor. All subscriptions under the management groups will be monitored.
+- `management_group_ids` (Set of String) A list of Azure management group IDs to monitor. All subscriptions under the management groups will be monitored.
 - `realtime_visibility` (Attributes) (see [below for nested schema](#nestedatt--realtime_visibility))
 - `resource_name_prefix` (String) The prefix added to resources created during onboarding. It will be used if you generate new .tfvars from the UI.
 - `resource_name_suffix` (String) The suffix added to resources created during onboarding. It will be used if you generate new .tfvars from the UI.
-- `subscription_ids` (List of String) A list of subscription IDs to register in addition to any subscriptions that are targeted by management_group_ids.
+- `subscription_ids` (Set of String) A list of subscription IDs to register in addition to any subscriptions that are targeted by management_group_ids.
 - `tags` (Map of String) Tags applied to managed resources. This does not effect the registration of the tenant. It will be used if you generate new .tfvars from the UI.
 
 ### Read-Only

--- a/internal/fcs/cloud_azure_tenant_resource.go
+++ b/internal/fcs/cloud_azure_tenant_resource.go
@@ -272,10 +272,16 @@ func (m *cloudAzureTenantModel) wrap(
 	m.MicrosoftGraphPermissionIds = graphPermissionIDs
 
 	subscriptionsIDs, d := flex.FlattenStringValueSet(ctx, registration.SubscriptionIds)
+	if subscriptionsIDs.IsNull() && !m.SubscriptionIds.IsNull() {
+		subscriptionsIDs = types.SetValueMust(types.StringType, []attr.Value{})
+	}
 	diags.Append(d...)
 	m.SubscriptionIds = subscriptionsIDs
 
 	managementGroupIDs, d := flex.FlattenStringValueSet(ctx, registration.ManagementGroupIds)
+	if managementGroupIDs.IsNull() && !m.ManagementGroupIds.IsNull() {
+		managementGroupIDs = types.SetValueMust(types.StringType, []attr.Value{})
+	}
 	diags.Append(d...)
 	m.ManagementGroupIds = managementGroupIDs
 

--- a/internal/fcs/cloud_azure_tenant_resource.go
+++ b/internal/fcs/cloud_azure_tenant_resource.go
@@ -8,6 +8,7 @@ import (
 	"github.com/crowdstrike/gofalcon/falcon/client/cloud_azure_registration"
 	"github.com/crowdstrike/gofalcon/falcon/models"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/config"
+	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/framework/flex"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/scopes"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/tferrors"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/utils"
@@ -86,9 +87,9 @@ type cloudAzureTenantModel struct {
 	CsInfraRegion               types.String `tfsdk:"cs_infra_location"`
 	CsInfraSubscriptionId       types.String `tfsdk:"cs_infra_subscription_id"`
 	Environment                 types.String `tfsdk:"environment"`
-	SubscriptionIds             types.List   `tfsdk:"subscription_ids"`
-	ManagementGroupIds          types.List   `tfsdk:"management_group_ids"`
-	MicrosoftGraphPermissionIds types.List   `tfsdk:"microsoft_graph_permission_ids"`
+	SubscriptionIds             types.Set    `tfsdk:"subscription_ids"`
+	ManagementGroupIds          types.Set    `tfsdk:"management_group_ids"`
+	MicrosoftGraphPermissionIds types.Set    `tfsdk:"microsoft_graph_permission_ids"`
 	ResourceNamePrefix          types.String `tfsdk:"resource_name_prefix"`
 	ResourceNameSuffix          types.String `tfsdk:"resource_name_suffix"`
 	Tags                        types.Map    `tfsdk:"tags"`
@@ -168,17 +169,17 @@ func (r *cloudAzureTenantResource) Schema(
 				MarkdownDescription: "Azure subscription ID where CrowdStrike infrastructure resources (such as Event Hubs) were deployed.",
 				Optional:            true,
 			},
-			"management_group_ids": schema.ListAttribute{
+			"management_group_ids": schema.SetAttribute{
 				ElementType:         types.StringType,
 				Optional:            true,
 				MarkdownDescription: "A list of Azure management group IDs to monitor. All subscriptions under the management groups will be monitored.",
 			},
-			"microsoft_graph_permission_ids": schema.ListAttribute{
+			"microsoft_graph_permission_ids": schema.SetAttribute{
 				ElementType:         types.StringType,
 				Required:            true,
 				MarkdownDescription: "A list of Microsoft Graph permission IDs to assign to the service principal.",
 			},
-			"subscription_ids": schema.ListAttribute{
+			"subscription_ids": schema.SetAttribute{
 				ElementType:         types.StringType,
 				Optional:            true,
 				MarkdownDescription: "A list of subscription IDs to register in addition to any subscriptions that are targeted by management_group_ids.",
@@ -266,22 +267,16 @@ func (m *cloudAzureTenantModel) wrap(
 ) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	graphPermissionIDs := utils.SliceToListTypeString(ctx, registration.MicrosoftGraphPermissionIds, &diags)
-	if m.MicrosoftGraphPermissionIds.IsNull() && len(graphPermissionIDs.Elements()) == 0 {
-		graphPermissionIDs = types.ListNull(types.StringType)
-	}
+	graphPermissionIDs, d := types.SetValueFrom(ctx, types.StringType, registration.MicrosoftGraphPermissionIds)
+	diags.Append(d...)
 	m.MicrosoftGraphPermissionIds = graphPermissionIDs
 
-	subscriptionsIDs := utils.SliceToListTypeString(ctx, registration.SubscriptionIds, &diags)
-	if m.SubscriptionIds.IsNull() && len(subscriptionsIDs.Elements()) == 0 {
-		subscriptionsIDs = types.ListNull(types.StringType)
-	}
+	subscriptionsIDs, d := flex.FlattenStringValueSet(ctx, registration.SubscriptionIds)
+	diags.Append(d...)
 	m.SubscriptionIds = subscriptionsIDs
 
-	managementGroupIDs := utils.SliceToListTypeString(ctx, registration.ManagementGroupIds, &diags)
-	if m.ManagementGroupIds.IsNull() && len(managementGroupIDs.Elements()) == 0 {
-		managementGroupIDs = types.ListNull(types.StringType)
-	}
+	managementGroupIDs, d := flex.FlattenStringValueSet(ctx, registration.ManagementGroupIds)
+	diags.Append(d...)
 	m.ManagementGroupIds = managementGroupIDs
 
 	tags, err := types.MapValueFrom(ctx, types.StringType, registration.Tags)
@@ -442,17 +437,17 @@ func (r *cloudAzureTenantResource) ValidateConfig(
 	}
 
 	resp.Diagnostics.Append(
-		utils.ValidateEmptyIDsList(ctx, types.Set(config.SubscriptionIds), "subscription_ids")...)
+		utils.ValidateEmptyIDsList(ctx, config.SubscriptionIds, "subscription_ids")...)
 	resp.Diagnostics.Append(
 		utils.ValidateEmptyIDsList(
 			ctx,
-			types.Set(config.ManagementGroupIds),
+			config.ManagementGroupIds,
 			"management_group_ids",
 		)...)
 	resp.Diagnostics.Append(
 		utils.ValidateEmptyIDsList(
 			ctx,
-			types.Set(config.MicrosoftGraphPermissionIds),
+			config.MicrosoftGraphPermissionIds,
 			"microsoft_graph_permission_ids",
 		)...)
 
@@ -601,9 +596,9 @@ func (r *cloudAzureTenantResource) createRegistration(
 				ResourceNamePrefix:          data.ResourceNamePrefix.ValueStringPointer(),
 				ResourceNameSuffix:          data.ResourceNameSuffix.ValueStringPointer(),
 				DeploymentMethod:            utils.Addr("terraform-native"),
-				SubscriptionIds:             utils.ListTypeAs[string](ctx, data.SubscriptionIds, &diags),
-				ManagementGroupIds:          utils.ListTypeAs[string](ctx, data.ManagementGroupIds, &diags),
-				MicrosoftGraphPermissionIds: utils.ListTypeAs[string](ctx, data.MicrosoftGraphPermissionIds, &diags),
+				SubscriptionIds:             flex.ExpandSetAs[string](ctx, data.SubscriptionIds, &diags),
+				ManagementGroupIds:          flex.ExpandSetAs[string](ctx, data.ManagementGroupIds, &diags),
+				MicrosoftGraphPermissionIds: flex.ExpandSetAs[string](ctx, data.MicrosoftGraphPermissionIds, &diags),
 				Products: []*models.DomainProductFeatures{
 					&cspmProductFeatures,
 				},
@@ -680,9 +675,9 @@ func (r *cloudAzureTenantResource) updateRegistration(
 				ResourceNamePrefix:          data.ResourceNamePrefix.ValueStringPointer(),
 				ResourceNameSuffix:          data.ResourceNameSuffix.ValueStringPointer(),
 				DeploymentMethod:            "terraform-native",
-				SubscriptionIds:             utils.ListTypeAs[string](ctx, data.SubscriptionIds, &diags),
-				ManagementGroupIds:          utils.ListTypeAs[string](ctx, data.ManagementGroupIds, &diags),
-				MicrosoftGraphPermissionIds: utils.ListTypeAs[string](ctx, data.MicrosoftGraphPermissionIds, &diags),
+				SubscriptionIds:             flex.ExpandSetAs[string](ctx, data.SubscriptionIds, &diags),
+				ManagementGroupIds:          flex.ExpandSetAs[string](ctx, data.ManagementGroupIds, &diags),
+				MicrosoftGraphPermissionIds: flex.ExpandSetAs[string](ctx, data.MicrosoftGraphPermissionIds, &diags),
 				Products: []*models.DomainProductFeatures{
 					&cspmProductFeatures,
 				},

--- a/internal/fcs/cloud_azure_tenant_resource_test.go
+++ b/internal/fcs/cloud_azure_tenant_resource_test.go
@@ -28,7 +28,7 @@ func TestAccCloudAzureTenant_basic(t *testing.T) {
 				Config: testAccCloudAzureTenantConfig_basic(tenantID),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("tenant_id"), knownvalue.StringExact(tenantID)),
-					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("microsoft_graph_permission_ids"), knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact(userReadAllPermissionID)})),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("microsoft_graph_permission_ids"), knownvalue.SetExact([]knownvalue.Check{knownvalue.StringExact(userReadAllPermissionID)})),
 					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("cs_azure_client_id"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("account_type"), knownvalue.StringExact("commercial")),
 					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("realtime_visibility").AtMapKey("enabled"), knownvalue.Bool(false)),
@@ -63,8 +63,8 @@ func TestAccCloudAzureTenant_update(t *testing.T) {
 				Config: testAccCloudAzureTenantConfig_withSubscription(tenantID, subID1),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("tenant_id"), knownvalue.StringExact(tenantID)),
-					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("microsoft_graph_permission_ids"), knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact(userReadAllPermissionID)})),
-					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("subscription_ids"), knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact(subID1)})),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("microsoft_graph_permission_ids"), knownvalue.SetExact([]knownvalue.Check{knownvalue.StringExact(userReadAllPermissionID)})),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("subscription_ids"), knownvalue.SetExact([]knownvalue.Check{knownvalue.StringExact(subID1)})),
 					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("cs_azure_client_id"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("account_type"), knownvalue.StringExact("commercial")),
 					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("realtime_visibility").AtMapKey("enabled"), knownvalue.Bool(false)),
@@ -77,8 +77,8 @@ func TestAccCloudAzureTenant_update(t *testing.T) {
 				Config: testAccCloudAzureTenantConfig_updated(tenantID, subID2),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("tenant_id"), knownvalue.StringExact(tenantID)),
-					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("microsoft_graph_permission_ids"), knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact(userReadAllPermissionID)})),
-					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("subscription_ids"), knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact(subID2)})),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("microsoft_graph_permission_ids"), knownvalue.SetExact([]knownvalue.Check{knownvalue.StringExact(userReadAllPermissionID)})),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("subscription_ids"), knownvalue.SetExact([]knownvalue.Check{knownvalue.StringExact(subID2)})),
 					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("realtime_visibility").AtMapKey("enabled"), knownvalue.Bool(true)),
 					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("dspm").AtMapKey("enabled"), knownvalue.Bool(true)),
 					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("resource_name_prefix"), knownvalue.StringExact("cs")),
@@ -94,7 +94,7 @@ func TestAccCloudAzureTenant_update(t *testing.T) {
 				Config: testAccCloudAzureTenantConfig_withSubscription(tenantID, subID3),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("tenant_id"), knownvalue.StringExact(tenantID)),
-					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("subscription_ids"), knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact(subID3)})),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("subscription_ids"), knownvalue.SetExact([]knownvalue.Check{knownvalue.StringExact(subID3)})),
 					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("realtime_visibility").AtMapKey("enabled"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("dspm").AtMapKey("enabled"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("resource_name_prefix"), knownvalue.StringExact("")),
@@ -126,7 +126,7 @@ func TestAccCloudAzureTenant_managementGroups(t *testing.T) {
 				Config: testAccCloudAzureTenantConfig_withManagementGroup(tenantID, mgID),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("tenant_id"), knownvalue.StringExact(tenantID)),
-					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("management_group_ids"), knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact(mgID)})),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("management_group_ids"), knownvalue.SetExact([]knownvalue.Check{knownvalue.StringExact(mgID)})),
 					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("subscription_ids"), knownvalue.Null()),
 				},
 			},
@@ -275,7 +275,7 @@ func TestAccCloudAzureTenant_emptyGraphPermissions(t *testing.T) {
 				Config: testAccCloudAzureTenantConfig_emptyGraphPermissions(tenantID),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("tenant_id"), knownvalue.StringExact(tenantID)),
-					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("microsoft_graph_permission_ids"), knownvalue.ListSizeExact(0)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("microsoft_graph_permission_ids"), knownvalue.SetSizeExact(0)),
 				},
 			},
 		},

--- a/internal/fcs/cloud_azure_tenant_resource_test.go
+++ b/internal/fcs/cloud_azure_tenant_resource_test.go
@@ -134,6 +134,41 @@ func TestAccCloudAzureTenant_managementGroups(t *testing.T) {
 	})
 }
 
+func TestAccCloudAzureTenant_emptyIdLists(t *testing.T) {
+	tenantID := acctest.RandomUUID()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudAzureTenantConfig_basic(tenantID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("tenant_id"), knownvalue.StringExact(tenantID)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("subscription_ids"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("management_group_ids"), knownvalue.Null()),
+				},
+			},
+			{
+				Config: testAccCloudAzureTenantConfig_emptyIdLists(tenantID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("tenant_id"), knownvalue.StringExact(tenantID)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("subscription_ids"), knownvalue.SetSizeExact(0)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("management_group_ids"), knownvalue.SetSizeExact(0)),
+				},
+			},
+			{
+				Config: testAccCloudAzureTenantConfig_basic(tenantID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("tenant_id"), knownvalue.StringExact(tenantID)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("subscription_ids"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("management_group_ids"), knownvalue.Null()),
+				},
+			},
+		},
+	})
+}
+
 func TestAccCloudAzureTenant_tags(t *testing.T) {
 	tenantID := acctest.RandomUUID()
 
@@ -330,6 +365,16 @@ resource "crowdstrike_cloud_azure_tenant" "test" {
   microsoft_graph_permission_ids = [%[2]q]
   management_group_ids           = [%[3]q]
 }`, tenantID, userReadAllPermissionID, managementGroupID)
+}
+
+func testAccCloudAzureTenantConfig_emptyIdLists(tenantID string) string {
+	return fmt.Sprintf(`
+resource "crowdstrike_cloud_azure_tenant" "test" {
+  tenant_id                      = %[1]q
+  microsoft_graph_permission_ids = [%[2]q]
+  subscription_ids               = []
+  management_group_ids           = []
+}`, tenantID, userReadAllPermissionID)
 }
 
 func testAccCloudAzureTenantConfig_withTags(tenantID string) string {


### PR DESCRIPTION
## Summary

Unordered `subscription_ids`, `management_group_ids`, and `microsoft_graph_permission_ids` caused state inconsistency errors when the API returned them in a different order than the config. Sets are order-insensitive, avoiding the drift.