### PR TITLE
feat(cloud_azure_tenant): add agentless_scanning_subscription_ids attribute

### DIFF
--- a/docs/resources/cloud_azure_tenant.md
+++ b/docs/resources/cloud_azure_tenant.md
@@ -67,6 +67,7 @@ output "tenant_registration" {
 ### Optional
 
 - `account_type` (String) The Azure Tenant account type. Value is 'commercial' for Commercial cloud accounts. For GovCloud environments, value can be either 'commercial' or 'gov' depending on the account type
+- `agentless_scanning_subscription_ids` (Set of String) Azure subscription IDs where agentless scanning is enabled. These are sent as `additional_features` to the CrowdStrike API.
 - `cs_infra_location` (String) Azure location where CrowdStrike infrastructure resources (such as Event Hubs) were deployed.
 - `cs_infra_subscription_id` (String) Azure subscription ID where CrowdStrike infrastructure resources (such as Event Hubs) were deployed.
 - `dspm` (Attributes) (see [below for nested schema](#nestedatt--dspm))

--- a/internal/fcs/cloud_azure_tenant_resource.go
+++ b/internal/fcs/cloud_azure_tenant_resource.go
@@ -322,11 +322,14 @@ func (m *cloudAzureTenantModel) wrap(
 		}
 	}
 
-	var agentlessSubIdsSlice []string
 	for _, af := range registration.AdditionalFeatures {
 		if af != nil && af.Feature != nil && *af.Feature == "dspm" {
-			hasDSPM = true
-			agentlessSubIdsSlice = af.SubscriptionIds
+			if !m.AgentlessScanningSubscriptionIds.IsNull() && len(af.SubscriptionIds) > 0 {
+				hasDSPM = true
+				agentlessSubIds, d := flex.FlattenStringValueSet(ctx, af.SubscriptionIds)
+				diags.Append(d...)
+				m.AgentlessScanningSubscriptionIds = agentlessSubIds
+			}
 			break
 		}
 	}
@@ -340,12 +343,6 @@ func (m *cloudAzureTenantModel) wrap(
 	dspmObj, d := dspm.ToObject(ctx)
 	diags.Append(d...)
 	m.DSPM = dspmObj
-
-	if !m.AgentlessScanningSubscriptionIds.IsNull() && len(agentlessSubIdsSlice) > 0 {
-		agentlessSubIds, d := flex.FlattenStringValueSet(ctx, agentlessSubIdsSlice)
-		diags.Append(d...)
-		m.AgentlessScanningSubscriptionIds = agentlessSubIds
-	}
 
 	return diags
 }

--- a/internal/fcs/cloud_azure_tenant_resource.go
+++ b/internal/fcs/cloud_azure_tenant_resource.go
@@ -82,20 +82,21 @@ func (r *cloudAzureTenantResource) Metadata(
 }
 
 type cloudAzureTenantModel struct {
-	AccountType                 types.String `tfsdk:"account_type"`
-	AppRegistrationId           types.String `tfsdk:"cs_azure_client_id"`
-	CsInfraRegion               types.String `tfsdk:"cs_infra_location"`
-	CsInfraSubscriptionId       types.String `tfsdk:"cs_infra_subscription_id"`
-	Environment                 types.String `tfsdk:"environment"`
-	SubscriptionIds             types.Set    `tfsdk:"subscription_ids"`
-	ManagementGroupIds          types.Set    `tfsdk:"management_group_ids"`
-	MicrosoftGraphPermissionIds types.Set    `tfsdk:"microsoft_graph_permission_ids"`
-	ResourceNamePrefix          types.String `tfsdk:"resource_name_prefix"`
-	ResourceNameSuffix          types.String `tfsdk:"resource_name_suffix"`
-	Tags                        types.Map    `tfsdk:"tags"`
-	TenantId                    types.String `tfsdk:"tenant_id"`
-	RealtimeVisibility          types.Object `tfsdk:"realtime_visibility"`
-	DSPM                        types.Object `tfsdk:"dspm"`
+	AccountType                      types.String `tfsdk:"account_type"`
+	AppRegistrationId                types.String `tfsdk:"cs_azure_client_id"`
+	CsInfraRegion                    types.String `tfsdk:"cs_infra_location"`
+	CsInfraSubscriptionId            types.String `tfsdk:"cs_infra_subscription_id"`
+	Environment                      types.String `tfsdk:"environment"`
+	SubscriptionIds                  types.Set    `tfsdk:"subscription_ids"`
+	ManagementGroupIds               types.Set    `tfsdk:"management_group_ids"`
+	MicrosoftGraphPermissionIds      types.Set    `tfsdk:"microsoft_graph_permission_ids"`
+	ResourceNamePrefix               types.String `tfsdk:"resource_name_prefix"`
+	ResourceNameSuffix               types.String `tfsdk:"resource_name_suffix"`
+	Tags                             types.Map    `tfsdk:"tags"`
+	TenantId                         types.String `tfsdk:"tenant_id"`
+	RealtimeVisibility               types.Object `tfsdk:"realtime_visibility"`
+	DSPM                             types.Object `tfsdk:"dspm"`
+	AgentlessScanningSubscriptionIds types.Set    `tfsdk:"agentless_scanning_subscription_ids"`
 }
 
 type realtimeVisibilityModel struct {
@@ -257,6 +258,11 @@ func (r *cloudAzureTenantResource) Schema(
 				Optional:            true,
 				MarkdownDescription: "Tags applied to managed resources. This does not effect the registration of the tenant. It will be used if you generate new .tfvars from the UI.",
 			},
+			"agentless_scanning_subscription_ids": schema.SetAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				MarkdownDescription: "Azure subscription IDs where agentless scanning is enabled. These are sent as `additional_features` to the CrowdStrike API.",
+			},
 		},
 	}
 }
