### PR TITLE
fix(ioa_rule_group): use correct API label for ICMP connection type

### DIFF
--- a/internal/ioa_rule_group/ioa_rule_group_resource.go
+++ b/internal/ioa_rule_group/ioa_rule_group_resource.go
@@ -176,7 +176,7 @@ var fileTypeLabelMap = map[string]string{
 }
 
 var connectionTypeLabelMap = map[string]string{
-	"ICMP": "ICMP",
+	"ICMP": "ICMP (Ping)",
 	"TCP":  "TCP",
 	"UDP":  "UDP",
 }

--- a/internal/ioa_rule_group/ioa_rule_group_resource_test.go
+++ b/internal/ioa_rule_group/ioa_rule_group_resource_test.go
@@ -388,6 +388,7 @@ func TestAccIOARuleGroupResource_NetworkConnection(t *testing.T) {
 									"exclude": knownvalue.Null(),
 								}),
 								"connection_type": knownvalue.SetExact([]knownvalue.Check{
+									knownvalue.StringExact("ICMP"),
 									knownvalue.StringExact("TCP"),
 									knownvalue.StringExact("UDP"),
 								}),
@@ -908,7 +909,7 @@ resource "crowdstrike_ioa_rule_group" "test" {
         include = ".*"
       }
 
-      connection_type = ["TCP", "UDP"]
+      connection_type = ["ICMP", "TCP", "UDP"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

The API expects `connection_type` ICMP to be sent with label `"ICMP (Ping)"` and value `"ICMP"`, but the provider was sending label `"ICMP"`, causing apply to fail with `item label not found or value invalid` when users specified `"ICMP"` in `connection_type`.

Updated `connectionTypeLabelMap` so the outbound `DomainValueItem` uses the API-expected label. The schema validator and the value read back from the API are unchanged, so user configuration stays `"ICMP"` with no drift.

Extended `TestAccIOARuleGroupResource_NetworkConnection` to cover ICMP, which reproduces the reported failure without the fix.

Fixes #362

## Test plan

- [x] Without fix + ICMP in test: acc test fails with the exact error from #362 (`item label not found... want=[{Label:ICMP (Ping) Value:ICMP}], got={Label:ICMP Value:ICMP}`)
- [x] With fix + ICMP in test: `PKG=ioa_rule_group TESTARGS="-run TestAccIOARuleGroupResource_NetworkConnection" make acctest` passes