### PR TITLE
feat: add vulnerability_scanning attribute to azure tenant resource -…

### DIFF
--- a/docs/resources/cloud_azure_tenant.md
+++ b/docs/resources/cloud_azure_tenant.md
@@ -78,6 +78,7 @@ output "tenant_registration" {
 - `resource_name_suffix` (String) The suffix added to resources created during onboarding. It will be used if you generate new .tfvars from the UI.
 - `subscription_ids` (Set of String) A list of subscription IDs to register in addition to any subscriptions that are targeted by management_group_ids.
 - `tags` (Map of String) Tags applied to managed resources. This does not effect the registration of the tenant. It will be used if you generate new .tfvars from the UI.
+- `vulnerability_scanning` (Attributes) (see [below for nested schema](#nestedatt--vulnerability_scanning))
 
 ### Read-Only
 
@@ -97,6 +98,14 @@ Required:
 Required:
 
 - `enabled` (Boolean) Enable real-time visibility and detection
+
+
+<a id="nestedatt--vulnerability_scanning"></a>
+### Nested Schema for `vulnerability_scanning`
+
+Required:
+
+- `enabled` (Boolean) Enable Vulnerability Scanning
 
 ## Import
 

--- a/internal/fcs/cloud_azure_tenant_resource.go
+++ b/internal/fcs/cloud_azure_tenant_resource.go
@@ -98,6 +98,7 @@ type cloudAzureTenantModel struct {
 	TenantId                         types.String `tfsdk:"tenant_id"`
 	RealtimeVisibility               types.Object `tfsdk:"realtime_visibility"`
 	DSPM                             types.Object `tfsdk:"dspm"`
+	VulnerabilityScanning            types.Object `tfsdk:"vulnerability_scanning"`
 	AgentlessScanningSubscriptionIds types.Set    `tfsdk:"agentless_scanning_subscription_ids"`
 }
 
@@ -137,6 +138,24 @@ func (r *dspmModel) FromObject(ctx context.Context, obj types.Object) diag.Diagn
 	return obj.As(ctx, r, basetypes.ObjectAsOptions{})
 }
 
+type vulnerabilityScanningModel struct {
+	Enabled types.Bool `tfsdk:"enabled"`
+}
+
+func (r *vulnerabilityScanningModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"enabled": types.BoolType,
+	}
+}
+
+func (r *vulnerabilityScanningModel) ToObject(ctx context.Context) (types.Object, diag.Diagnostics) {
+	return types.ObjectValueFrom(ctx, r.AttributeTypes(), r)
+}
+
+func (r *vulnerabilityScanningModel) FromObject(ctx context.Context, obj types.Object) diag.Diagnostics {
+	return obj.As(ctx, r, basetypes.ObjectAsOptions{})
+}
+
 func buildAzureProductConfig(
 	ctx context.Context,
 	data *cloudAzureTenantModel,
@@ -159,6 +178,17 @@ func buildAzureProductConfig(
 	if diags.HasError() {
 		return features, additionalFeatures
 	}
+
+	var vulnScanning vulnerabilityScanningModel
+	diags.Append(vulnScanning.FromObject(ctx, data.VulnerabilityScanning)...)
+	if diags.HasError() {
+		return features, additionalFeatures
+	}
+
+	if vulnScanning.Enabled.ValueBool() {
+		features = append(features, "vulnerability_scanning")
+	}
+
 	if !dspm.Enabled.ValueBool() {
 		return features, additionalFeatures
 	}
@@ -276,6 +306,27 @@ func (r *cloudAzureTenantResource) Schema(
 					),
 				),
 			},
+			"vulnerability_scanning": schema.SingleNestedAttribute{
+				Required: false,
+				Optional: true,
+				Computed: true,
+				Attributes: map[string]schema.Attribute{
+					"enabled": schema.BoolAttribute{
+						Required:    true,
+						Description: "Enable Vulnerability Scanning",
+					},
+				},
+				Default: objectdefault.StaticValue(
+					types.ObjectValueMust(
+						map[string]attr.Type{
+							"enabled": types.BoolType,
+						},
+						map[string]attr.Value{
+							"enabled": types.BoolValue(false),
+						},
+					),
+				),
+			},
 			"resource_name_prefix": schema.StringAttribute{
 				MarkdownDescription: "The prefix added to resources created during onboarding. It will be used if you generate new .tfvars from the UI.",
 				Optional:            true,
@@ -368,6 +419,7 @@ func (m *cloudAzureTenantModel) wrap(
 
 	hasIOA := false
 	hasDSPM := false
+	hasVulnScanning := false
 	for _, product := range registration.Products {
 		if *product.Product == "cspm" {
 			for _, feature := range product.Features {
@@ -376,6 +428,8 @@ func (m *cloudAzureTenantModel) wrap(
 					hasIOA = true
 				case "dspm":
 					hasDSPM = true
+				case "vulnerability_scanning":
+					hasVulnScanning = true
 				}
 			}
 		}
@@ -404,6 +458,11 @@ func (m *cloudAzureTenantModel) wrap(
 	dspmObj, d := dspm.ToObject(ctx)
 	diags.Append(d...)
 	m.DSPM = dspmObj
+
+	vulnScanning := vulnerabilityScanningModel{Enabled: types.BoolValue(hasVulnScanning)}
+	vulnScanningObj, d := vulnScanning.ToObject(ctx)
+	diags.Append(d...)
+	m.VulnerabilityScanning = vulnScanningObj
 
 	return diags
 }
@@ -579,17 +638,22 @@ func (r cloudAzureTenantResource) ModifyPlan(
 	// terraform_data.output), it is unknown on the first run and resolved on the second. The
 	// IsUnknown guards skip validation on the first run to avoid false positives; the second run
 	// sees the real values and validates them.
-	if utils.IsKnown(plan.AgentlessScanningSubscriptionIds) && utils.IsKnown(plan.DSPM) {
+	if utils.IsKnown(plan.AgentlessScanningSubscriptionIds) && utils.IsKnown(plan.DSPM) && utils.IsKnown(plan.VulnerabilityScanning) {
 		var dspm dspmModel
 		resp.Diagnostics.Append(dspm.FromObject(ctx, plan.DSPM)...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		if utils.IsKnown(dspm.Enabled) && !dspm.Enabled.ValueBool() {
+		var vulnScanning vulnerabilityScanningModel
+		resp.Diagnostics.Append(vulnScanning.FromObject(ctx, plan.VulnerabilityScanning)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		if utils.IsKnown(dspm.Enabled) && utils.IsKnown(vulnScanning.Enabled) && !dspm.Enabled.ValueBool() && !vulnScanning.Enabled.ValueBool() {
 			resp.Diagnostics.Append(diag.NewAttributeErrorDiagnostic(
 				path.Root("agentless_scanning_subscription_ids"),
 				"Invalid configuration",
-				"agentless_scanning_subscription_ids requires dspm to be enabled.",
+				"agentless_scanning_subscription_ids requires dspm or vulnerability_scanning to be enabled.",
 			))
 			return
 		}

--- a/internal/fcs/cloud_azure_tenant_resource.go
+++ b/internal/fcs/cloud_azure_tenant_resource.go
@@ -185,52 +185,32 @@ func buildAzureProductConfig(
 		return features, additionalFeatures
 	}
 
-	if vulnScanning.Enabled.ValueBool() {
-		features = append(features, "vulnerability_scanning")
-	}
+	agentlessSubscriptionIDs := flex.ExpandSetAs[string](ctx, data.AgentlessScanningSubscriptionIds, diags)
 
 	if dspm.Enabled.ValueBool() {
-		features = append(features, "dspm")
-	}
-
-	if !dspm.Enabled.ValueBool() && !vulnScanning.Enabled.ValueBool() {
-		return features, additionalFeatures
-	}
-
-	subs := flex.ExpandSetAs[string](ctx, data.AgentlessScanningSubscriptionIds, diags)
-	if len(subs) == 0 {
-		return features, additionalFeatures
-	}
-
-	// Send subscription IDs as additional features for whichever scanning features are enabled
-	if dspm.Enabled.ValueBool() {
-		additionalFeatures = append(additionalFeatures, &models.AzureAdditionalFeature{
-			Feature:         utils.Addr("dspm"),
-			Product:         utils.Addr("cspm"),
-			SubscriptionIds: subs,
-		})
-		// Remove "dspm" from top-level features since it's now in additionalFeatures
-		for i, f := range features {
-			if f == "dspm" {
-				features = append(features[:i], features[i+1:]...)
-				break
-			}
+		if len(agentlessSubscriptionIDs) == 0 {
+			features = append(features, "dspm")
+		} else {
+			additionalFeatures = append(additionalFeatures, &models.AzureAdditionalFeature{
+				Feature:         utils.Addr("dspm"),
+				Product:         utils.Addr("cspm"),
+				SubscriptionIds: agentlessSubscriptionIDs,
+			})
 		}
 	}
+
 	if vulnScanning.Enabled.ValueBool() {
-		additionalFeatures = append(additionalFeatures, &models.AzureAdditionalFeature{
-			Feature:         utils.Addr("vulnerability_scanning"),
-			Product:         utils.Addr("cspm"),
-			SubscriptionIds: subs,
-		})
-		// Remove "vulnerability_scanning" from top-level features since it's now in additionalFeatures
-		for i, f := range features {
-			if f == "vulnerability_scanning" {
-				features = append(features[:i], features[i+1:]...)
-				break
-			}
+		if len(agentlessSubscriptionIDs) == 0 {
+			features = append(features, "vulnerability_scanning")
+		} else {
+			additionalFeatures = append(additionalFeatures, &models.AzureAdditionalFeature{
+				Feature:         utils.Addr("vulnerability_scanning"),
+				Product:         utils.Addr("cspm"),
+				SubscriptionIds: agentlessSubscriptionIDs,
+			})
 		}
 	}
+
 	return features, additionalFeatures
 }
 
@@ -470,16 +450,14 @@ func (m *cloudAzureTenantModel) wrap(
 				agentlessSubIds = af.SubscriptionIds
 				hasDSPM = true
 			case "vulnerability_scanning":
-				if len(agentlessSubIds) == 0 {
-					agentlessSubIds = af.SubscriptionIds
-				}
+				agentlessSubIds = af.SubscriptionIds
 				hasVulnScanning = true
 			}
 		}
 	}
-	agentlessSet, d := flex.FlattenStringValueSet(ctx, agentlessSubIds)
+	agentlessSubscriptionsSet, d := flex.FlattenStringValueSet(ctx, agentlessSubIds)
 	diags.Append(d...)
-	m.AgentlessScanningSubscriptionIds = agentlessSet
+	m.AgentlessScanningSubscriptionIds = agentlessSubscriptionsSet
 
 	rtv := realtimeVisibilityModel{Enabled: types.BoolValue(hasIOA)}
 	rtvObj, d := rtv.ToObject(ctx)

--- a/internal/fcs/cloud_azure_tenant_resource.go
+++ b/internal/fcs/cloud_azure_tenant_resource.go
@@ -189,21 +189,48 @@ func buildAzureProductConfig(
 		features = append(features, "vulnerability_scanning")
 	}
 
-	if !dspm.Enabled.ValueBool() {
+	if dspm.Enabled.ValueBool() {
+		features = append(features, "dspm")
+	}
+
+	if !dspm.Enabled.ValueBool() && !vulnScanning.Enabled.ValueBool() {
 		return features, additionalFeatures
 	}
 
 	subs := flex.ExpandSetAs[string](ctx, data.AgentlessScanningSubscriptionIds, diags)
 	if len(subs) == 0 {
-		features = append(features, "dspm")
 		return features, additionalFeatures
 	}
 
-	additionalFeatures = []*models.AzureAdditionalFeature{{
-		Feature:         utils.Addr("dspm"),
-		Product:         utils.Addr("cspm"),
-		SubscriptionIds: subs,
-	}}
+	// Send subscription IDs as additional features for whichever scanning features are enabled
+	if dspm.Enabled.ValueBool() {
+		additionalFeatures = append(additionalFeatures, &models.AzureAdditionalFeature{
+			Feature:         utils.Addr("dspm"),
+			Product:         utils.Addr("cspm"),
+			SubscriptionIds: subs,
+		})
+		// Remove "dspm" from top-level features since it's now in additionalFeatures
+		for i, f := range features {
+			if f == "dspm" {
+				features = append(features[:i], features[i+1:]...)
+				break
+			}
+		}
+	}
+	if vulnScanning.Enabled.ValueBool() {
+		additionalFeatures = append(additionalFeatures, &models.AzureAdditionalFeature{
+			Feature:         utils.Addr("vulnerability_scanning"),
+			Product:         utils.Addr("cspm"),
+			SubscriptionIds: subs,
+		})
+		// Remove "vulnerability_scanning" from top-level features since it's now in additionalFeatures
+		for i, f := range features {
+			if f == "vulnerability_scanning" {
+				features = append(features[:i], features[i+1:]...)
+				break
+			}
+		}
+	}
 	return features, additionalFeatures
 }
 
@@ -437,13 +464,18 @@ func (m *cloudAzureTenantModel) wrap(
 
 	var agentlessSubIds []string
 	for _, af := range registration.AdditionalFeatures {
-		if af != nil && af.Feature != nil && *af.Feature == "dspm" {
-			agentlessSubIds = af.SubscriptionIds
-			break
+		if af != nil && af.Feature != nil {
+			switch *af.Feature {
+			case "dspm":
+				agentlessSubIds = af.SubscriptionIds
+				hasDSPM = true
+			case "vulnerability_scanning":
+				if len(agentlessSubIds) == 0 {
+					agentlessSubIds = af.SubscriptionIds
+				}
+				hasVulnScanning = true
+			}
 		}
-	}
-	if len(agentlessSubIds) > 0 {
-		hasDSPM = true
 	}
 	agentlessSet, d := flex.FlattenStringValueSet(ctx, agentlessSubIds)
 	diags.Append(d...)

--- a/internal/fcs/cloud_azure_tenant_resource_test.go
+++ b/internal/fcs/cloud_azure_tenant_resource_test.go
@@ -473,7 +473,7 @@ func TestAccCloudAzureTenant_agentlessScanningSubscriptionIdsTenantWide(t *testi
 	})
 }
 
-func TestAccCloudAzureTenant_agentlessSubIdsRequiresDSPM(t *testing.T) {
+func TestAccCloudAzureTenant_agentlessSubIdsRequiresDSPMOrVulnScanning(t *testing.T) {
 	tenantID := acctest.RandomUUID()
 	subID1 := acctest.RandomUUID()
 
@@ -483,7 +483,7 @@ func TestAccCloudAzureTenant_agentlessSubIdsRequiresDSPM(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccCloudAzureTenantConfig_agentlessSubIdsNoDSPM(tenantID, subID1),
-				ExpectError: regexp.MustCompile("agentless_scanning_subscription_ids requires dspm to be enabled"),
+				ExpectError: regexp.MustCompile("agentless_scanning_subscription_ids requires dspm or vulnerability_scanning to be enabled"),
 			},
 		},
 	})
@@ -509,11 +509,11 @@ func TestAccCloudAzureTenant_agentless_UnknownDSPMEnabled(t *testing.T) {
 			},
 			{
 				Config:      testAccCloudAzureTenantConfig_agentlessSubIdsUnknownDSPM(tenantID, subID1, false),
-				ExpectError: regexp.MustCompile("agentless_scanning_subscription_ids requires dspm to be enabled"),
+				ExpectError: regexp.MustCompile("agentless_scanning_subscription_ids requires dspm or vulnerability_scanning to be enabled"),
 			},
 			{
 				Config:      testAccCloudAzureTenantConfig_agentlessSubIdsNoDSPM(tenantID, subID1),
-				ExpectError: regexp.MustCompile("agentless_scanning_subscription_ids requires dspm to be enabled"),
+				ExpectError: regexp.MustCompile("agentless_scanning_subscription_ids requires dspm or vulnerability_scanning to be enabled"),
 			},
 		},
 	})
@@ -539,7 +539,7 @@ func TestAccCloudAzureTenant_agentless_UnknownSubIds(t *testing.T) {
 			},
 			{
 				Config:      testAccCloudAzureTenantConfig_unknownAgentlessSubIds(tenantID, subID1, false),
-				ExpectError: regexp.MustCompile("agentless_scanning_subscription_ids requires dspm to be enabled"),
+				ExpectError: regexp.MustCompile("agentless_scanning_subscription_ids requires dspm or vulnerability_scanning to be enabled"),
 			},
 		},
 	})
@@ -565,7 +565,7 @@ func TestAccCloudAzureTenant_agentless_UnknownDSPMObject(t *testing.T) {
 			},
 			{
 				Config:      testAccCloudAzureTenantConfig_unknownDSPMObject(tenantID, subID1, false),
-				ExpectError: regexp.MustCompile("agentless_scanning_subscription_ids requires dspm to be enabled"),
+				ExpectError: regexp.MustCompile("agentless_scanning_subscription_ids requires dspm or vulnerability_scanning to be enabled"),
 			},
 		},
 	})
