### PR TITLE
fix(cloud_security_suppression_rule): treat same-instant RFC3339 timestamps as equal

### DIFF
--- a/internal/cloud_security/suppression_rule_resource.go
+++ b/internal/cloud_security/suppression_rule_resource.go
@@ -17,7 +17,6 @@ import (
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/scopes"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/tferrors"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/utils"
-	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
@@ -64,15 +63,15 @@ type cloudSecuritySuppressionRuleResource struct {
 }
 
 type cloudSecuritySuppressionRuleResourceModel struct {
-	ID                  types.String      `tfsdk:"id"`
-	Type                types.String      `tfsdk:"type"`
-	Description         types.String      `tfsdk:"description"`
-	Name                types.String      `tfsdk:"name"`
-	RuleSelectionFilter types.Object      `tfsdk:"rule_selection_filter"`
-	AssetFilter         types.Object      `tfsdk:"asset_filter"`
-	Comment             types.String      `tfsdk:"comment"`
-	ExpirationDate      timetypes.RFC3339 `tfsdk:"expiration_date"`
-	Reason              types.String      `tfsdk:"reason"`
+	ID                  types.String    `tfsdk:"id"`
+	Type                types.String    `tfsdk:"type"`
+	Description         types.String    `tfsdk:"description"`
+	Name                types.String    `tfsdk:"name"`
+	RuleSelectionFilter types.Object    `tfsdk:"rule_selection_filter"`
+	AssetFilter         types.Object    `tfsdk:"asset_filter"`
+	Comment             types.String    `tfsdk:"comment"`
+	ExpirationDate      fwtypes.RFC3339 `tfsdk:"expiration_date"`
+	Reason              types.String    `tfsdk:"reason"`
 }
 
 type ruleSelectionFilterModel struct {
@@ -210,7 +209,7 @@ func (r *cloudSecuritySuppressionRuleResource) Schema(
 				},
 			},
 			"expiration_date": schema.StringAttribute{
-				CustomType:          timetypes.RFC3339Type{},
+				CustomType:          fwtypes.RFC3339Type{},
 				MarkdownDescription: "Expiration date for suppression. If defined, must be in RFC3339 format (e.g., `2025-08-11T10:00:00Z`). Once set, clearing this field requires resource replacement. The suppression rule will still exist after expiration and can be reset by updating the expiration date.",
 				Optional:            true,
 				Validators: []validator.String{
@@ -222,7 +221,7 @@ func (r *cloudSecuritySuppressionRuleResource) Schema(
 							return
 						}
 
-						var stateValue timetypes.RFC3339
+						var stateValue fwtypes.RFC3339
 						diags := req.State.GetAttribute(ctx, req.Path, &stateValue)
 						if diags.HasError() {
 							return
@@ -515,7 +514,7 @@ func (r *cloudSecuritySuppressionRuleResource) Update(
 	if plan.ExpirationDate.Equal(state.ExpirationDate) {
 		// Don't send expiration date to API if it hasn't changed, even if it's expired.
 		// A warning for the expired date is already in Read()
-		plan.ExpirationDate = timetypes.NewRFC3339Null()
+		plan.ExpirationDate = fwtypes.NewRFC3339Null()
 	}
 
 	rule, diags := r.updateSuppressionRule(ctx, plan)
@@ -577,7 +576,7 @@ func (r *cloudSecuritySuppressionRuleResource) ModifyPlan(
 	}
 }
 
-func isTimestampExpired(timestampStr timetypes.RFC3339) (bool, diag.Diagnostics) {
+func isTimestampExpired(timestampStr fwtypes.RFC3339) (bool, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	timestamp, err := timestampStr.ValueRFC3339Time()
@@ -796,9 +795,16 @@ func (m *cloudSecuritySuppressionRuleResourceModel) wrap(
 	m.Reason = flex.StringPointerToFramework(rule.SuppressionReason)
 	m.Type = flex.StringPointerToFramework(rule.Subdomain)
 
-	m.ExpirationDate, diags = flex.RFC3339ValueToFramework(rule.SuppressionExpirationDate)
-	if diags.HasError() {
-		return diags
+	// TODO: replace with flex.RFC3339ValueToFramework once the helper is updated
+	// to return fwtypes.RFC3339 and other call sites (e.g. install_token) are
+	// migrated to the fwtypes fork.
+	if rule.SuppressionExpirationDate == "" {
+		m.ExpirationDate = fwtypes.NewRFC3339Null()
+	} else {
+		m.ExpirationDate, diags = fwtypes.NewRFC3339Value(rule.SuppressionExpirationDate)
+		if diags.HasError() {
+			return diags
+		}
 	}
 
 	diags.Append(m.setRuleSelectionFilter(ctx, rule)...)

--- a/internal/cloud_security/suppression_rule_resource_test.go
+++ b/internal/cloud_security/suppression_rule_resource_test.go
@@ -9,7 +9,10 @@ import (
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/acctest"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 func TestCloudSecuritySuppressionRuleResource_Basic(t *testing.T) {
@@ -1725,4 +1728,56 @@ resource "crowdstrike_cloud_security_suppression_rule" "whitespace_tag_value_tes
   }
 }
 `, suffix)
+}
+
+// TestCloudSecuritySuppressionRuleResource_ExpirationDateNonUTCOffset is a
+// regression test for https://github.com/CrowdStrike/terraform-provider-crowdstrike/issues/328.
+//
+// The API normalizes suppression_expiration_date to UTC on the server side, so
+// a configuration value like "2026-07-01T00:00:00+10:00" is returned as
+// "2026-06-30T14:00:00Z" on subsequent reads. Because timetypes.RFC3339 only
+// treats "Z" and "+00:00" as semantically equal, Terraform's post-apply check
+// fails with "produced an unexpected new value" even though both strings
+// represent the same instant.
+func TestCloudSecuritySuppressionRuleResource_ExpirationDateNonUTCOffset(t *testing.T) {
+	randomSuffix := sdkacctest.RandString(8)
+	resourceName := "crowdstrike_cloud_security_suppression_rule.nonutc_expiration_test"
+
+	future := time.Now().Add(30 * 24 * time.Hour).In(time.FixedZone("AEST", 10*60*60))
+	expirationDate := future.Format("2006-01-02T15:04:05-07:00")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testSuppressionRuleNonUTCExpirationConfig(randomSuffix, expirationDate),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("expiration_date"), knownvalue.StringExact(expirationDate)),
+				},
+			},
+		},
+	})
+}
+
+func testSuppressionRuleNonUTCExpirationConfig(suffix, expirationDate string) string {
+	return fmt.Sprintf(`
+resource "crowdstrike_cloud_security_suppression_rule" "nonutc_expiration_test" {
+  name            = "TF Test NonUTC Expiration %[1]s"
+  type            = "IOM"
+  description     = "Regression test for issue #328 - non-UTC timezone offset"
+  reason          = "false-positive"
+  expiration_date = %[2]q
+
+  rule_selection_filter = {
+    names = ["Test Rule with NonUTC Expiration"]
+  }
+
+  asset_filter = {
+    cloud_providers = ["aws"]
+    regions         = ["us-east-1"]
+  }
+}
+`, suffix, expirationDate)
 }

--- a/internal/framework/types/rfc3339.go
+++ b/internal/framework/types/rfc3339.go
@@ -1,0 +1,310 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+// This file is derived from github.com/hashicorp/terraform-plugin-framework-timetypes
+// and modified so that RFC 3339 timestamps which resolve to the same instant in
+// time are treated as semantically equal regardless of timezone offset.
+
+// Package types provides custom Terraform framework types for this provider.
+package types
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/attr/xattr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/function"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var (
+	_ basetypes.StringTypable        = (*RFC3339Type)(nil)
+	_ basetypes.StringValuable       = (*RFC3339)(nil)
+	_ xattr.ValidateableAttribute    = (*RFC3339)(nil)
+	_ function.ValidateableParameter = (*RFC3339)(nil)
+)
+
+// RFC3339Type is an attribute type that represents a valid RFC 3339 string. Semantic equality logic is defined
+// for RFC3339Type such that two RFC 3339 strings are considered equal when they resolve to the same instant in
+// time, regardless of timezone offset.
+type RFC3339Type struct {
+	basetypes.StringType
+}
+
+// String returns a human-readable string of the type name.
+func (t RFC3339Type) String() string {
+	return "types.RFC3339Type"
+}
+
+// ValueType returns the Value type.
+func (t RFC3339Type) ValueType(ctx context.Context) attr.Value {
+	return RFC3339{}
+}
+
+// Equal returns true if the given type is equivalent.
+func (t RFC3339Type) Equal(o attr.Type) bool {
+	other, ok := o.(RFC3339Type)
+
+	if !ok {
+		return false
+	}
+
+	return t.StringType.Equal(other.StringType)
+}
+
+// ValueFromString returns a StringValuable type given a StringValue.
+func (t RFC3339Type) ValueFromString(ctx context.Context, in basetypes.StringValue) (basetypes.StringValuable, diag.Diagnostics) {
+	return RFC3339{
+		StringValue: in,
+	}, nil
+}
+
+// ValueFromTerraform returns a Value given a tftypes.Value.  This is meant to convert the tftypes.Value into a more convenient Go type
+// for the provider to consume the data with.
+func (t RFC3339Type) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.StringType.ValueFromTerraform(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+
+	stringValue, ok := attrValue.(basetypes.StringValue)
+
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	stringValuable, diags := t.ValueFromString(ctx, stringValue)
+
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting StringValue to StringValuable: %v", diags)
+	}
+
+	return stringValuable, nil
+}
+
+// RFC3339 represents a valid RFC3339-formatted string. Semantic equality logic is defined for RFC3339
+// such that two RFC 3339 strings are considered equal when they resolve to the same instant in time,
+// regardless of timezone offset.
+type RFC3339 struct {
+	basetypes.StringValue
+}
+
+// Type returns an RFC3339Type.
+func (v RFC3339) Type(_ context.Context) attr.Type {
+	return RFC3339Type{}
+}
+
+// Equal returns true if the given value is equivalent.
+func (v RFC3339) Equal(o attr.Value) bool {
+	other, ok := o.(RFC3339)
+
+	if !ok {
+		return false
+	}
+
+	return v.StringValue.Equal(other.StringValue)
+}
+
+// StringSemanticEquals returns true if the given RFC3339 string value is semantically equal to the current RFC3339 string value.
+// This comparison utilizes time.Parse to create time.Time instances and then compares them with time.Time.Equal, which compares
+// the underlying instant in time regardless of the timezone offset. This means two RFC 3339 strings that resolve to the same
+// instant are considered semantically equal even if they use different offsets.
+//
+// Examples:
+//   - `2023-07-25T20:43:16+00:00` is semantically equal to `2023-07-25T20:43:16Z`
+//   - `2023-07-25T23:43:16Z` is semantically equal to `2023-07-25T20:43:16-03:00` (same instant, different offsets)
+//   - `2023-07-25T20:43:16-00:00` is semantically equal to `2023-07-25T20:43:16Z`
+//
+// Counterexamples:
+//   - `2023-07-25T23:43:16Z` is NOT semantically equal to `2023-07-26T23:43:16Z` (different instants)
+//
+// See RFC 3339 for more details on the string format: https://www.rfc-editor.org/rfc/rfc3339.html.
+func (v RFC3339) StringSemanticEquals(_ context.Context, newValuable basetypes.StringValuable) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	newValue, ok := newValuable.(RFC3339)
+	if !ok {
+		diags.AddError(
+			"Semantic Equality Check Error",
+			"An unexpected value type was received while performing semantic equality checks. "+
+				"Please report this to the provider developers.\n\n"+
+				"Expected Value Type: "+fmt.Sprintf("%T", v)+"\n"+
+				"Got Value Type: "+fmt.Sprintf("%T", newValuable),
+		)
+
+		return false, diags
+	}
+
+	// RFC3339 strings are already validated at this point, ignoring errors
+	newRFC3339time, _ := time.Parse(time.RFC3339, newValue.ValueString())
+	currentRFC3339time, _ := time.Parse(time.RFC3339, v.ValueString())
+
+	return currentRFC3339time.Equal(newRFC3339time), diags
+}
+
+// ValidateAttribute implements attribute value validation. This type requires the value to be a String value that
+// is valid RFC 3339 format. This utilizes the Go `time` library which does not strictly adhere to the RFC 3339
+// standard and may allow strings that are not valid RFC 3339 strings
+//
+// See https://github.com/golang/go/issues/54580 for more info on the Go `time` library's RFC 3339 parsing differences.
+func (v RFC3339) ValidateAttribute(ctx context.Context, req xattr.ValidateAttributeRequest, resp *xattr.ValidateAttributeResponse) {
+	if v.IsUnknown() || v.IsNull() {
+		return
+	}
+
+	if _, err := time.Parse(time.RFC3339, v.ValueString()); err != nil {
+		resp.Diagnostics.Append(diag.WithPath(req.Path, rfc3339InvalidStringDiagnostic(v.ValueString(), err)))
+
+		return
+	}
+}
+
+// ValidateParameter implements provider-defined function parameter value validation. This type requires the value to
+// be a String value that is valid RFC 3339 format. This utilizes the Go `time` library which does not strictly
+// adhere to the RFC 3339 standard and may allow strings that are not valid RFC 3339 strings
+//
+// See https://github.com/golang/go/issues/54580 for more info on the Go `time` library's RFC 3339 parsing differences.
+func (v RFC3339) ValidateParameter(ctx context.Context, req function.ValidateParameterRequest, resp *function.ValidateParameterResponse) {
+	if v.IsUnknown() || v.IsNull() {
+		return
+	}
+
+	if _, err := time.Parse(time.RFC3339, v.ValueString()); err != nil {
+		resp.Error = function.NewArgumentFuncError(
+			req.Position,
+			"Invalid RFC3339 String Value: "+
+				"A string value was provided that is not valid RFC3339 string format.\n\n"+
+				"Given Value: "+v.ValueString()+"\n"+
+				"Error: "+err.Error(),
+		)
+
+		return
+	}
+}
+
+// ValueRFC3339Time creates a new time.Time instance with the RFC3339 StringValue. A null or unknown value will produce an error diagnostic.
+func (v RFC3339) ValueRFC3339Time() (time.Time, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if v.IsNull() {
+		diags.Append(diag.NewErrorDiagnostic("RFC3339 ValueRFC3339Time Error", "RFC3339 string value is null"))
+		return time.Time{}, diags
+	}
+
+	if v.IsUnknown() {
+		diags.Append(diag.NewErrorDiagnostic("RFC3339 ValueRFC3339Time Error", "RFC3339 string value is unknown"))
+		return time.Time{}, diags
+	}
+
+	rfc3339Time, err := time.Parse(time.RFC3339, v.ValueString())
+	if err != nil {
+		diags.Append(diag.NewErrorDiagnostic("RFC3339 ValueRFC3339Time Error", err.Error()))
+		return time.Time{}, diags
+	}
+
+	return rfc3339Time, nil
+}
+
+// NewRFC3339Null creates an RFC3339 with a null value. Determine whether the value is null via IsNull method.
+func NewRFC3339Null() RFC3339 {
+	return RFC3339{
+		StringValue: basetypes.NewStringNull(),
+	}
+}
+
+// NewRFC3339Unknown creates an RFC3339 with an unknown value. Determine whether the value is unknown via IsUnknown method.
+func NewRFC3339Unknown() RFC3339 {
+	return RFC3339{
+		StringValue: basetypes.NewStringUnknown(),
+	}
+}
+
+// NewRFC3339TimeValue creates an RFC3339 with a known value.
+func NewRFC3339TimeValue(value time.Time) RFC3339 {
+	return RFC3339{
+		StringValue: basetypes.NewStringValue(value.Format(time.RFC3339)),
+	}
+}
+
+// NewRFC3339TimePointerValue creates an RFC3339 with a null value if nil or
+// a known value.
+func NewRFC3339TimePointerValue(value *time.Time) RFC3339 {
+	if value == nil {
+		return NewRFC3339Null()
+	}
+
+	return RFC3339{
+		StringValue: basetypes.NewStringValue(value.Format(time.RFC3339)),
+	}
+}
+
+// NewRFC3339Value creates an RFC3339 with a known value or raises an error
+// diagnostic if the string is not RFC3339 format.
+func NewRFC3339Value(value string) (RFC3339, diag.Diagnostics) {
+	_, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		// Returning an unknown value will guarantee that, as a last resort,
+		// Terraform will return an error if attempting to store into state.
+		return NewRFC3339Unknown(), diag.Diagnostics{rfc3339InvalidStringDiagnostic(value, err)}
+	}
+
+	return RFC3339{
+		StringValue: basetypes.NewStringValue(value),
+	}, nil
+}
+
+// NewRFC3339ValueMust creates an RFC3339 with a known value or raises a panic
+// if the string is not RFC3339 format.
+//
+// This creation function is only recommended to create RFC3339 values which
+// either will not potentially affect practitioners, such as testing, or within
+// exhaustively tested provider logic.
+func NewRFC3339ValueMust(value string) RFC3339 {
+	_, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		panic(fmt.Sprintf("Invalid RFC3339 String Value (%s): %s", value, err))
+	}
+
+	return RFC3339{
+		StringValue: basetypes.NewStringValue(value),
+	}
+}
+
+// NewRFC3339PointerValue creates an RFC3339 with a null value if nil, a known
+// value, or raises an error diagnostic if the string is not RFC3339 format.
+func NewRFC3339PointerValue(value *string) (RFC3339, diag.Diagnostics) {
+	if value == nil {
+		return NewRFC3339Null(), nil
+	}
+
+	return NewRFC3339Value(*value)
+}
+
+// NewRFC3339PointerValueMust creates an RFC3339 with a null value if nil, a
+// known value, or raises a panic if the string is not RFC3339 format.
+//
+// This creation function is only recommended to create RFC3339 values which
+// either will not potentially affect practitioners, such as testing, or within
+// exhaustively tested provider logic.
+func NewRFC3339PointerValueMust(value *string) RFC3339 {
+	if value == nil {
+		return NewRFC3339Null()
+	}
+
+	return NewRFC3339ValueMust(*value)
+}
+
+// rfc3339InvalidStringDiagnostic returns an error diagnostic intended to report
+// when a string is not RFC3339 format.
+func rfc3339InvalidStringDiagnostic(value string, err error) diag.Diagnostic {
+	return diag.NewErrorDiagnostic(
+		"Invalid RFC3339 String Value",
+		"A string value was provided that is not valid RFC3339 string format.\n\n"+
+			"Given Value: "+value+"\n"+
+			"Error: "+err.Error(),
+	)
+}

--- a/internal/framework/types/rfc3339_type_test.go
+++ b/internal/framework/types/rfc3339_type_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+// This file is derived from github.com/hashicorp/terraform-plugin-framework-timetypes.
+
+package types_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	fwtypes "github.com/crowdstrike/terraform-provider-crowdstrike/internal/framework/types"
+)
+
+func TestRFC3339TypeValueFromTerraform(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in          tftypes.Value
+		expectation attr.Value
+		expectedErr string
+	}{
+		"true": {
+			in:          tftypes.NewValue(tftypes.String, "2023-07-25T20:43:16+00:00"),
+			expectation: fwtypes.NewRFC3339ValueMust("2023-07-25T20:43:16+00:00"),
+		},
+		"unknown": {
+			in:          tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+			expectation: fwtypes.NewRFC3339Unknown(),
+		},
+		"null": {
+			in:          tftypes.NewValue(tftypes.String, nil),
+			expectation: fwtypes.NewRFC3339Null(),
+		},
+		"wrongType": {
+			in:          tftypes.NewValue(tftypes.Number, 123),
+			expectedErr: "can't unmarshal tftypes.Number into *string, expected string",
+		},
+	}
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			got, err := fwtypes.RFC3339Type{}.ValueFromTerraform(ctx, testCase.in)
+			if err != nil {
+				if testCase.expectedErr == "" {
+					t.Fatalf("Unexpected error: %s", err)
+				}
+				if testCase.expectedErr != err.Error() {
+					t.Fatalf("Expected error to be %q, got %q", testCase.expectedErr, err.Error())
+				}
+				return
+			}
+			if err == nil && testCase.expectedErr != "" {
+				t.Fatalf("Expected error to be %q, didn't get an error", testCase.expectedErr)
+			}
+			if !got.Equal(testCase.expectation) {
+				t.Errorf("Expected %+v, got %+v", testCase.expectation, got)
+			}
+			if testCase.expectation.IsNull() != testCase.in.IsNull() {
+				t.Errorf("Expected null-ness match: expected %t, got %t", testCase.expectation.IsNull(), testCase.in.IsNull())
+			}
+			if testCase.expectation.IsUnknown() != !testCase.in.IsKnown() {
+				t.Errorf("Expected unknown-ness match: expected %t, got %t", testCase.expectation.IsUnknown(), !testCase.in.IsKnown())
+			}
+		})
+	}
+}

--- a/internal/framework/types/rfc3339_value_test.go
+++ b/internal/framework/types/rfc3339_value_test.go
@@ -1,0 +1,356 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+// This file is derived from github.com/hashicorp/terraform-plugin-framework-timetypes.
+
+package types_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr/xattr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/function"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+
+	fwtypes "github.com/crowdstrike/terraform-provider-crowdstrike/internal/framework/types"
+)
+
+func TestRFC3339_StringSemanticEquals(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		currentRFC3339time fwtypes.RFC3339
+		givenRFC3339time   basetypes.StringValuable
+		expectedMatch      bool
+		expectedDiags      diag.Diagnostics
+	}{
+		"not equal - different dates": {
+			currentRFC3339time: fwtypes.NewRFC3339ValueMust("2023-07-25T23:43:16Z"),
+			givenRFC3339time:   fwtypes.NewRFC3339ValueMust("2023-07-26T23:43:16Z"),
+			expectedMatch:      false,
+		},
+		"not equal - different times": {
+			currentRFC3339time: fwtypes.NewRFC3339ValueMust("2023-07-25T23:43:16Z"),
+			givenRFC3339time:   fwtypes.NewRFC3339ValueMust("2023-07-25T23:01:16Z"),
+			expectedMatch:      false,
+		},
+		"not equal - different offset times": {
+			currentRFC3339time: fwtypes.NewRFC3339ValueMust("2023-07-25T23:43:16Z"),
+			givenRFC3339time:   fwtypes.NewRFC3339ValueMust("2023-07-25T23:43:16+03:00"),
+			expectedMatch:      false,
+		},
+		"semantically equal - UTC time and local time resolving to same instant": {
+			currentRFC3339time: fwtypes.NewRFC3339ValueMust("2023-07-25T23:43:16Z"),
+			givenRFC3339time:   fwtypes.NewRFC3339ValueMust("2023-07-25T20:43:16-03:00"),
+			expectedMatch:      true,
+		},
+		"semantically equal - Z suffix and positive zero num offset": {
+			currentRFC3339time: fwtypes.NewRFC3339ValueMust("2023-07-25T23:43:16Z"),
+			givenRFC3339time:   fwtypes.NewRFC3339ValueMust("2023-07-25T23:43:16+00:00"),
+			expectedMatch:      true,
+		},
+		"semantically equal - Z suffix and negative zero num offset": {
+			currentRFC3339time: fwtypes.NewRFC3339ValueMust("2023-07-25T23:43:16Z"),
+			givenRFC3339time:   fwtypes.NewRFC3339ValueMust("2023-07-25T23:43:16-00:00"),
+			expectedMatch:      true,
+		},
+		"semantically equal - negative zero and positive zero num offset": {
+			currentRFC3339time: fwtypes.NewRFC3339ValueMust("2023-07-25T23:43:16-00:00"),
+			givenRFC3339time:   fwtypes.NewRFC3339ValueMust("2023-07-25T23:43:16+00:00"),
+			expectedMatch:      true,
+		},
+		"semantically equal - byte for byte match": {
+			currentRFC3339time: fwtypes.NewRFC3339ValueMust("2023-07-25T23:43:16Z"),
+			givenRFC3339time:   fwtypes.NewRFC3339ValueMust("2023-07-25T23:43:16Z"),
+			expectedMatch:      true,
+		},
+		"semantically equal - positive offset and UTC resolving to same instant": {
+			currentRFC3339time: fwtypes.NewRFC3339ValueMust("2026-07-01T00:00:00+10:00"),
+			givenRFC3339time:   fwtypes.NewRFC3339ValueMust("2026-06-30T14:00:00Z"),
+			expectedMatch:      true,
+		},
+		"semantically equal - negative offset and UTC resolving to same instant": {
+			currentRFC3339time: fwtypes.NewRFC3339ValueMust("2026-01-15T12:00:00-05:00"),
+			givenRFC3339time:   fwtypes.NewRFC3339ValueMust("2026-01-15T17:00:00Z"),
+			expectedMatch:      true,
+		},
+		"not equal - same wall clock, different offsets": {
+			currentRFC3339time: fwtypes.NewRFC3339ValueMust("2026-07-01T00:00:00+10:00"),
+			givenRFC3339time:   fwtypes.NewRFC3339ValueMust("2026-07-01T00:00:00Z"),
+			expectedMatch:      false,
+		},
+		"error - not given RFC3339 value": {
+			currentRFC3339time: fwtypes.NewRFC3339ValueMust("2023-07-25T23:43:16Z"),
+			givenRFC3339time:   basetypes.NewStringValue("0000-00-00T00:00:00-00:00"),
+			expectedMatch:      false,
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Semantic Equality Check Error",
+					"An unexpected value type was received while performing semantic equality checks. "+
+						"Please report this to the provider developers.\n\n"+
+						"Expected Value Type: types.RFC3339\n"+
+						"Got Value Type: basetypes.StringValue",
+				),
+			},
+		},
+	}
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			match, diags := testCase.currentRFC3339time.StringSemanticEquals(context.Background(), testCase.givenRFC3339time)
+
+			if testCase.expectedMatch != match {
+				t.Errorf("Expected StringSemanticEquals to return: %t, but got: %t", testCase.expectedMatch, match)
+			}
+
+			if diff := cmp.Diff(diags, testCase.expectedDiags); diff != "" {
+				t.Errorf("Unexpected diagnostics (-got, +expected): %s", diff)
+			}
+		})
+	}
+}
+
+func TestRFC3339ValidateAttribute(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		RFC3339       fwtypes.RFC3339
+		expectedDiags diag.Diagnostics
+	}{
+		"empty-struct": {
+			RFC3339: fwtypes.RFC3339{},
+		},
+		"null": {
+			RFC3339: fwtypes.NewRFC3339Null(),
+		},
+		"unknown": {
+			RFC3339: fwtypes.NewRFC3339Unknown(),
+		},
+		"valid RFC3339": {
+			RFC3339: fwtypes.NewRFC3339ValueMust("2023-07-25T20:43:16+00:00"),
+		},
+		"valid RFC3339 - Zulu": {
+			RFC3339: fwtypes.NewRFC3339ValueMust("2023-07-25T20:43:16Z"),
+		},
+		"valid RFC3339 - UTC Offset": {
+			RFC3339: fwtypes.NewRFC3339ValueMust("2023-07-25T20:43:16-05:00"),
+		},
+		"invalid RFC3339 - no date": {
+			RFC3339: fwtypes.RFC3339{
+				StringValue: basetypes.NewStringValue("20:43:16-05:00"),
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Invalid RFC3339 String Value",
+					"A string value was provided that is not valid RFC3339 string format.\n\n"+
+						"Given Value: 20:43:16-05:00\n"+
+						"Error: parsing time \"20:43:16-05:00\" as \"2006-01-02T15:04:05Z07:00\": "+
+						"cannot parse \"20:43:16-05:00\" as \"2006\"",
+				),
+			},
+		},
+		"invalid RFC3339 - no time": {
+			RFC3339: fwtypes.RFC3339{
+				StringValue: basetypes.NewStringValue("2023-07-25T"),
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Invalid RFC3339 String Value",
+					"A string value was provided that is not valid RFC3339 string format.\n\n"+
+						"Given Value: 2023-07-25T\n"+
+						"Error: parsing time \"2023-07-25T\" as \"2006-01-02T15:04:05Z07:00\": "+
+						"cannot parse \"\" as \"15\"",
+				),
+			},
+		},
+		"invalid RFC3339 - normal string": {
+			RFC3339: fwtypes.RFC3339{
+				StringValue: basetypes.NewStringValue("notvalidrfc3339"),
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Invalid RFC3339 String Value",
+					"A string value was provided that is not valid RFC3339 string format.\n\n"+
+						"Given Value: notvalidrfc3339\n"+
+						"Error: parsing time \"notvalidrfc3339\" as \"2006-01-02T15:04:05Z07:00\": "+
+						"cannot parse \"notvalidrfc3339\" as \"2006\"",
+				),
+			},
+		},
+	}
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			resp := xattr.ValidateAttributeResponse{}
+
+			testCase.RFC3339.ValidateAttribute(
+				context.Background(),
+				xattr.ValidateAttributeRequest{
+					Path: path.Root("test"),
+				},
+				&resp,
+			)
+
+			if diff := cmp.Diff(resp.Diagnostics, testCase.expectedDiags); diff != "" {
+				t.Errorf("Unexpected diagnostics (-got, +expected): %s", diff)
+			}
+		})
+	}
+}
+
+func TestRFC3339ValidateParameter(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		RFC3339         fwtypes.RFC3339
+		expectedFuncErr *function.FuncError
+	}{
+		"empty-struct": {
+			RFC3339: fwtypes.RFC3339{},
+		},
+		"null": {
+			RFC3339: fwtypes.NewRFC3339Null(),
+		},
+		"unknown": {
+			RFC3339: fwtypes.NewRFC3339Unknown(),
+		},
+		"valid RFC3339": {
+			RFC3339: fwtypes.NewRFC3339ValueMust("2023-07-25T20:43:16+00:00"),
+		},
+		"valid RFC3339 - Zulu": {
+			RFC3339: fwtypes.NewRFC3339ValueMust("2023-07-25T20:43:16Z"),
+		},
+		"valid RFC3339 - UTC Offset": {
+			RFC3339: fwtypes.NewRFC3339ValueMust("2023-07-25T20:43:16-05:00"),
+		},
+		"invalid RFC3339 - no date": {
+			RFC3339: fwtypes.RFC3339{
+				StringValue: basetypes.NewStringValue("20:43:16-05:00"),
+			},
+			expectedFuncErr: function.NewArgumentFuncError(
+				0,
+				"Invalid RFC3339 String Value: "+
+					"A string value was provided that is not valid RFC3339 string format.\n\n"+
+					"Given Value: 20:43:16-05:00\n"+
+					"Error: parsing time \"20:43:16-05:00\" as \"2006-01-02T15:04:05Z07:00\": "+
+					"cannot parse \"20:43:16-05:00\" as \"2006\"",
+			),
+		},
+		"invalid RFC3339 - no time": {
+			RFC3339: fwtypes.RFC3339{
+				StringValue: basetypes.NewStringValue("2023-07-25T"),
+			},
+			expectedFuncErr: function.NewArgumentFuncError(
+				0,
+				"Invalid RFC3339 String Value: "+
+					"A string value was provided that is not valid RFC3339 string format.\n\n"+
+					"Given Value: 2023-07-25T\n"+
+					"Error: parsing time \"2023-07-25T\" as \"2006-01-02T15:04:05Z07:00\": "+
+					"cannot parse \"\" as \"15\"",
+			),
+		},
+		"invalid RFC3339 - normal string": {
+			RFC3339: fwtypes.RFC3339{
+				StringValue: basetypes.NewStringValue("notvalidrfc3339"),
+			},
+			expectedFuncErr: function.NewArgumentFuncError(
+				0,
+				"Invalid RFC3339 String Value: "+
+					"A string value was provided that is not valid RFC3339 string format.\n\n"+
+					"Given Value: notvalidrfc3339\n"+
+					"Error: parsing time \"notvalidrfc3339\" as \"2006-01-02T15:04:05Z07:00\": "+
+					"cannot parse \"notvalidrfc3339\" as \"2006\"",
+			),
+		},
+	}
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			resp := function.ValidateParameterResponse{}
+
+			testCase.RFC3339.ValidateParameter(
+				context.Background(),
+				function.ValidateParameterRequest{
+					Position: int64(0),
+				},
+				&resp,
+			)
+
+			if diff := cmp.Diff(resp.Error, testCase.expectedFuncErr); diff != "" {
+				t.Errorf("Unexpected diagnostics (-got, +expected): %s", diff)
+			}
+		})
+	}
+}
+
+func TestRFC3339_ValueRFC3339Time(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		RFC3339           fwtypes.RFC3339
+		expectedTimestamp string
+		expectedDiags     diag.Diagnostics
+	}{
+		"RFC3339 string value is null ": {
+			RFC3339: fwtypes.NewRFC3339Null(),
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"RFC3339 ValueRFC3339Time Error",
+					"RFC3339 string value is null",
+				),
+			},
+		},
+		"RFC3339 string value is unknown ": {
+			RFC3339: fwtypes.NewRFC3339Unknown(),
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"RFC3339 ValueRFC3339Time Error",
+					"RFC3339 string value is unknown",
+				),
+			},
+		},
+		"valid RFC3339 Timestamp - Zulu suffix": {
+			RFC3339:           fwtypes.NewRFC3339ValueMust("2023-07-25T23:43:16Z"),
+			expectedTimestamp: "2023-07-25T23:43:16Z",
+		},
+		"valid RFC3339 Timestamp - UTC offset ": {
+			RFC3339:           fwtypes.NewRFC3339ValueMust("2023-07-25T23:43:16-00:00"),
+			expectedTimestamp: "2023-07-25T23:43:16-00:00",
+		},
+		"valid RFC3339 Timestamp - EDT offset ": {
+			RFC3339:           fwtypes.NewRFC3339ValueMust("2023-07-25T23:43:16-04:00"),
+			expectedTimestamp: "2023-07-25T23:43:16-04:00",
+		},
+	}
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			rfc3339Time, diags := testCase.RFC3339.ValueRFC3339Time()
+			expectedRFC3339Time, _ := time.Parse(time.RFC3339, testCase.expectedTimestamp)
+
+			if rfc3339Time != expectedRFC3339Time {
+				t.Errorf("Unexpected difference in time.Time, got: %s, expected: %s", rfc3339Time, expectedRFC3339Time)
+			}
+
+			if diff := cmp.Diff(diags, testCase.expectedDiags); diff != "" {
+				t.Errorf("Unexpected diagnostics (-got, +expected): %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #328. The CrowdStrike API normalizes suppression expiration dates to UTC, causing "inconsistent result after apply" errors when users supply non-UTC offsets (e.g. `+10:00`). Upstream `timetypes.RFC3339` only treats `Z` vs `+00:00` as semantically equal, so the plan/state comparison fails even though the two timestamps refer to the same instant.

- Forks `timetypes.RFC3339` into `internal/framework/types/rfc3339.go` (kept as a 1-to-1 copy of upstream with MPL attribution; only `StringSemanticEquals` is changed to compare via `time.Time.Equal`).
- Copies upstream's unit tests into `internal/framework/types/rfc3339_type_test.go` and `internal/framework/types/rfc3339_value_test.go`, flipping the one case that previously asserted "not equal" for same-instant-different-offset timestamps and adding three new cases covering the regression.
- Wires `crowdstrike_cloud_security_suppression_rule.expiration_date` to the forked type. A TODO notes that the inline empty-string handling should be replaced with `flex.RFC3339ValueToFramework` once that helper and other call sites (e.g. `install_token`) migrate to `fwtypes.RFC3339`.