### PR TITLE
fix: bump gofalcon to v0.21.0 and fix breaking type changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/crowdstrike/terraform-provider-crowdstrike
 go 1.24.3
 
 require (
-	github.com/crowdstrike/gofalcon v0.20.1-0.20260504192251-d605fd0841a2
+	github.com/crowdstrike/gofalcon v0.21.0
 	github.com/go-openapi/runtime v0.27.1
 	github.com/go-openapi/strfmt v0.23.0
 	github.com/go-viper/mapstructure/v2 v2.4.0
@@ -39,6 +39,7 @@ require (
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.6.1 // indirect
+	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cloudflare/circl v1.6.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fatih/color v1.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,10 +31,12 @@ github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwN
 github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
+github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
+github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
 github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
-github.com/crowdstrike/gofalcon v0.20.1-0.20260504192251-d605fd0841a2 h1:YTCfGukH7Y08sUMC/bgVn6CMUlE0be6Pstsen5PHBOU=
-github.com/crowdstrike/gofalcon v0.20.1-0.20260504192251-d605fd0841a2/go.mod h1:a12GB+md+hRSgVCb3Pv6CakeTIsDIUCIVWRlJelIhY0=
+github.com/crowdstrike/gofalcon v0.21.0 h1:vMHpMtzidy07VxhQHMRH6uzHsOL3Efk6y829efDdOUQ=
+github.com/crowdstrike/gofalcon v0.21.0/go.mod h1:GYbhi35odSf8qFrcxAX6Sx7N/QIJyz8vKmUzuam7Xd8=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/correlation_rules/correlation_rule_resource.go
+++ b/internal/correlation_rules/correlation_rule_resource.go
@@ -981,7 +981,7 @@ func (r *correlationRuleResource) buildCreateRequest(
 		Outcome:        utils.Addr(outcomeFromCreateCase(searchModel.CreateCase.ValueBool())),
 		TriggerMode:    utils.Addr(searchModel.TriggerMode.ValueString()),
 		ExecutionMode:  utils.Addr(searchModel.ExecutionMode.ValueString()),
-		UseIngestTime:  utils.Addr(searchModel.UseIngestTime.ValueBool()),
+		UseIngestTime:  searchModel.UseIngestTime.ValueBool(),
 		CaseTemplateID: searchModel.CaseTemplateID.ValueString(),
 	}
 
@@ -1445,7 +1445,7 @@ func (model *CorrelationRuleResourceModel) wrap(
 			CreateCase:     types.BoolValue(rule.Search.Outcome != nil && *rule.Search.Outcome == outcomeCase),
 			TriggerMode:    types.StringPointerValue(rule.Search.TriggerMode),
 			ExecutionMode:  types.StringPointerValue(rule.Search.ExecutionMode),
-			UseIngestTime:  types.BoolValue(rule.Search.UseIngestTime != nil && *rule.Search.UseIngestTime),
+			UseIngestTime:  types.BoolValue(rule.Search.UseIngestTime),
 			CaseTemplateID: flex.StringValueToFramework(rule.Search.CaseTemplateID),
 		}
 		searchObj, d := types.ObjectValueFrom(ctx, searchModel.AttributeTypes(), searchModel)

--- a/internal/data_protection/content_pattern_resource.go
+++ b/internal/data_protection/content_pattern_resource.go
@@ -262,10 +262,10 @@ func (r *dataProtectionContentPatternResource) Update(
 	}
 
 	updateRequest := &models.APIContentPatternUpdateRequestV1{
-		ID:                utils.Addr(plan.ID.ValueString()),
-		Name:              plan.Name.ValueStringPointer(),
-		Description:       flex.FrameworkToStringPointer(plan.Description),
-		MinMatchThreshold: plan.MinMatchThreshold.ValueInt32Pointer(),
+		ID:                plan.ID.ValueString(),
+		Name:              plan.Name.ValueString(),
+		Description:       plan.Description.ValueString(),
+		MinMatchThreshold: plan.MinMatchThreshold.ValueInt32(),
 		Regexes:           []string{plan.Regex.ValueString()},
 	}
 

--- a/internal/fcs/cloud_azure_tenant_eventhub_settings.go
+++ b/internal/fcs/cloud_azure_tenant_eventhub_settings.go
@@ -317,7 +317,7 @@ func (r *cloudAzureTenantEventhubSettingsResource) getRegistration(
 
 	res, err := r.client.CloudAzureRegistration.CloudRegistrationAzureGetRegistration(
 		&cloud_azure_registration.CloudRegistrationAzureGetRegistrationParams{
-			TenantID: tenantID,
+			TenantID: &tenantID,
 			Context:  ctx,
 		},
 	)

--- a/internal/fcs/cloud_azure_tenant_resource.go
+++ b/internal/fcs/cloud_azure_tenant_resource.go
@@ -645,7 +645,7 @@ func (r *cloudAzureTenantResource) getRegistration(
 
 	res, err := r.client.CloudAzureRegistration.CloudRegistrationAzureGetRegistration(
 		&cloud_azure_registration.CloudRegistrationAzureGetRegistrationParams{
-			TenantID: tenantID,
+			TenantID: &tenantID,
 			Context:  ctx,
 		},
 	)


### PR DESCRIPTION
## Summary

Bump gofalcon from `v0.20.1-0.20260504192251-d605fd0841a2` to `v0.21.0`.

gofalcon v0.21.0 regenerated the SDK from an updated swagger spec, which introduced breaking type changes in 3 packages. The swagger spec changes were made by the endpoint owners.
gofalcon now correctly reflects the spec's required/optional field semantics.

## Changes

| Package | File | Change | Reason |
|---------|------|--------|--------|
| `data_protection` | `content_pattern_resource.go` | `*string`/`*int32` → `string`/`int32` for `ID`, `Name`, `Description`, `MinMatchThreshold` | Fields are not required in swagger spec (`required: []`) |
| `fcs` | `cloud_azure_tenant_eventhub_settings.go`, `cloud_azure_tenant_resource.go` | `TenantID` from `string` → `*string` | Query param is optional per swagger |
| `correlation_rules` | `correlation_rule_resource.go` | `UseIngestTime` from `*bool` → `bool` | Field is no longer required in swagger spec |

All fixes are mechanical pointer ↔ value conversions with no logic changes.

## Test plan

All affected code paths are covered by existing acceptance tests. Verified on dodo-red:

- [x] `TestAccDataProtectionContentPatternResource_Basic` — **PASS** (covers Update with all 4 changed fields)
- [x] `TestAccCloudAzureTenant_basic` — **PASS** (covers Read + ImportState with `&tenantID`)
- [x] `TestAccCorrelationRuleResource_basic` — **PASS** (covers Read with `UseIngestTime = false`)
- [x] `TestAccCorrelationRuleResource_update` — **PASS** (covers Write with `UseIngestTime = true` and Read verification)
- [x] `go build ./...` — **PASS**
- [x] `go test ./... -short` (all unit tests) — **PASS**