@@ -316,6 +322,15 @@ func (m *cloudAzureTenantModel) wrap(
 		}
 	}
 
+	var agentlessSubIdsSlice []string
+	for _, af := range registration.AdditionalFeatures {
+		if af != nil && af.Feature != nil && *af.Feature == "dspm" {
+			hasDSPM = true
+			agentlessSubIdsSlice = af.SubscriptionIds
+			break
+		}
+	}
+
 	rtv := realtimeVisibilityModel{Enabled: types.BoolValue(hasIOA)}
 	rtvObj, d := rtv.ToObject(ctx)
 	diags.Append(d...)
@@ -325,6 +340,12 @@ func (m *cloudAzureTenantModel) wrap(
 	dspmObj, d := dspm.ToObject(ctx)
 	diags.Append(d...)
 	m.DSPM = dspmObj
+
+	if !m.AgentlessScanningSubscriptionIds.IsNull() && len(agentlessSubIdsSlice) > 0 {
+		agentlessSubIds, d := flex.FlattenStringValueSet(ctx, agentlessSubIdsSlice)
+		diags.Append(d...)
+		m.AgentlessScanningSubscriptionIds = agentlessSubIds
+	}
 
 	return diags
 }
@@ -614,6 +635,17 @@ func (r *cloudAzureTenantResource) createRegistration(
 		Context: ctx,
 	}
 
+	agentlessSubIds := flex.ExpandSetAs[string](ctx, data.AgentlessScanningSubscriptionIds, &diags)
+	if len(agentlessSubIds) > 0 {
+		params.Body.Resource.AdditionalFeatures = []*models.AzureAdditionalFeature{
+			{
+				Feature:         utils.Addr("dspm"),
+				Product:         utils.Addr("cspm"),
+				SubscriptionIds: agentlessSubIds,
+			},
+		}
+	}
+
 	if diags.HasError() {
 		return nil, diags
 	}
@@ -691,6 +723,17 @@ func (r *cloudAzureTenantResource) updateRegistration(
 			},
 		},
 		Context: ctx,
