### PR TITLE
fix(cloud_azure_tenant): preserve empty string for cs_infra fields

### DIFF
--- a/internal/fcs/cloud_azure_tenant_resource.go
+++ b/internal/fcs/cloud_azure_tenant_resource.go
@@ -294,8 +294,19 @@ func (m *cloudAzureTenantModel) wrap(
 	m.TenantId = types.StringValue(*registration.TenantID)
 	m.AppRegistrationId = types.StringValue(registration.AppRegistrationID)
 	m.AccountType = types.StringValue(registration.AccountType)
-	m.CsInfraRegion = types.StringPointerValue(registration.CsInfraRegion)
-	m.CsInfraSubscriptionId = types.StringPointerValue(registration.CsInfraSubscriptionID)
+
+	csInfraRegion := types.StringPointerValue(registration.CsInfraRegion)
+	if csInfraRegion.IsNull() && !m.CsInfraRegion.IsNull() {
+		csInfraRegion = types.StringValue("")
+	}
+	m.CsInfraRegion = csInfraRegion
+
+	csInfraSubscriptionId := types.StringPointerValue(registration.CsInfraSubscriptionID)
+	if csInfraSubscriptionId.IsNull() && !m.CsInfraSubscriptionId.IsNull() {
+		csInfraSubscriptionId = types.StringValue("")
+	}
+	m.CsInfraSubscriptionId = csInfraSubscriptionId
+
 	m.Environment = types.StringPointerValue(registration.Environment)
 	m.ResourceNamePrefix = types.StringPointerValue(registration.ResourceNamePrefix)
 	m.ResourceNameSuffix = types.StringPointerValue(registration.ResourceNameSuffix)

--- a/internal/fcs/cloud_azure_tenant_resource_test.go
+++ b/internal/fcs/cloud_azure_tenant_resource_test.go
@@ -235,6 +235,43 @@ func TestAccCloudAzureTenant_environment(t *testing.T) {
 	})
 }
 
+func TestAccCloudAzureTenant_csInfra(t *testing.T) {
+	tenantID := acctest.RandomUUID()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudAzureTenantConfig_csInfra(tenantID, "", ""),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("tenant_id"), knownvalue.StringExact(tenantID)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("cs_infra_subscription_id"), knownvalue.StringExact("")),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("cs_infra_location"), knownvalue.StringExact("")),
+				},
+			},
+			{
+				Config: testAccCloudAzureTenantConfig_csInfra(tenantID, tenantID, "westus"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("tenant_id"), knownvalue.StringExact(tenantID)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("cs_infra_subscription_id"), knownvalue.StringExact(tenantID)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("cs_infra_location"), knownvalue.StringExact("westus")),
+				},
+			},
+			// TODO: API silently ignores empty-string clears for cs_infra_subscription_id
+			// and cs_infra_location, so unsetting after set is not currently supported.
+			// {
+			// 	Config: testAccCloudAzureTenantConfig_basic(tenantID),
+			// 	ConfigStateChecks: []statecheck.StateCheck{
+			// 		statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("tenant_id"), knownvalue.StringExact(tenantID)),
+			// 		statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("cs_infra_subscription_id"), knownvalue.Null()),
+			// 		statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("cs_infra_location"), knownvalue.Null()),
+			// 	},
+			// },
+		},
+	})
+}
+
 func TestAccCloudAzureTenant_realtimeVisibility(t *testing.T) {
 	tenantID := acctest.RandomUUID()
 
@@ -406,6 +443,16 @@ resource "crowdstrike_cloud_azure_tenant" "test" {
   microsoft_graph_permission_ids = [%[2]q]
   environment                    = %[3]q
 }`, tenantID, userReadAllPermissionID, env)
+}
+
+func testAccCloudAzureTenantConfig_csInfra(tenantID, csInfraSubscriptionID, csInfraLocation string) string {
+	return fmt.Sprintf(`
+resource "crowdstrike_cloud_azure_tenant" "test" {
+  tenant_id                      = %[1]q
+  microsoft_graph_permission_ids = [%[2]q]
+  cs_infra_subscription_id       = %[3]q
+  cs_infra_location              = %[4]q
+}`, tenantID, userReadAllPermissionID, csInfraSubscriptionID, csInfraLocation)
 }
 
 func testAccCloudAzureTenantConfig_rtvEnabled(tenantID string, enabled bool) string {


### PR DESCRIPTION
Fixes #398. The `wrap` method on `cloudAzureTenantModel` converted nil API pointers into null Terraform values, producing `was cty.StringVal(""), but now null` plan-after-apply errors when `cs_infra_subscription_id` or `cs_infra_region` were configured as empty strings.