@@ -845,4 +845,140 @@ resource "crowdstrike_cloud_azure_tenant" "test" {
   agentless_scanning_subscription_ids = [%[3]q]
   dspm                                = terraform_data.dspm_obj.output
 }`, tenantID, userReadAllPermissionID, subID, enabled)
+}
+
+func TestAccCloudAzureTenant_vulnerabilityScanning(t *testing.T) {
+	tenantID := acctest.RandomUUID()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudAzureTenantConfig_basic(tenantID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("vulnerability_scanning").AtMapKey("enabled"), knownvalue.Bool(false)),
+				},
+			},
+			{
+				Config: testAccCloudAzureTenantConfig_vulnScanningEnabled(tenantID, true),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("vulnerability_scanning").AtMapKey("enabled"), knownvalue.Bool(true)),
+				},
+			},
+			{
+				Config: testAccCloudAzureTenantConfig_vulnScanningEnabled(tenantID, false),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("vulnerability_scanning").AtMapKey("enabled"), knownvalue.Bool(false)),
+				},
+			},
+		},
+	})
+}
+
+func TestAccCloudAzureTenant_vulnScanningWithSubscriptionIds(t *testing.T) {
+	tenantID := acctest.RandomUUID()
+	subID1 := acctest.RandomUUID()
+	subID2 := acctest.RandomUUID()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudAzureTenantConfig_vulnScanningWithSubIds(tenantID, subID1, subID2),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("vulnerability_scanning").AtMapKey("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("agentless_scanning_subscription_ids"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact(subID1),
+						knownvalue.StringExact(subID2),
+					})),
+				},
+			},
+			{
+				ResourceName:                         cloudAzureTenantResourceName,
+				ImportState:                          true,
+				ImportStateId:                        tenantID,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "tenant_id",
+			},
+		},
+	})
+}
+
+func TestAccCloudAzureTenant_vulnScanningAndDSPM(t *testing.T) {
+	tenantID := acctest.RandomUUID()
+	subID1 := acctest.RandomUUID()
+	subID2 := acctest.RandomUUID()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudAzureTenantConfig_vulnScanningAndDSPM(tenantID, subID1, subID2),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("vulnerability_scanning").AtMapKey("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("dspm").AtMapKey("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("agentless_scanning_subscription_ids"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact(subID1),
+						knownvalue.StringExact(subID2),
+					})),
+				},
+			},
+			{
+				ResourceName:                         cloudAzureTenantResourceName,
+				ImportState:                          true,
+				ImportStateId:                        tenantID,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "tenant_id",
+			},
+			{
+				Config: testAccCloudAzureTenantConfig_vulnScanningEnabled(tenantID, true),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("vulnerability_scanning").AtMapKey("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("dspm").AtMapKey("enabled"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("agentless_scanning_subscription_ids"), knownvalue.Null()),
+				},
+			},
+		},
+	})
+}
+
+func testAccCloudAzureTenantConfig_vulnScanningEnabled(tenantID string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "crowdstrike_cloud_azure_tenant" "test" {
+  tenant_id                      = %[1]q
+  microsoft_graph_permission_ids = [%[2]q]
+  vulnerability_scanning = {
+    enabled = %[3]t
+  }
+}`, tenantID, userReadAllPermissionID, enabled)
+}
+
+func testAccCloudAzureTenantConfig_vulnScanningWithSubIds(tenantID, subID1, subID2 string) string {
+	return fmt.Sprintf(`
+resource "crowdstrike_cloud_azure_tenant" "test" {
+  tenant_id                           = %[1]q
+  microsoft_graph_permission_ids      = [%[2]q]
+  agentless_scanning_subscription_ids = [%[3]q, %[4]q]
+  vulnerability_scanning = {
+    enabled = true
+  }
+}`, tenantID, userReadAllPermissionID, subID1, subID2)
+}
+
+func testAccCloudAzureTenantConfig_vulnScanningAndDSPM(tenantID, subID1, subID2 string) string {
+	return fmt.Sprintf(`
+resource "crowdstrike_cloud_azure_tenant" "test" {
+  tenant_id                           = %[1]q
+  microsoft_graph_permission_ids      = [%[2]q]
+  agentless_scanning_subscription_ids = [%[3]q, %[4]q]
+  vulnerability_scanning = {
+    enabled = true
+  }
+  dspm = {
+    enabled = true
+  }
+}`, tenantID, userReadAllPermissionID, subID1, subID2)
 }