+	}
+
+	agentlessSubIds := flex.ExpandSetAs[string](ctx, data.AgentlessScanningSubscriptionIds, &diags)
+	if len(agentlessSubIds) > 0 {
+		params.Body.Resource.AdditionalFeatures = []*models.AzureAdditionalFeature{
+			{
+				Feature:         utils.Addr("dspm"),
+				Product:         utils.Addr("cspm"),
+				SubscriptionIds: agentlessSubIds,
+			},
+		}
 	}
 
 	if diags.HasError() {

--- a/internal/fcs/cloud_azure_tenant_resource.go
+++ b/internal/fcs/cloud_azure_tenant_resource.go
@@ -141,13 +141,14 @@ func buildAzureProductConfig(
 	ctx context.Context,
 	data *cloudAzureTenantModel,
 	diags *diag.Diagnostics,
-) (features []string, additional []*models.AzureAdditionalFeature) {
+) (features []string, additionalFeatures []*models.AzureAdditionalFeature) {
 	features = []string{"iom"}
+	additionalFeatures = []*models.AzureAdditionalFeature{}
 
 	var rtv realtimeVisibilityModel
 	diags.Append(rtv.FromObject(ctx, data.RealtimeVisibility)...)
 	if diags.HasError() {
-		return features, nil
+		return features, additionalFeatures
 	}
 	if rtv.Enabled.ValueBool() {
 		features = append(features, "ioa")
@@ -156,24 +157,24 @@ func buildAzureProductConfig(
 	var dspm dspmModel
 	diags.Append(dspm.FromObject(ctx, data.DSPM)...)
 	if diags.HasError() {
-		return features, nil
+		return features, additionalFeatures
 	}
 	if !dspm.Enabled.ValueBool() {
-		return features, nil
+		return features, additionalFeatures
 	}
 
 	subs := flex.ExpandSetAs[string](ctx, data.AgentlessScanningSubscriptionIds, diags)
 	if len(subs) == 0 {
 		features = append(features, "dspm")
-		return features, nil
+		return features, additionalFeatures
 	}
 
-	additional = []*models.AzureAdditionalFeature{{
+	additionalFeatures = []*models.AzureAdditionalFeature{{
 		Feature:         utils.Addr("dspm"),
 		Product:         utils.Addr("cspm"),
 		SubscriptionIds: subs,
 	}}
-	return features, additional
+	return features, additionalFeatures
 }
 
 func (r *cloudAzureTenantResource) Schema(
@@ -561,10 +562,19 @@ func (r cloudAzureTenantResource) ModifyPlan(
 		return
 	}
 
-	if !plan.AgentlessScanningSubscriptionIds.IsNull() && !plan.AgentlessScanningSubscriptionIds.IsUnknown() {
+	// ModifyPlan runs twice: once during `terraform plan` and again during `terraform apply` after
+	// upstream resources have been applied. When a value is sourced from another resource's
+	// computed output (e.g. dspm or agentless_scanning_subscription_ids set from
+	// terraform_data.output), it is unknown on the first run and resolved on the second. The
+	// IsUnknown guards skip validation on the first run to avoid false positives; the second run
+	// sees the real values and validates them.
+	if utils.IsKnown(plan.AgentlessScanningSubscriptionIds) && utils.IsKnown(plan.DSPM) {
 		var dspm dspmModel
 		resp.Diagnostics.Append(dspm.FromObject(ctx, plan.DSPM)...)
-		if !resp.Diagnostics.HasError() && !dspm.Enabled.IsUnknown() && !dspm.Enabled.ValueBool() {
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		if utils.IsKnown(dspm.Enabled) && !dspm.Enabled.ValueBool() {
 			resp.Diagnostics.Append(diag.NewAttributeErrorDiagnostic(
 				path.Root("agentless_scanning_subscription_ids"),
 				"Invalid configuration",
@@ -652,7 +662,7 @@ func (r *cloudAzureTenantResource) createRegistration(
 ) (*models.AzureTenantRegistration, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	features, additional := buildAzureProductConfig(ctx, data, &diags)
+	features, additionalFeatures := buildAzureProductConfig(ctx, data, &diags)
 	if diags.HasError() {
 		return nil, diags
 	}
@@ -676,7 +686,7 @@ func (r *cloudAzureTenantResource) createRegistration(
 				Products: []*models.DomainProductFeatures{
 					{Product: utils.Addr("cspm"), Features: features},
 				},
-				AdditionalFeatures: additional,
+				AdditionalFeatures: additionalFeatures,
 				Tags:               utils.MapTypeAs[string](ctx, data.Tags, &diags),
 			},
 		},
@@ -712,7 +722,7 @@ func (r *cloudAzureTenantResource) updateRegistration(
 ) (*models.AzureTenantRegistration, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	features, additional := buildAzureProductConfig(ctx, data, &diags)
+	features, additionalFeatures := buildAzureProductConfig(ctx, data, &diags)
 	if diags.HasError() {
 		return nil, diags
 	}
@@ -736,7 +746,7 @@ func (r *cloudAzureTenantResource) updateRegistration(
 				Products: []*models.DomainProductFeatures{
 					{Product: utils.Addr("cspm"), Features: features},
 				},
-				AdditionalFeatures: additional,
+				AdditionalFeatures: additionalFeatures,
 				Tags:               utils.MapTypeAs[string](ctx, data.Tags, &diags),
 			},
 		},
@@ -761,10 +771,6 @@ func (r *cloudAzureTenantResource) updateRegistration(
 
 	if params.Body.Resource.MicrosoftGraphPermissionIds == nil {
 		params.Body.Resource.MicrosoftGraphPermissionIds = []string{}
-	}
-
-	if params.Body.Resource.AdditionalFeatures == nil {
-		params.Body.Resource.AdditionalFeatures = []*models.AzureAdditionalFeature{}
 	}
 
 	res, err := r.client.CloudAzureRegistration.CloudRegistrationAzureUpdateRegistration(&params)

--- a/internal/fcs/cloud_azure_tenant_resource.go
+++ b/internal/fcs/cloud_azure_tenant_resource.go
@@ -9,9 +9,11 @@ import (
 	"github.com/crowdstrike/gofalcon/falcon/models"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/config"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/framework/flex"
+	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/framework/validators"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/scopes"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/tferrors"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/utils"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -262,6 +264,12 @@ func (r *cloudAzureTenantResource) Schema(
 				ElementType:         types.StringType,
 				Optional:            true,
 				MarkdownDescription: "Azure subscription IDs where agentless scanning is enabled. These are sent as `additional_features` to the CrowdStrike API.",
+				Validators: []validator.Set{
+					setvalidator.SizeAtLeast(1),
+					setvalidator.ValueStringsAre(
+						validators.StringNotWhitespace(),
+					),
+				},
 			},
 		},
 	}
@@ -502,14 +510,35 @@ func (r cloudAzureTenantResource) ModifyPlan(
 	req resource.ModifyPlanRequest,
 	resp *resource.ModifyPlanResponse,
 ) {
-	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+	if req.Plan.Raw.IsNull() {
 		return
 	}
 
-	var state, plan cloudAzureTenantModel
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	var plan cloudAzureTenantModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
+	if !plan.AgentlessScanningSubscriptionIds.IsNull() {
+		var dspm dspmModel
+		resp.Diagnostics.Append(dspm.FromObject(ctx, plan.DSPM)...)
+		if !resp.Diagnostics.HasError() && !dspm.Enabled.ValueBool() {
+			resp.Diagnostics.Append(diag.NewAttributeErrorDiagnostic(
+				path.Root("agentless_scanning_subscription_ids"),
+				"Invalid configuration",
+				"agentless_scanning_subscription_ids requires dspm to be enabled.",
+			))
+			return
+		}
+	}
+
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	var state cloudAzureTenantModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -603,7 +632,8 @@ func (r *cloudAzureTenantResource) createRegistration(
 	if diags.HasError() {
 		return nil, diags
 	}
-	if dspm.Enabled.ValueBool() {
+	agentlessSubIds := flex.ExpandSetAs[string](ctx, data.AgentlessScanningSubscriptionIds, &diags)
+	if dspm.Enabled.ValueBool() && len(agentlessSubIds) == 0 {
 		cspmProductFeatures.Features = append(cspmProductFeatures.Features, "dspm")
 	}
 
@@ -632,8 +662,7 @@ func (r *cloudAzureTenantResource) createRegistration(
 		Context: ctx,
 	}
 
-	agentlessSubIds := flex.ExpandSetAs[string](ctx, data.AgentlessScanningSubscriptionIds, &diags)
-	if len(agentlessSubIds) > 0 {
+	if len(agentlessSubIds) > 0 && dspm.Enabled.ValueBool() {
 		params.Body.Resource.AdditionalFeatures = []*models.AzureAdditionalFeature{
 			{
 				Feature:         utils.Addr("dspm"),
@@ -693,7 +722,8 @@ func (r *cloudAzureTenantResource) updateRegistration(
 	if diags.HasError() {
 		return nil, diags
 	}
-	if dspm.Enabled.ValueBool() {
+	agentlessSubIds := flex.ExpandSetAs[string](ctx, data.AgentlessScanningSubscriptionIds, &diags)
+	if dspm.Enabled.ValueBool() && len(agentlessSubIds) == 0 {
 		cspmProductFeatures.Features = append(cspmProductFeatures.Features, "dspm")
 	}
 
@@ -722,8 +752,7 @@ func (r *cloudAzureTenantResource) updateRegistration(
 		Context: ctx,
 	}
 
-	agentlessSubIds := flex.ExpandSetAs[string](ctx, data.AgentlessScanningSubscriptionIds, &diags)
-	if len(agentlessSubIds) > 0 {
+	if len(agentlessSubIds) > 0 && dspm.Enabled.ValueBool() {
 		params.Body.Resource.AdditionalFeatures = []*models.AzureAdditionalFeature{
 			{
 				Feature:         utils.Addr("dspm"),

--- a/internal/fcs/cloud_azure_tenant_resource.go
+++ b/internal/fcs/cloud_azure_tenant_resource.go
@@ -137,6 +137,45 @@ func (r *dspmModel) FromObject(ctx context.Context, obj types.Object) diag.Diagn
 	return obj.As(ctx, r, basetypes.ObjectAsOptions{})
 }
 
+func buildAzureProductConfig(
+	ctx context.Context,
+	data *cloudAzureTenantModel,
+	diags *diag.Diagnostics,
+) (features []string, additional []*models.AzureAdditionalFeature) {
+	features = []string{"iom"}
+
+	var rtv realtimeVisibilityModel
+	diags.Append(rtv.FromObject(ctx, data.RealtimeVisibility)...)
+	if diags.HasError() {
+		return features, nil
+	}
+	if rtv.Enabled.ValueBool() {
+		features = append(features, "ioa")
+	}
+
+	var dspm dspmModel
+	diags.Append(dspm.FromObject(ctx, data.DSPM)...)
+	if diags.HasError() {
+		return features, nil
+	}
+	if !dspm.Enabled.ValueBool() {
+		return features, nil
+	}
+
+	subs := flex.ExpandSetAs[string](ctx, data.AgentlessScanningSubscriptionIds, diags)
+	if len(subs) == 0 {
+		features = append(features, "dspm")
+		return features, nil
+	}
+
+	additional = []*models.AzureAdditionalFeature{{
+		Feature:         utils.Addr("dspm"),
+		Product:         utils.Addr("cspm"),
+		SubscriptionIds: subs,
+	}}
+	return features, additional
+}
+
 func (r *cloudAzureTenantResource) Schema(
 	ctx context.Context,
 	req resource.SchemaRequest,
@@ -330,17 +369,19 @@ func (m *cloudAzureTenantModel) wrap(
 		}
 	}
 
+	var agentlessSubIds []string
 	for _, af := range registration.AdditionalFeatures {
 		if af != nil && af.Feature != nil && *af.Feature == "dspm" {
-			if !m.AgentlessScanningSubscriptionIds.IsNull() && len(af.SubscriptionIds) > 0 {
-				hasDSPM = true
-				agentlessSubIds, d := flex.FlattenStringValueSet(ctx, af.SubscriptionIds)
-				diags.Append(d...)
-				m.AgentlessScanningSubscriptionIds = agentlessSubIds
-			}
+			agentlessSubIds = af.SubscriptionIds
 			break
 		}
 	}
+	if len(agentlessSubIds) > 0 {
+		hasDSPM = true
+	}
+	agentlessSet, d := flex.FlattenStringValueSet(ctx, agentlessSubIds)
+	diags.Append(d...)
+	m.AgentlessScanningSubscriptionIds = agentlessSet
 
 	rtv := realtimeVisibilityModel{Enabled: types.BoolValue(hasIOA)}
 	rtvObj, d := rtv.ToObject(ctx)
@@ -520,10 +561,10 @@ func (r cloudAzureTenantResource) ModifyPlan(
 		return
 	}
 
-	if !plan.AgentlessScanningSubscriptionIds.IsNull() {
+	if !plan.AgentlessScanningSubscriptionIds.IsNull() && !plan.AgentlessScanningSubscriptionIds.IsUnknown() {
 		var dspm dspmModel
 		resp.Diagnostics.Append(dspm.FromObject(ctx, plan.DSPM)...)
-		if !resp.Diagnostics.HasError() && !dspm.Enabled.ValueBool() {
+		if !resp.Diagnostics.HasError() && !dspm.Enabled.IsUnknown() && !dspm.Enabled.ValueBool() {
 			resp.Diagnostics.Append(diag.NewAttributeErrorDiagnostic(
 				path.Root("agentless_scanning_subscription_ids"),
 				"Invalid configuration",
@@ -611,30 +652,9 @@ func (r *cloudAzureTenantResource) createRegistration(
 ) (*models.AzureTenantRegistration, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	cspmProductFeatures := models.DomainProductFeatures{
-		Product:  utils.Addr("cspm"),
-		Features: []string{"iom"},
-	}
-
-	// RTV&D
-	var rtv realtimeVisibilityModel
-	diags.Append(rtv.FromObject(ctx, data.RealtimeVisibility)...)
+	features, additional := buildAzureProductConfig(ctx, data, &diags)
 	if diags.HasError() {
 		return nil, diags
-	}
-	if rtv.Enabled.ValueBool() {
-		cspmProductFeatures.Features = append(cspmProductFeatures.Features, "ioa")
-	}
-
-	// DSPM
-	var dspm dspmModel
-	diags.Append(dspm.FromObject(ctx, data.DSPM)...)
-	if diags.HasError() {
-		return nil, diags
-	}
-	agentlessSubIds := flex.ExpandSetAs[string](ctx, data.AgentlessScanningSubscriptionIds, &diags)
-	if dspm.Enabled.ValueBool() && len(agentlessSubIds) == 0 {
-		cspmProductFeatures.Features = append(cspmProductFeatures.Features, "dspm")
 	}
 
 	params := cloud_azure_registration.CloudRegistrationAzureCreateRegistrationParams{
@@ -654,22 +674,13 @@ func (r *cloudAzureTenantResource) createRegistration(
 				ManagementGroupIds:          flex.ExpandSetAs[string](ctx, data.ManagementGroupIds, &diags),
 				MicrosoftGraphPermissionIds: flex.ExpandSetAs[string](ctx, data.MicrosoftGraphPermissionIds, &diags),
 				Products: []*models.DomainProductFeatures{
-					&cspmProductFeatures,
+					{Product: utils.Addr("cspm"), Features: features},
 				},
-				Tags: utils.MapTypeAs[string](ctx, data.Tags, &diags),
+				AdditionalFeatures: additional,
+				Tags:               utils.MapTypeAs[string](ctx, data.Tags, &diags),
 			},
 		},
 		Context: ctx,
-	}
-
-	if len(agentlessSubIds) > 0 && dspm.Enabled.ValueBool() {
-		params.Body.Resource.AdditionalFeatures = []*models.AzureAdditionalFeature{
-			{
-				Feature:         utils.Addr("dspm"),
-				Product:         utils.Addr("cspm"),
-				SubscriptionIds: agentlessSubIds,
-			},
-		}
 	}
 
 	if diags.HasError() {
@@ -701,30 +712,9 @@ func (r *cloudAzureTenantResource) updateRegistration(
 ) (*models.AzureTenantRegistration, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	cspmProductFeatures := models.DomainProductFeatures{
-		Product:  utils.Addr("cspm"),
-		Features: []string{"iom"},
-	}
-
-	// RTV&D
-	var rtv realtimeVisibilityModel
-	diags.Append(rtv.FromObject(ctx, data.RealtimeVisibility)...)
+	features, additional := buildAzureProductConfig(ctx, data, &diags)
 	if diags.HasError() {
 		return nil, diags
-	}
-	if rtv.Enabled.ValueBool() {
-		cspmProductFeatures.Features = append(cspmProductFeatures.Features, "ioa")
-	}
-
-	// DSPM
-	var dspm dspmModel
-	diags.Append(dspm.FromObject(ctx, data.DSPM)...)
-	if diags.HasError() {
-		return nil, diags
-	}
-	agentlessSubIds := flex.ExpandSetAs[string](ctx, data.AgentlessScanningSubscriptionIds, &diags)
-	if dspm.Enabled.ValueBool() && len(agentlessSubIds) == 0 {
-		cspmProductFeatures.Features = append(cspmProductFeatures.Features, "dspm")
 	}
 
 	params := cloud_azure_registration.CloudRegistrationAzureUpdateRegistrationParams{
@@ -744,22 +734,13 @@ func (r *cloudAzureTenantResource) updateRegistration(
 				ManagementGroupIds:          flex.ExpandSetAs[string](ctx, data.ManagementGroupIds, &diags),
 				MicrosoftGraphPermissionIds: flex.ExpandSetAs[string](ctx, data.MicrosoftGraphPermissionIds, &diags),
 				Products: []*models.DomainProductFeatures{
-					&cspmProductFeatures,
+					{Product: utils.Addr("cspm"), Features: features},
 				},
-				Tags: utils.MapTypeAs[string](ctx, data.Tags, &diags),
+				AdditionalFeatures: additional,
+				Tags:               utils.MapTypeAs[string](ctx, data.Tags, &diags),
 			},
 		},
 		Context: ctx,
-	}
-
-	if len(agentlessSubIds) > 0 && dspm.Enabled.ValueBool() {
-		params.Body.Resource.AdditionalFeatures = []*models.AzureAdditionalFeature{
-			{
-				Feature:         utils.Addr("dspm"),
-				Product:         utils.Addr("cspm"),
-				SubscriptionIds: agentlessSubIds,
-			},
-		}
 	}
 
 	if diags.HasError() {
@@ -780,6 +761,10 @@ func (r *cloudAzureTenantResource) updateRegistration(
 
 	if params.Body.Resource.MicrosoftGraphPermissionIds == nil {
 		params.Body.Resource.MicrosoftGraphPermissionIds = []string{}
+	}
+
+	if params.Body.Resource.AdditionalFeatures == nil {
+		params.Body.Resource.AdditionalFeatures = []*models.AzureAdditionalFeature{}
 	}
 
 	res, err := r.client.CloudAzureRegistration.CloudRegistrationAzureUpdateRegistration(&params)

--- a/internal/fcs/cloud_azure_tenant_resource_test.go
+++ b/internal/fcs/cloud_azure_tenant_resource_test.go
@@ -452,7 +452,7 @@ func TestAccCloudAzureTenant_agentlessSubIdsRequiresDSPM(t *testing.T) {
 	})
 }
 
-func TestAccCloudAzureTenant_agentlessSubIdsUnknown(t *testing.T) {
+func TestAccCloudAzureTenant_agentless_UnknownDSPMEnabled(t *testing.T) {
 	tenantID := acctest.RandomUUID()
 	subID1 := acctest.RandomUUID()
 
@@ -482,7 +482,7 @@ func TestAccCloudAzureTenant_agentlessSubIdsUnknown(t *testing.T) {
 	})
 }
 
-func TestAccCloudAzureTenant_agentlessSubIdsUnknownIDs(t *testing.T) {
+func TestAccCloudAzureTenant_agentless_UnknownSubIds(t *testing.T) {
 	tenantID := acctest.RandomUUID()
 	subID1 := acctest.RandomUUID()
 
@@ -508,7 +508,7 @@ func TestAccCloudAzureTenant_agentlessSubIdsUnknownIDs(t *testing.T) {
 	})
 }
 
-func TestAccCloudAzureTenant_agentlessSubIdsUnknownDSPMObject(t *testing.T) {
+func TestAccCloudAzureTenant_agentless_UnknownDSPMObject(t *testing.T) {
 	tenantID := acctest.RandomUUID()
 	subID1 := acctest.RandomUUID()
 

--- a/internal/fcs/cloud_azure_tenant_resource_test.go
+++ b/internal/fcs/cloud_azure_tenant_resource_test.go
@@ -422,6 +422,22 @@ func TestAccCloudAzureTenant_agentlessScanningSubscriptionIdsTenantWide(t *testi
 	})
 }
 
+func TestAccCloudAzureTenant_agentlessSubIdsRequiresDSPM(t *testing.T) {
+	tenantID := acctest.RandomUUID()
+	subID1 := acctest.RandomUUID()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCloudAzureTenantConfig_agentlessSubIdsNoDSPM(tenantID, subID1),
+				ExpectError: regexp.MustCompile("agentless_scanning_subscription_ids requires dspm to be enabled"),
+			},
+		},
+	})
+}
+
 // Config helpers
 
 func testAccCloudAzureTenantConfig_basic(tenantID string) string {
@@ -566,4 +582,13 @@ resource "crowdstrike_cloud_azure_tenant" "test" {
     enabled = true
   }
 }`, tenantID, userReadAllPermissionID, subID1, subID2)
+}
+
+func testAccCloudAzureTenantConfig_agentlessSubIdsNoDSPM(tenantID, subID string) string {
+	return fmt.Sprintf(`
+resource "crowdstrike_cloud_azure_tenant" "test" {
+  tenant_id                              = %[1]q
+  microsoft_graph_permission_ids         = [%[2]q]
+  agentless_scanning_subscription_ids    = [%[3]q]
+}`, tenantID, userReadAllPermissionID, subID)
 }

--- a/internal/fcs/cloud_azure_tenant_resource_test.go
+++ b/internal/fcs/cloud_azure_tenant_resource_test.go
@@ -452,6 +452,88 @@ func TestAccCloudAzureTenant_agentlessSubIdsRequiresDSPM(t *testing.T) {
 	})
 }
 
+func TestAccCloudAzureTenant_agentlessSubIdsUnknown(t *testing.T) {
+	tenantID := acctest.RandomUUID()
+	subID1 := acctest.RandomUUID()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudAzureTenantConfig_agentlessSubIdsUnknownDSPM(tenantID, subID1, true),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("tenant_id"), knownvalue.StringExact(tenantID)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("dspm").AtMapKey("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("agentless_scanning_subscription_ids"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact(subID1),
+					})),
+				},
+			},
+			{
+				Config:      testAccCloudAzureTenantConfig_agentlessSubIdsUnknownDSPM(tenantID, subID1, false),
+				ExpectError: regexp.MustCompile("agentless_scanning_subscription_ids requires dspm to be enabled"),
+			},
+			{
+				Config:      testAccCloudAzureTenantConfig_agentlessSubIdsNoDSPM(tenantID, subID1),
+				ExpectError: regexp.MustCompile("agentless_scanning_subscription_ids requires dspm to be enabled"),
+			},
+		},
+	})
+}
+
+func TestAccCloudAzureTenant_agentlessSubIdsUnknownIDs(t *testing.T) {
+	tenantID := acctest.RandomUUID()
+	subID1 := acctest.RandomUUID()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudAzureTenantConfig_unknownAgentlessSubIds(tenantID, subID1, true),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("tenant_id"), knownvalue.StringExact(tenantID)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("dspm").AtMapKey("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("agentless_scanning_subscription_ids"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact(subID1),
+					})),
+				},
+			},
+			{
+				Config:      testAccCloudAzureTenantConfig_unknownAgentlessSubIds(tenantID, subID1, false),
+				ExpectError: regexp.MustCompile("agentless_scanning_subscription_ids requires dspm to be enabled"),
+			},
+		},
+	})
+}
+
+func TestAccCloudAzureTenant_agentlessSubIdsUnknownDSPMObject(t *testing.T) {
+	tenantID := acctest.RandomUUID()
+	subID1 := acctest.RandomUUID()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudAzureTenantConfig_unknownDSPMObject(tenantID, subID1, true),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("tenant_id"), knownvalue.StringExact(tenantID)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("dspm").AtMapKey("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("agentless_scanning_subscription_ids"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact(subID1),
+					})),
+				},
+			},
+			{
+				Config:      testAccCloudAzureTenantConfig_unknownDSPMObject(tenantID, subID1, false),
+				ExpectError: regexp.MustCompile("agentless_scanning_subscription_ids requires dspm to be enabled"),
+			},
+		},
+	})
+}
+
 func TestAccCloudAzureTenant_agentlessSubIdsShapeTransitions(t *testing.T) {
 	tenantID := acctest.RandomUUID()
 	subID1 := acctest.RandomUUID()
@@ -668,4 +750,52 @@ resource "crowdstrike_cloud_azure_tenant" "test" {
   microsoft_graph_permission_ids         = [%[2]q]
   agentless_scanning_subscription_ids    = [%[3]q]
 }`, tenantID, userReadAllPermissionID, subID)
+}
+
+func testAccCloudAzureTenantConfig_agentlessSubIdsUnknownDSPM(tenantID, subID string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "terraform_data" "dspm_flag" {
+  input = %[4]t
+}
+
+resource "crowdstrike_cloud_azure_tenant" "test" {
+  tenant_id                           = %[1]q
+  microsoft_graph_permission_ids      = [%[2]q]
+  agentless_scanning_subscription_ids = [%[3]q]
+  dspm = {
+    enabled = tobool(terraform_data.dspm_flag.output)
+  }
+}`, tenantID, userReadAllPermissionID, subID, enabled)
+}
+
+func testAccCloudAzureTenantConfig_unknownAgentlessSubIds(tenantID, subID string, dspmEnabled bool) string {
+	return fmt.Sprintf(`
+resource "terraform_data" "sub_id" {
+  input = %[3]q
+}
+
+resource "crowdstrike_cloud_azure_tenant" "test" {
+  tenant_id                           = %[1]q
+  microsoft_graph_permission_ids      = [%[2]q]
+  agentless_scanning_subscription_ids = [tostring(terraform_data.sub_id.output)]
+  dspm = {
+    enabled = %[4]t
+  }
+}`, tenantID, userReadAllPermissionID, subID, dspmEnabled)
+}
+
+func testAccCloudAzureTenantConfig_unknownDSPMObject(tenantID, subID string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "terraform_data" "dspm_obj" {
+  input = {
+    enabled = %[4]t
+  }
+}
+
+resource "crowdstrike_cloud_azure_tenant" "test" {
+  tenant_id                           = %[1]q
+  microsoft_graph_permission_ids      = [%[2]q]
+  agentless_scanning_subscription_ids = [%[3]q]
+  dspm                                = terraform_data.dspm_obj.output
+}`, tenantID, userReadAllPermissionID, subID, enabled)
 }

--- a/internal/fcs/cloud_azure_tenant_resource_test.go
+++ b/internal/fcs/cloud_azure_tenant_resource_test.go
@@ -317,6 +317,111 @@ func TestAccCloudAzureTenant_emptyGraphPermissions(t *testing.T) {
 	})
 }
 
+func TestAccCloudAzureTenant_agentlessScanningSubscriptionIds(t *testing.T) {
+	tenantID := acctest.RandomUUID()
+	mgID := acctest.RandomUUID()
+	subID1 := acctest.RandomUUID()
+	subID2 := acctest.RandomUUID()
+	subID3 := acctest.RandomUUID()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudAzureTenantConfig_withManagementGroup(tenantID, mgID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("tenant_id"), knownvalue.StringExact(tenantID)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("management_group_ids"), knownvalue.SetExact([]knownvalue.Check{knownvalue.StringExact(mgID)})),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("dspm").AtMapKey("enabled"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("agentless_scanning_subscription_ids"), knownvalue.Null()),
+				},
+			},
+			{
+				Config: testAccCloudAzureTenantConfig_withAgentlessSubIds(tenantID, mgID, subID1, subID2),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("tenant_id"), knownvalue.StringExact(tenantID)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("management_group_ids"), knownvalue.SetExact([]knownvalue.Check{knownvalue.StringExact(mgID)})),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("dspm").AtMapKey("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("agentless_scanning_subscription_ids"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact(subID1),
+						knownvalue.StringExact(subID2),
+					})),
+				},
+			},
+			{
+				Config: testAccCloudAzureTenantConfig_withAgentlessSubIds(tenantID, mgID, subID2, subID3),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("dspm").AtMapKey("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("agentless_scanning_subscription_ids"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact(subID2),
+						knownvalue.StringExact(subID3),
+					})),
+				},
+			},
+			{
+				Config: testAccCloudAzureTenantConfig_withManagementGroup(tenantID, mgID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("tenant_id"), knownvalue.StringExact(tenantID)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("dspm").AtMapKey("enabled"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("agentless_scanning_subscription_ids"), knownvalue.Null()),
+				},
+			},
+		},
+	})
+}
+
+func TestAccCloudAzureTenant_agentlessScanningSubscriptionIdsTenantWide(t *testing.T) {
+	tenantID := acctest.RandomUUID()
+	subID1 := acctest.RandomUUID()
+	subID2 := acctest.RandomUUID()
+	subID3 := acctest.RandomUUID()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudAzureTenantConfig_basic(tenantID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("tenant_id"), knownvalue.StringExact(tenantID)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("dspm").AtMapKey("enabled"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("agentless_scanning_subscription_ids"), knownvalue.Null()),
+				},
+			},
+			{
+				Config: testAccCloudAzureTenantConfig_tenantWideWithAgentlessSubIds(tenantID, subID1, subID2),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("tenant_id"), knownvalue.StringExact(tenantID)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("dspm").AtMapKey("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("agentless_scanning_subscription_ids"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact(subID1),
+						knownvalue.StringExact(subID2),
+					})),
+				},
+			},
+			{
+				Config: testAccCloudAzureTenantConfig_tenantWideWithAgentlessSubIds(tenantID, subID2, subID3),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("dspm").AtMapKey("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("agentless_scanning_subscription_ids"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact(subID2),
+						knownvalue.StringExact(subID3),
+					})),
+				},
+			},
+			{
+				Config: testAccCloudAzureTenantConfig_basic(tenantID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("tenant_id"), knownvalue.StringExact(tenantID)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("dspm").AtMapKey("enabled"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("agentless_scanning_subscription_ids"), knownvalue.Null()),
+				},
+			},
+		},
+	})
+}
+
 // Config helpers
 
 func testAccCloudAzureTenantConfig_basic(tenantID string) string {
@@ -436,4 +541,29 @@ resource "crowdstrike_cloud_azure_tenant" "test" {
   tenant_id                      = %[1]q
   microsoft_graph_permission_ids = []
 }`, tenantID)
+}
+
+func testAccCloudAzureTenantConfig_withAgentlessSubIds(tenantID, mgID, subID1, subID2 string) string {
+	return fmt.Sprintf(`
+resource "crowdstrike_cloud_azure_tenant" "test" {
+  tenant_id                              = %[1]q
+  microsoft_graph_permission_ids         = [%[2]q]
+  management_group_ids                   = [%[3]q]
+  agentless_scanning_subscription_ids    = [%[4]q, %[5]q]
+  dspm = {
+    enabled = true
+  }
+}`, tenantID, userReadAllPermissionID, mgID, subID1, subID2)
+}
+
+func testAccCloudAzureTenantConfig_tenantWideWithAgentlessSubIds(tenantID, subID1, subID2 string) string {
+	return fmt.Sprintf(`
+resource "crowdstrike_cloud_azure_tenant" "test" {
+  tenant_id                              = %[1]q
+  microsoft_graph_permission_ids         = [%[2]q]
+  agentless_scanning_subscription_ids    = [%[3]q, %[4]q]
+  dspm = {
+    enabled = true
+  }
+}`, tenantID, userReadAllPermissionID, subID1, subID2)
 }

--- a/internal/fcs/cloud_azure_tenant_resource_test.go
+++ b/internal/fcs/cloud_azure_tenant_resource_test.go
@@ -360,6 +360,13 @@ func TestAccCloudAzureTenant_agentlessScanningSubscriptionIds(t *testing.T) {
 				},
 			},
 			{
+				ResourceName:                         cloudAzureTenantResourceName,
+				ImportState:                          true,
+				ImportStateId:                        tenantID,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "tenant_id",
+			},
+			{
 				Config: testAccCloudAzureTenantConfig_withManagementGroup(tenantID, mgID),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("tenant_id"), knownvalue.StringExact(tenantID)),
@@ -411,6 +418,13 @@ func TestAccCloudAzureTenant_agentlessScanningSubscriptionIdsTenantWide(t *testi
 				},
 			},
 			{
+				ResourceName:                         cloudAzureTenantResourceName,
+				ImportState:                          true,
+				ImportStateId:                        tenantID,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "tenant_id",
+			},
+			{
 				Config: testAccCloudAzureTenantConfig_basic(tenantID),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("tenant_id"), knownvalue.StringExact(tenantID)),
@@ -433,6 +447,69 @@ func TestAccCloudAzureTenant_agentlessSubIdsRequiresDSPM(t *testing.T) {
 			{
 				Config:      testAccCloudAzureTenantConfig_agentlessSubIdsNoDSPM(tenantID, subID1),
 				ExpectError: regexp.MustCompile("agentless_scanning_subscription_ids requires dspm to be enabled"),
+			},
+		},
+	})
+}
+
+func TestAccCloudAzureTenant_agentlessSubIdsShapeTransitions(t *testing.T) {
+	tenantID := acctest.RandomUUID()
+	subID1 := acctest.RandomUUID()
+	subID2 := acctest.RandomUUID()
+
+	importStep := resource.TestStep{
+		ResourceName:                         cloudAzureTenantResourceName,
+		ImportState:                          true,
+		ImportStateId:                        tenantID,
+		ImportStateVerify:                    true,
+		ImportStateVerifyIdentifierAttribute: "tenant_id",
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudAzureTenantConfig_basic(tenantID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("tenant_id"), knownvalue.StringExact(tenantID)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("dspm").AtMapKey("enabled"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("agentless_scanning_subscription_ids"), knownvalue.Null()),
+				},
+			},
+			{
+				Config: testAccCloudAzureTenantConfig_dspmEnabled(tenantID, true),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("dspm").AtMapKey("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("agentless_scanning_subscription_ids"), knownvalue.Null()),
+				},
+			},
+			importStep,
+			{
+				Config: testAccCloudAzureTenantConfig_tenantWideWithAgentlessSubIds(tenantID, subID1, subID2),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("dspm").AtMapKey("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("agentless_scanning_subscription_ids"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact(subID1),
+						knownvalue.StringExact(subID2),
+					})),
+				},
+			},
+			importStep,
+			{
+				Config: testAccCloudAzureTenantConfig_dspmEnabled(tenantID, true),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("dspm").AtMapKey("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("agentless_scanning_subscription_ids"), knownvalue.Null()),
+				},
+			},
+			importStep,
+			{
+				Config: testAccCloudAzureTenantConfig_basic(tenantID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("dspm").AtMapKey("enabled"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("agentless_scanning_subscription_ids"), knownvalue.Null()),
+				},
 			},
 		},
 	})


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                            
                                                            
  - Add optional `agentless_scanning_subscription_ids` (Set of String) attribute to `crowdstrike_cloud_azure_tenant`                                                                                                                    
  - Send subscription IDs as `additional_features` to the CrowdStrike API on Create and Update
  - Fix `dspm.enabled` reading from `additional_features` when subscription-scoped DSPM is configured                                                                                                                                   
                                                                                                                                                                                                                                        
  ## Context                                                                                                                                                                                                                            
                                                                                                                                                                                                                                        
  When using tenant-wide registration with limited DSPM subscriptions (`agentless_scanning_locations_per_subscription`), the API stores DSPM in `additional_features` rather than `products.features`. This caused:                     
  1. Provider couldn't pass subscription IDs to the API
  2. `dspm.enabled` was incorrectly `false` after apply → "inconsistent result" error                                                                                                                                                   
                                                                                                                                                                                                                                        
  ## Changes                                                                                                                                                                                                                            
                                                                                                                                                                                                                                        
  | File | Change |                                                                                                                                                                                                                     
  |------|--------|                                         
  | `internal/fcs/cloud_azure_tenant_resource.go` | Add field to model, schema, Create, Update, and `wrap()` |                                                                                                                          
  | `docs/resources/cloud_azure_tenant.md` | Auto-generated |                                                                                                                                                                           
                                                                                                                                                                                                                                        
  ## Backward Compatibility                                                                                                                                                                                                             
                                                                                                                                                                                                                                        
  Attribute is optional — omitting it sends no `additional_features`. Existing configs unchanged.                                                                                                                                       
                                                            
  ## Test plan                                                                                                                                                                                                                      
                                                            
  - [V] `terraform apply` with `agentless_scanning_subscription_ids` set (tenant-wide scenario)                                                                                                                                         
  - [V] `terraform apply` without the attribute (regression)
  - [V] Verify `dspm.enabled` reads correctly from `additional_features` response                                                                                                                                                       
  - [V] Verify `terraform destroy` cleans up properly 