### PR TITLE
docs(prevention_policy): note Data Protection subscription for cloud_data_protection_visibility

### DIFF
--- a/docs/resources/default_prevention_policy_linux.md
+++ b/docs/resources/default_prevention_policy_linux.md
@@ -88,7 +88,7 @@ output "default_prevention_policy_linux" {
 ### Optional
 
 - `cloud_anti_malware` (Attributes) Use cloud-based machine learning informed by global analysis of executables to detect and prevent known malware for your online hosts. (see [below for nested schema](#nestedatt--cloud_anti_malware))
-- `cloud_data_protection_visibility` (Boolean) Whether to enable the setting. Allows the sensor to monitor and analyze data flows for protection against data breaches and leaks, and to improve data-related detections.
+- `cloud_data_protection_visibility` (Boolean) Whether to enable the setting. Allows the sensor to monitor and analyze data flows for protection against data breaches and leaks, and to improve data-related detections. This setting requires an additional Data Protection subscription; refer to the official [CrowdStrike documentation](https://docs.crowdstrike.com/) for the required entitlements. If you do not have the required subscription, set this to `false` or omit the attribute to avoid a `Provider produced inconsistent result after apply` error.
 - `custom_blocking` (Boolean) Whether to enable the setting. Block processes matching hashes that you add to IOC Management with the action set to "Block" or "Block, hide detection".
 - `dbus_visibility` (Boolean) Whether to enable the setting. Allows the sensor to monitor local D-Bus traffic for malicious patterns and improved detections.
 - `description` (String) Description of the prevention policy.

--- a/docs/resources/prevention_policy_linux.md
+++ b/docs/resources/prevention_policy_linux.md
@@ -93,7 +93,7 @@ output "prevention_policy_linux" {
 ### Optional
 
 - `cloud_anti_malware` (Attributes) Use cloud-based machine learning informed by global analysis of executables to detect and prevent known malware for your online hosts. (see [below for nested schema](#nestedatt--cloud_anti_malware))
-- `cloud_data_protection_visibility` (Boolean) Whether to enable the setting. Allows the sensor to monitor and analyze data flows for protection against data breaches and leaks, and to improve data-related detections.
+- `cloud_data_protection_visibility` (Boolean) Whether to enable the setting. Allows the sensor to monitor and analyze data flows for protection against data breaches and leaks, and to improve data-related detections. This setting requires an additional Data Protection subscription; refer to the official [CrowdStrike documentation](https://docs.crowdstrike.com/) for the required entitlements. If you do not have the required subscription, set this to `false` or omit the attribute to avoid a `Provider produced inconsistent result after apply` error.
 - `custom_blocking` (Boolean) Whether to enable the setting. Block processes matching hashes that you add to IOC Management with the action set to "Block" or "Block, hide detection".
 - `dbus_visibility` (Boolean) Whether to enable the setting. Allows the sensor to monitor local D-Bus traffic for malicious patterns and improved detections.
 - `description` (String) Description of the prevention policy.

--- a/internal/prevention_policy/schema.go
+++ b/internal/prevention_policy/schema.go
@@ -685,7 +685,7 @@ func generateLinuxSchema(defaultPolicy bool) schema.Schema {
 				"Upload suspicious files for advanced threat analysis with QuickScan Pro.",
 			),
 			"cloud_data_protection_visibility": toggleAttribute(
-				"Allows the sensor to monitor and analyze data flows for protection against data breaches and leaks, and to improve data-related detections.",
+				"Allows the sensor to monitor and analyze data flows for protection against data breaches and leaks, and to improve data-related detections. This setting requires an additional Data Protection subscription; refer to the official [CrowdStrike documentation](https://docs.crowdstrike.com/) for the required entitlements. If you do not have the required subscription, set this to `false` or omit the attribute to avoid a `Provider produced inconsistent result after apply` error.",
 			),
 			"ssh_visibility": toggleAttribute(
 				"Enable monitoring of activities performed by SSH servers.",


### PR DESCRIPTION
## Summary

Clarifies that the `cloud_data_protection_visibility` setting on the Linux prevention policy resources requires an additional Data Protection subscription. Customers without the subscription hit a `Provider produced inconsistent result after apply` error because the API returns `false` regardless of the configured value.

The updated attribute description:
- Notes the additional Data Protection subscription requirement and links to the [CrowdStrike documentation](https://docs.crowdstrike.com/) for required entitlements.
- Suggests setting the attribute to `false` or omitting it when the subscription is not present to avoid the inconsistent-result error.

Affects `crowdstrike_prevention_policy_linux` and `crowdstrike_default_prevention_policy_linux`. Docs regenerated via `make gen`.