--- a/internal/fcs/cloud_azure_tenant_resource_test.go
+++ b/internal/fcs/cloud_azure_tenant_resource_test.go
@@ -571,6 +571,32 @@ func TestAccCloudAzureTenant_agentless_UnknownDSPMObject(t *testing.T) {
 	})
 }
 
+func TestAccCloudAzureTenant_agentless_UnknownVulnerabilityScanningEnabled(t *testing.T) {
+	tenantID := acctest.RandomUUID()
+	subID1 := acctest.RandomUUID()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudAzureTenantConfig_agentlessSubIdsUnknownVulnScanning(tenantID, subID1, true),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("tenant_id"), knownvalue.StringExact(tenantID)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("vulnerability_scanning").AtMapKey("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(cloudAzureTenantResourceName, tfjsonpath.New("agentless_scanning_subscription_ids"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact(subID1),
+					})),
+				},
+			},
+			{
+				Config:      testAccCloudAzureTenantConfig_agentlessSubIdsUnknownVulnScanning(tenantID, subID1, false),
+				ExpectError: regexp.MustCompile("agentless_scanning_subscription_ids requires dspm or vulnerability_scanning to be enabled"),
+			},
+		},
+	})
+}
+
 func TestAccCloudAzureTenant_agentlessSubIdsShapeTransitions(t *testing.T) {
 	tenantID := acctest.RandomUUID()
 	subID1 := acctest.RandomUUID()
@@ -844,6 +870,22 @@ resource "crowdstrike_cloud_azure_tenant" "test" {
   microsoft_graph_permission_ids      = [%[2]q]
   agentless_scanning_subscription_ids = [%[3]q]
   dspm                                = terraform_data.dspm_obj.output
+}`, tenantID, userReadAllPermissionID, subID, enabled)
+}
+
+func testAccCloudAzureTenantConfig_agentlessSubIdsUnknownVulnScanning(tenantID, subID string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "terraform_data" "vuln_scanning_flag" {
+  input = %[4]t
+}
+
+resource "crowdstrike_cloud_azure_tenant" "test" {
+  tenant_id                           = %[1]q
+  microsoft_graph_permission_ids      = [%[2]q]
+  agentless_scanning_subscription_ids = [%[3]q]
+  vulnerability_scanning = {
+    enabled = tobool(terraform_data.vuln_scanning_flag.output)
+  }
 }`, tenantID, userReadAllPermissionID, subID, enabled)
 }
 

