### PR TITLE
fix(ioa_rule_group): accept windows ruletype_id 5 on read

### DIFF
--- a/internal/ioa_rule_group/ioa_rule_group_resource.go
+++ b/internal/ioa_rule_group/ioa_rule_group_resource.go
@@ -86,6 +86,21 @@ var ruleTypeIDMap = map[string]map[string]string{
 
 var ruleTypeNameMap = invertNestedMap(ruleTypeIDMap)
 
+// ruleTypeReadAliasMap holds additional Falcon API rule-type IDs that should
+// fold into the same Terraform `type` enum value on read. The write path is
+// unaffected: rules created by the provider use the canonical IDs in
+// ruleTypeIDMap. Some Falcon-side rules (typically created outside the
+// provider or under earlier API versions) carry these alias IDs, and the
+// resource must accept them on read/import without erroring.
+var ruleTypeReadAliasMap = map[string]map[string]string{
+	"Windows": {
+		// Some Windows Process Creation rules return id "5" (the canonical
+		// write-side id is "1"); see CrowdStrike/terraform-provider-crowdstrike
+		// upstream issue for details.
+		"5": "Process Creation",
+	},
+}
+
 var dispositionMap = map[string]int32{
 	"Monitor":      10,
 	"Detect":       20,
@@ -637,7 +652,12 @@ func wrapRules(
 			if nameMap, ok := ruleTypeNameMap[platform]; ok {
 				if name, found := nameMap[*apiRule.RuletypeID]; found {
 					ruleTypeName = name
-				} else {
+				} else if aliasMap, ok := ruleTypeReadAliasMap[platform]; ok {
+					if name, found := aliasMap[*apiRule.RuletypeID]; found {
+						ruleTypeName = name
+					}
+				}
+				if ruleTypeName == "" {
 					diags.AddError(
 						"Unknown rule type ID",
 						fmt.Sprintf("Rule type ID %q for platform %q is not recognized by this provider version.", *apiRule.RuletypeID, platform),

--- a/internal/ioa_rule_group/ioa_rule_group_test.go
+++ b/internal/ioa_rule_group/ioa_rule_group_test.go
@@ -162,3 +162,73 @@ func TestConvertIOARuleGroupToList(t *testing.T) {
 		})
 	}
 }
+
+func TestWrapRulesRuleTypeIDLookup(t *testing.T) {
+	int32Ptr := func(v int32) *int32 { return &v }
+
+	tests := []struct {
+		name       string
+		platform   string
+		ruletypeID string
+		wantType   string
+		wantErr    bool
+	}{
+		{
+			name:       "windows canonical id 1 resolves to Process Creation",
+			platform:   "Windows",
+			ruletypeID: "1",
+			wantType:   "Process Creation",
+		},
+		{
+			name:       "windows alias id 5 resolves to Process Creation",
+			platform:   "Windows",
+			ruletypeID: "5",
+			wantType:   "Process Creation",
+		},
+		{
+			name:       "windows unknown id errors",
+			platform:   "Windows",
+			ruletypeID: "99",
+			wantErr:    true,
+		},
+		{
+			name:       "mac canonical id 5 resolves to Process Creation",
+			platform:   "Mac",
+			ruletypeID: "5",
+			wantType:   "Process Creation",
+		},
+		{
+			name:       "linux canonical id 12 resolves to Process Creation",
+			platform:   "Linux",
+			ruletypeID: "12",
+			wantType:   "Process Creation",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			apiRules := []*models.APIRuleV1{
+				{
+					RuletypeID:    strPtr(tt.ruletypeID),
+					DispositionID: int32Ptr(dispositionMap["Monitor"]),
+				},
+			}
+
+			result, diags := wrapRules(t.Context(), apiRules, tt.platform, nil)
+
+			if tt.wantErr {
+				assert.True(t, diags.HasError(), "expected error for %s/%s", tt.platform, tt.ruletypeID)
+				return
+			}
+
+			assert.False(t, diags.HasError(), "unexpected diags: %v", diags)
+			assert.Len(t, result.Elements(), 1)
+
+			obj, ok := result.Elements()[0].(types.Object)
+			assert.True(t, ok, "rule element should be types.Object")
+			typeAttr, ok := obj.Attributes()["type"].(types.String)
+			assert.True(t, ok, "type attribute should be types.String")
+			assert.Equal(t, tt.wantType, typeAttr.ValueString())
+		})
+	}
+}


### PR DESCRIPTION
Closes #400.

Adds a read-side alias map (`ruleTypeReadAliasMap`) so multiple Falcon API rule-type IDs can collapse to one Terraform `type` enum value on read. Concrete case: Windows Process Creation rules created outside the provider can carry `ruletype_id = "5"` (the provider writes `"1"`); the read path previously errored with "Unknown rule type ID" on `terraform plan` / `import`.

Write path is unchanged — `ruleTypeIDMap` still owns one canonical API ID per Terraform `type`, and the schema `OneOf` validator at `ioa_rule_group_resource.go:502` still pins users to the four canonical type names. The alias map only affects round-trip on read/import/refresh.

Tested with `go test ./...` (all packages pass). Did not run `make acctest` — requires `FALCON_CLIENT_ID` / `FALCON_CLIENT_SECRET`.

See #400 for the original error text, repro, and a more general "type → list of API ids" shape that could replace this if more aliases turn up across platforms. This PR keeps the change minimal and scoped to the observed Windows/5 case.
