### PR TITLE
fix(compliance_custom_framework): use UseNonNullStateForUnknown for control id

### DIFF
--- a/internal/cloud_compliance/custom_framework_resource.go
+++ b/internal/cloud_compliance/custom_framework_resource.go
@@ -183,7 +183,7 @@ func (r *cloudComplianceCustomFrameworkResource) Schema(
 										Computed:            true,
 										MarkdownDescription: "Identifier for the compliance framework control.",
 										PlanModifiers: []planmodifier.String{
-											stringplanmodifier.UseStateForUnknown(),
+											stringplanmodifier.UseNonNullStateForUnknown(),
 										},
 									},
 									"name": schema.StringAttribute{

--- a/internal/cloud_compliance/custom_framework_resource_test.go
+++ b/internal/cloud_compliance/custom_framework_resource_test.go
@@ -823,6 +823,15 @@ func TestAccCloudComplianceCustomFrameworkResource_ComprehensiveCRUD(t *testing.
 							customFrameworkResourceName,
 							plancheck.ResourceActionUpdate,
 						),
+						// Verify new control IDs are unknown (not null) in plan - reproduces SUPPORT-50542
+						plancheck.ExpectUnknownValue(
+							customFrameworkResourceName,
+							tfjsonpath.New("sections").AtMapKey("section-1").AtMapKey("controls").AtMapKey("control-1.1").AtMapKey("id"),
+						),
+						plancheck.ExpectUnknownValue(
+							customFrameworkResourceName,
+							tfjsonpath.New("sections").AtMapKey("section-1").AtMapKey("controls").AtMapKey("control-1.2").AtMapKey("id"),
+						),
 					},
 				},
 				Check: addSectionConfig.TestChecks(),
@@ -840,6 +849,19 @@ func TestAccCloudComplianceCustomFrameworkResource_ComprehensiveCRUD(t *testing.
 							customFrameworkResourceName,
 							tfjsonpath.New("sections").AtMapKey("section-1").AtMapKey("controls").AtMapKey("control-1.2").AtMapKey("id"),
 							knownvalue.NotNull(),
+						),
+						// Verify new control IDs are unknown (not null) in plan
+						plancheck.ExpectUnknownValue(
+							customFrameworkResourceName,
+							tfjsonpath.New("sections").AtMapKey("section-1").AtMapKey("controls").AtMapKey("control-1.3").AtMapKey("id"),
+						),
+						plancheck.ExpectUnknownValue(
+							customFrameworkResourceName,
+							tfjsonpath.New("sections").AtMapKey("section-2").AtMapKey("controls").AtMapKey("control-2.1").AtMapKey("id"),
+						),
+						plancheck.ExpectUnknownValue(
+							customFrameworkResourceName,
+							tfjsonpath.New("sections").AtMapKey("section-2").AtMapKey("controls").AtMapKey("control-2.2").AtMapKey("id"),
 						),
 					},
 				},

--- a/internal/cloud_compliance/custom_framework_resource_test.go
+++ b/internal/cloud_compliance/custom_framework_resource_test.go
@@ -1010,3 +1010,60 @@ func TestAccCloudComplianceCustomFrameworkResource_EmptySectionsValidation(t *te
 		},
 	})
 }
+
+// verifies that adding a new control to an existing framework plans the control's id as unknown (not null)
+// and does not cause "Provider produced inconsistent result after apply" error on apply.
+func TestAccCloudComplianceCustomFrameworkResource_NewControlIDUnknown(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	initialConfig := completeFrameworkConfig{
+		Name:        rName,
+		Description: "Framework to test new control ID is unknown in plan",
+		Sections: map[string]sectionConfig{
+			"section-1": {
+				Name: "Section 1",
+				Controls: map[string]controlConfig{
+					"existing-control": {
+						Name:        "Existing Control",
+						Description: "Control that exists from the start",
+					},
+				},
+			},
+		},
+	}
+
+	addControlConfig := completeFrameworkConfig{
+		Name:        rName,
+		Description: "Framework to test new control ID is unknown in plan",
+		Sections: map[string]sectionConfig{
+			"section-1": {
+				Name: "Section 1",
+				Controls: map[string]controlConfig{
+					"existing-control": {
+						Name:        "Existing Control",
+						Description: "Control that exists from the start",
+					},
+					"new-control": {
+						Name:        "New Control",
+						Description: "Control added after initial creation",
+					},
+				},
+			},
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderConfig + initialConfig.String(),
+				Check:  initialConfig.TestChecks(),
+			},
+			{
+				Config: acctest.ProviderConfig + addControlConfig.String(),
+				Check:  addControlConfig.TestChecks(),
+			},
+		},
+	})
+}

--- a/internal/cloud_compliance/custom_framework_resource_test.go
+++ b/internal/cloud_compliance/custom_framework_resource_test.go
@@ -823,7 +823,7 @@ func TestAccCloudComplianceCustomFrameworkResource_ComprehensiveCRUD(t *testing.
 							customFrameworkResourceName,
 							plancheck.ResourceActionUpdate,
 						),
-						// Verify new control IDs are unknown (not null) in plan - reproduces SUPPORT-50542
+						// Verify new control IDs are unknown (not null) in plan
 						plancheck.ExpectUnknownValue(
 							customFrameworkResourceName,
 							tfjsonpath.New("sections").AtMapKey("section-1").AtMapKey("controls").AtMapKey("control-1.1").AtMapKey("id"),


### PR DESCRIPTION
When a crowdstrike_cloud_compliance_custom_framework resource already exists in state with sections and controls, adding a new control fails with `"Provider produced inconsistent result after apply"`. The control's id is null in the plan but receives a UUID after apply.

### Root Cause
The controls[*].id attribute uses UseStateForUnknown(), which copies the prior state value into the plan during updates. Since the resource already exists (making this an Update, not a Create), the modifier fires, but for a new control that didn't exist in prior state, the state value at that path is null. This overwrites the expected unknown with null. Terraform accepts unknown→value transitions but rejects null→value transitions.

###  How to Replicate
  1. Apply a framework with at least one section and one control (so the resource exists in state)
  2. Add a new control to any section (existing or new)
  3. Run terraform apply, fails with "inconsistent result after apply" on the new control's id

  ### Fix
Replace UseStateForUnknown() with UseNonNullStateForUnknown() on the control id attribute. This variant skips copying when the state value is null (new entry), leaving the plan as unknown so Terraform accepts the UUID assigned after apply.

Fixes: SUPPORT-50542