--- a/internal/fcs/cloud_azure_tenant_resource_test.go
+++ b/internal/fcs/cloud_azure_tenant_resource_test.go
@@ -483,7 +483,7 @@ func TestAccCloudAzureTenant_agentlessSubIdsRequiresDSPMOrVulnScanning(t *testin
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccCloudAzureTenantConfig_agentlessSubIdsNoDSPM(tenantID, subID1),
-				ExpectError: regexp.MustCompile("agentless_scanning_subscription_ids requires dspm or vulnerability_scanning to be enabled"),
+				ExpectError: regexp.MustCompile(`agentless_scanning_subscription_ids requires dspm or vulnerability_scanning\s+to be enabled`),
 			},
 		},
 	})
@@ -509,11 +509,11 @@ func TestAccCloudAzureTenant_agentless_UnknownDSPMEnabled(t *testing.T) {
 			},
 			{
 				Config:      testAccCloudAzureTenantConfig_agentlessSubIdsUnknownDSPM(tenantID, subID1, false),
-				ExpectError: regexp.MustCompile("agentless_scanning_subscription_ids requires dspm or vulnerability_scanning to be enabled"),
+				ExpectError: regexp.MustCompile(`agentless_scanning_subscription_ids requires dspm or vulnerability_scanning\s+to be enabled`),
 			},
 			{
 				Config:      testAccCloudAzureTenantConfig_agentlessSubIdsNoDSPM(tenantID, subID1),
-				ExpectError: regexp.MustCompile("agentless_scanning_subscription_ids requires dspm or vulnerability_scanning to be enabled"),
+				ExpectError: regexp.MustCompile(`agentless_scanning_subscription_ids requires dspm or vulnerability_scanning\s+to be enabled`),
 			},
 		},
 	})
