### PR TITLE
fix(cloud_aws_account): accept 'cft' as deployment_method value

### DIFF
--- a/docs/resources/cloud_aws_account.md
+++ b/docs/resources/cloud_aws_account.md
@@ -72,7 +72,7 @@ resource "crowdstrike_cloud_aws_account" "org" {
 
 - `account_type` (String) The AWS account type. Value is 'commercial' for Commercial cloud accounts. For GovCloud environments, value can be either 'commercial' or 'gov' depending on the account type
 - `asset_inventory` (Attributes) (see [below for nested schema](#nestedatt--asset_inventory))
-- `deployment_method` (String) How the account was deployed. Valid values are 'terraform-native' and 'terraform-cft'
+- `deployment_method` (String) How the account was deployed. Valid values are 'terraform-native', 'terraform-cft', and 'cft'. This value cannot be changed after the account is created.
 - `dspm` (Attributes) (see [below for nested schema](#nestedatt--dspm))
 - `idp` (Attributes) (see [below for nested schema](#nestedatt--idp))
 - `organization_id` (String) The AWS Organization ID (starts with `o-`). When specified, accounts within the organization will be registered. If `target_ous` is empty, all accounts in the organization will be registered. The `account_id` must be the organization's management account ID.

--- a/internal/fcs/cloud_aws_account.go
+++ b/internal/fcs/cloud_aws_account.go
@@ -247,16 +247,20 @@ func (r *cloudAWSAccountResource) Schema(
 					stringvalidator.OneOf("commercial", "gov"),
 				},
 			},
+			// TODO: deprecate deployment_method. The API does not allow changing this
+			// value after creation, which forces awkward import/drift handling for
+			// callers. Future direction: remove this attribute or replace it with a
+			// read-only computed field.
 			"deployment_method": schema.StringAttribute{
 				Optional:    true,
 				Default:     stringdefault.StaticString("terraform-native"),
 				Computed:    true,
-				Description: "How the account was deployed. Valid values are 'terraform-native' and 'terraform-cft'",
+				Description: "How the account was deployed. Valid values are 'terraform-native', 'terraform-cft', and 'cft'. This value cannot be changed after the account is created.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 				Validators: []validator.String{
-					stringvalidator.OneOf("terraform-native", "terraform-cft"),
+					stringvalidator.OneOf("terraform-native", "terraform-cft", "cft"),
 				},
 			},
 			"asset_inventory": schema.SingleNestedAttribute{


### PR DESCRIPTION
Customers importing older AWS registrations with deployment_method "cft"
hit inconsistent-result-after-apply errors because the validator only
allowed "terraform-native" and "terraform-cft", and the API does not
permit changing this value on update. Adding "cft" lets those imports
round-trip cleanly and prevents drift.

Also clarify in the description that the value cannot be changed after
creation, and add a TODO noting this attribute should likely be
deprecated.