@@ -539,7 +539,7 @@ func TestAccCloudAzureTenant_agentless_UnknownSubIds(t *testing.T) {
 			},
 			{
 				Config:      testAccCloudAzureTenantConfig_unknownAgentlessSubIds(tenantID, subID1, false),
-				ExpectError: regexp.MustCompile("agentless_scanning_subscription_ids requires dspm or vulnerability_scanning to be enabled"),
+				ExpectError: regexp.MustCompile(`agentless_scanning_subscription_ids requires dspm or vulnerability_scanning\s+to be enabled`),
 			},
 		},
 	})
@@ -565,7 +565,7 @@ func TestAccCloudAzureTenant_agentless_UnknownDSPMObject(t *testing.T) {
 			},
 			{
 				Config:      testAccCloudAzureTenantConfig_unknownDSPMObject(tenantID, subID1, false),
-				ExpectError: regexp.MustCompile("agentless_scanning_subscription_ids requires dspm or vulnerability_scanning to be enabled"),
+				ExpectError: regexp.MustCompile(`agentless_scanning_subscription_ids requires dspm or vulnerability_scanning\s+to be enabled`),
 			},
 		},
 	})
@@ -591,7 +591,7 @@ func TestAccCloudAzureTenant_agentless_UnknownVulnerabilityScanningEnabled(t *te
 			},
 			{
 				Config:      testAccCloudAzureTenantConfig_agentlessSubIdsUnknownVulnScanning(tenantID, subID1, false),
-				ExpectError: regexp.MustCompile("agentless_scanning_subscription_ids requires dspm or vulnerability_scanning to be enabled"),
+				ExpectError: regexp.MustCompile(`agentless_scanning_subscription_ids requires dspm or vulnerability_scanning\s+to be enabled`),
 			},
 		},
 	})


### PR DESCRIPTION
… CSPG-87057

Add vulnerability_scanning nested attribute (with enabled bool) to crowdstrike_cloud_azure_tenant resource, matching the pattern used by dspm. Sends "vulnerability_scanning" feature to the CSPM product config. Updates ModifyPlan to accept either dspm or vulnerability_scanning for agentless_scanning_subscription_ids validation.