### PR TITLE
feat: add agentless scanning for gcp

### DIFF
--- a/docs/resources/cloud_google_registration.md
+++ b/docs/resources/cloud_google_registration.md
@@ -122,6 +122,7 @@ resource "crowdstrike_cloud_google_registration" "example_infrastructure_manager
 ### Optional
 
 - `deployment_method` (String) The deployment method for the registration. Can be either terraform-native or infrastructure-manager. Defaults to terraform-native
+- `dspm` (Attributes) Enable DSPM agentless scanning (see [below for nested schema](#nestedatt--dspm))
 - `excluded_project_patterns` (List of String) Wildcard patterns to exclude specific projects from registration. Each pattern must contain only lowercase letters, hyphens, numbers, and wildcard (*). A pattern containing only a wildcard is not valid
 - `folders` (Set of String) Google Cloud folder IDs to register. Each must be numeric. Mutually exclusive with `organization` and `projects`
 - `infrastructure_manager_region` (String) The Google Cloud region for Infrastructure Manager. Required when deployment_method is infrastructure-manager
@@ -132,6 +133,7 @@ resource "crowdstrike_cloud_google_registration" "example_infrastructure_manager
 - `resource_name_prefix` (String) Prefix to add to created Google Cloud resource names. The combined length of prefix and suffix must not exceed 13 characters
 - `resource_name_suffix` (String) Suffix to add to created Google Cloud resource names. The combined length of prefix and suffix must not exceed 13 characters
 - `tags` (Map of String) Google Cloud tags to apply to created resources
+- `vulnerability_scanning` (Attributes) Enable vulnerability scanning (see [below for nested schema](#nestedatt--vulnerability_scanning))
 
 ### Read-Only
 
@@ -143,12 +145,28 @@ resource "crowdstrike_cloud_google_registration" "example_infrastructure_manager
 - `wif_provider_id` (String) Workload Identity Federation provider ID
 - `wif_provider_name` (String) Workload Identity Federation provider name
 
+<a id="nestedatt--dspm"></a>
+### Nested Schema for `dspm`
+
+Required:
+
+- `enabled` (Boolean) Enable DSPM agentless scanning for this registration
+
+
 <a id="nestedatt--realtime_visibility"></a>
 ### Nested Schema for `realtime_visibility`
 
 Required:
 
 - `enabled` (Boolean) Enable real-time visibility and detection
+
+
+<a id="nestedatt--vulnerability_scanning"></a>
+### Nested Schema for `vulnerability_scanning`
+
+Required:
+
+- `enabled` (Boolean) Enable vulnerability scanning for this registration
 
 ## Import
 

--- a/docs/resources/cloud_google_registration_settings.md
+++ b/docs/resources/cloud_google_registration_settings.md
@@ -71,11 +71,56 @@ output "log_ingestion_settings" {
 
 ### Optional
 
+- `agentless_scanning_settings` (Attributes) Agentless scanning settings. Only configurable after the agentless scanning infrastructure has been created via Terraform. (see [below for nested schema](#nestedatt--agentless_scanning_settings))
 - `log_ingestion_sink_name` (String) The name of the log sink for ingestion.
 - `log_ingestion_subscription_name` (String) The Pub/Sub subscription name for log ingestion.
 - `log_ingestion_topic_id` (String) The Pub/Sub topic ID for log ingestion.
 - `wif_pool_name` (String) The Workload Identity Federation (WIF) pool name.
 - `wif_provider_name` (String) The Workload Identity Federation (WIF) provider name.
+
+<a id="nestedatt--agentless_scanning_settings"></a>
+### Nested Schema for `agentless_scanning_settings`
+
+Required:
+
+- `deployment_version` (String) The TF module deployment version for tracking.
+- `infra` (Attributes Map) Per-project scanning infrastructure details, keyed by GCP project ID. In cross-project mode this contains a single entry for the host project. (see [below for nested schema](#nestedatt--agentless_scanning_settings--infra))
+- `network_configuration_type` (String) Network configuration type for scanner VMs: managed (with NAT), managed_no_nat, or custom (BYO VPC).
+- `regions` (Set of String) The GCP regions where agentless scanning infrastructure is deployed.
+- `wif_principal` (String) The Workload Identity Federation principal for the agentless scanning.
+
+Optional:
+
+- `custom_network` (Attributes) Custom (BYO) network configuration. Required when network_configuration_type is 'custom'. (see [below for nested schema](#nestedatt--agentless_scanning_settings--custom_network))
+- `host_project_id` (String) The GCP project hosting shared scanning infrastructure. When set, indicates cross-project mode.
+- `org_id` (String) The GCP organization ID. Required only for folder-scoped registrations.
+
+<a id="nestedatt--agentless_scanning_settings--infra"></a>
+### Nested Schema for `agentless_scanning_settings.infra`
+
+Required:
+
+- `client_credentials_secret_name` (String) The Secret Manager secret name containing Falcon client credentials for scanner authentication.
+- `network` (Attributes) Network configuration for scanner VMs in this project. (see [below for nested schema](#nestedatt--agentless_scanning_settings--infra--network))
+- `scanner_sa_email` (String) The service account email used by the scanner in this project.
+
+<a id="nestedatt--agentless_scanning_settings--infra--network"></a>
+### Nested Schema for `agentless_scanning_settings.infra.network`
+
+Required:
+
+- `subnets` (Map of String) Map of region to subnet name for scanner VMs.
+- `vpc_name` (String) The VPC network name used by scanner VMs.
+
+
+
+<a id="nestedatt--agentless_scanning_settings--custom_network"></a>
+### Nested Schema for `agentless_scanning_settings.custom_network`
+
+Required:
+
+- `subnets` (Map of String) Map of region to subnet name within the custom VPC.
+- `vpc_name` (String) The name of the customer-provided VPC network.
 
 ## Import
 

--- a/internal/cloud_google_registration/cloud_google_registration.go
+++ b/internal/cloud_google_registration/cloud_google_registration.go
@@ -33,6 +33,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
+const (
+	featureDSPM                  = "dspm"
+	featureVulnerabilityScanning = "vulnerability_scanning"
+)
+
 var (
 	_ resource.Resource                     = &cloudGoogleRegistrationResource{}
 	_ resource.ResourceWithConfigure        = &cloudGoogleRegistrationResource{}
@@ -79,6 +84,42 @@ func (r *realtimeVisibilityModel) FromObject(ctx context.Context, obj types.Obje
 	return obj.As(ctx, r, basetypes.ObjectAsOptions{})
 }
 
+type dspmModel struct {
+	Enabled types.Bool `tfsdk:"enabled"`
+}
+
+func (d *dspmModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"enabled": types.BoolType,
+	}
+}
+
+func (d *dspmModel) ToObject(ctx context.Context) (types.Object, diag.Diagnostics) {
+	return types.ObjectValueFrom(ctx, d.AttributeTypes(), d)
+}
+
+func (d *dspmModel) FromObject(ctx context.Context, obj types.Object) diag.Diagnostics {
+	return obj.As(ctx, d, basetypes.ObjectAsOptions{})
+}
+
+type vulnerabilityScanningModel struct {
+	Enabled types.Bool `tfsdk:"enabled"`
+}
+
+func (v *vulnerabilityScanningModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"enabled": types.BoolType,
+	}
+}
+
+func (v *vulnerabilityScanningModel) ToObject(ctx context.Context) (types.Object, diag.Diagnostics) {
+	return types.ObjectValueFrom(ctx, v.AttributeTypes(), v)
+}
+
+func (v *vulnerabilityScanningModel) FromObject(ctx context.Context, obj types.Object) diag.Diagnostics {
+	return obj.As(ctx, v, basetypes.ObjectAsOptions{})
+}
+
 type cloudGoogleRegistrationResourceModel struct {
 	ID                          types.String `tfsdk:"id"`
 	Name                        types.String `tfsdk:"name"`
@@ -96,6 +137,8 @@ type cloudGoogleRegistrationResourceModel struct {
 	Labels                      types.Map    `tfsdk:"labels"`
 	Tags                        types.Map    `tfsdk:"tags"`
 	RealtimeVisibility          types.Object `tfsdk:"realtime_visibility"`
+	DSPM                        types.Object `tfsdk:"dspm"`
+	VulnerabilityScanning       types.Object `tfsdk:"vulnerability_scanning"`
 	Status                      types.String `tfsdk:"status"`
 	WifPoolID                   types.String `tfsdk:"wif_pool_id"`
 	WifPoolName                 types.String `tfsdk:"wif_pool_name"`
@@ -224,12 +267,19 @@ func (m *cloudGoogleRegistrationResourceModel) wrap(
 	m.WifProviderName = flex.StringValueToFramework(wifProviderName)
 
 	hasIOA := false
+	hasDSPM := false
+	hasVulnScanning := false
 	for _, product := range registration.Products {
 		if product.Product != nil && *product.Product == "cspm" {
 			for _, feature := range product.Features {
 				if feature == "ioa" {
 					hasIOA = true
-					break
+				}
+				if feature == featureDSPM {
+					hasDSPM = true
+				}
+				if feature == featureVulnerabilityScanning {
+					hasVulnScanning = true
 				}
 			}
 			break
@@ -249,6 +299,36 @@ func (m *cloudGoogleRegistrationResourceModel) wrap(
 		m.RealtimeVisibility = rtvObj
 	default:
 		m.RealtimeVisibility = types.ObjectNull((&realtimeVisibilityModel{}).AttributeTypes())
+	}
+
+	switch {
+	case hasDSPM:
+		dspmObj := dspmModel{Enabled: types.BoolValue(true)}
+		obj, d := dspmObj.ToObject(ctx)
+		diags.Append(d...)
+		m.DSPM = obj
+	case !m.DSPM.IsNull():
+		dspmObj := dspmModel{Enabled: types.BoolValue(false)}
+		obj, d := dspmObj.ToObject(ctx)
+		diags.Append(d...)
+		m.DSPM = obj
+	default:
+		m.DSPM = types.ObjectNull((&dspmModel{}).AttributeTypes())
+	}
+
+	switch {
+	case hasVulnScanning:
+		vulnObj := vulnerabilityScanningModel{Enabled: types.BoolValue(true)}
+		obj, d := vulnObj.ToObject(ctx)
+		diags.Append(d...)
+		m.VulnerabilityScanning = obj
+	case !m.VulnerabilityScanning.IsNull():
+		vulnObj := vulnerabilityScanningModel{Enabled: types.BoolValue(false)}
+		obj, d := vulnObj.ToObject(ctx)
+		diags.Append(d...)
+		m.VulnerabilityScanning = obj
+	default:
+		m.VulnerabilityScanning = types.ObjectNull((&vulnerabilityScanningModel{}).AttributeTypes())
 	}
 
 	return diags
@@ -473,6 +553,26 @@ func (r *cloudGoogleRegistrationResource) Schema(
 					},
 				},
 			},
+			"dspm": schema.SingleNestedAttribute{
+				Optional:    true,
+				Description: "Enable DSPM agentless scanning",
+				Attributes: map[string]schema.Attribute{
+					"enabled": schema.BoolAttribute{
+						Required:    true,
+						Description: "Enable DSPM agentless scanning for this registration",
+					},
+				},
+			},
+			"vulnerability_scanning": schema.SingleNestedAttribute{
+				Optional:    true,
+				Description: "Enable vulnerability scanning",
+				Attributes: map[string]schema.Attribute{
+					"enabled": schema.BoolAttribute{
+						Required:    true,
+						Description: "Enable vulnerability scanning for this registration",
+					},
+				},
+			},
 			"status": schema.StringAttribute{
 				Computed:            true,
 				Description:         "The current status of the registration. Possible values: partial (registration is in setup incomplete status), complete (registration was setup successfully and validation succeeded), validation_failed (registration was setup successfully, but validation failed)",
@@ -639,6 +739,28 @@ func (r *cloudGoogleRegistrationResource) Create(
 		}
 	}
 
+	if !plan.DSPM.IsNull() {
+		var dspm dspmModel
+		resp.Diagnostics.Append(dspm.FromObject(ctx, plan.DSPM)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		if dspm.Enabled.ValueBool() {
+			cspmProductFeatures.Features = append(cspmProductFeatures.Features, featureDSPM)
+		}
+	}
+
+	if !plan.VulnerabilityScanning.IsNull() {
+		var vulnScan vulnerabilityScanningModel
+		resp.Diagnostics.Append(vulnScan.FromObject(ctx, plan.VulnerabilityScanning)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		if vulnScan.Enabled.ValueBool() {
+			cspmProductFeatures.Features = append(cspmProductFeatures.Features, featureVulnerabilityScanning)
+		}
+	}
+
 	createReq.Products = []*models.DomainProductFeatures{
 		&cspmProductFeatures,
 	}
@@ -800,6 +922,28 @@ func (r *cloudGoogleRegistrationResource) Update(
 		}
 		if rtv.Enabled.ValueBool() {
 			cspmProductFeatures.Features = append(cspmProductFeatures.Features, "ioa")
+		}
+	}
+
+	if !plan.DSPM.IsNull() {
+		var dspm dspmModel
+		resp.Diagnostics.Append(dspm.FromObject(ctx, plan.DSPM)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		if dspm.Enabled.ValueBool() {
+			cspmProductFeatures.Features = append(cspmProductFeatures.Features, featureDSPM)
+		}
+	}
+
+	if !plan.VulnerabilityScanning.IsNull() {
+		var vulnScan vulnerabilityScanningModel
+		resp.Diagnostics.Append(vulnScan.FromObject(ctx, plan.VulnerabilityScanning)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		if vulnScan.Enabled.ValueBool() {
+			cspmProductFeatures.Features = append(cspmProductFeatures.Features, featureVulnerabilityScanning)
 		}
 	}
 

--- a/internal/cloud_google_registration/cloud_google_registration_settings.go
+++ b/internal/cloud_google_registration/cloud_google_registration_settings.go
@@ -13,6 +13,8 @@ import (
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/framework/validators"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/tferrors"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/utils"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -21,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
@@ -80,6 +83,82 @@ type cloudGoogleRegistrationSettingsModel struct {
 	LogIngestionSubscriptionName types.String `tfsdk:"log_ingestion_subscription_name"`
 	WifPoolName                  types.String `tfsdk:"wif_pool_name"`
 	WifProviderName              types.String `tfsdk:"wif_provider_name"`
+	AgentlessScanningSettings    types.Object `tfsdk:"agentless_scanning_settings"`
+}
+
+// TF schema ↔ provider mapping layer for agentless_scanning_settings.
+type agentlessScanningSettingsModel struct {
+	WIFPrincipal             types.String `tfsdk:"wif_principal"`
+	DeploymentVersion        types.String `tfsdk:"deployment_version"`
+	Regions                  types.Set    `tfsdk:"regions"`
+	HostProjectID            types.String `tfsdk:"host_project_id"`
+	OrgID                    types.String `tfsdk:"org_id"`
+	NetworkConfigurationType types.String `tfsdk:"network_configuration_type"`
+	CustomNetwork            types.Object `tfsdk:"custom_network"`
+	Infra                    types.Map    `tfsdk:"infra"`
+}
+
+func (d *agentlessScanningSettingsModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"wif_principal":              types.StringType,
+		"deployment_version":         types.StringType,
+		"regions":                    types.SetType{ElemType: types.StringType},
+		"host_project_id":            types.StringType,
+		"org_id":                     types.StringType,
+		"network_configuration_type": types.StringType,
+		"custom_network":             types.ObjectType{AttrTypes: (&networkConfigModel{}).AttributeTypes()},
+		"infra":                      types.MapType{ElemType: types.ObjectType{AttrTypes: (&infraProjectModel{}).AttributeTypes()}},
+	}
+}
+
+func (d *agentlessScanningSettingsModel) ToObject(ctx context.Context) (types.Object, diag.Diagnostics) {
+	return types.ObjectValueFrom(ctx, d.AttributeTypes(), d)
+}
+
+func (d *agentlessScanningSettingsModel) FromObject(ctx context.Context, obj types.Object) diag.Diagnostics {
+	return obj.As(ctx, d, basetypes.ObjectAsOptions{})
+}
+
+type infraProjectModel struct {
+	ScannerSAEmail              types.String `tfsdk:"scanner_sa_email"`
+	ClientCredentialsSecretName types.String `tfsdk:"client_credentials_secret_name"`
+	Network                     types.Object `tfsdk:"network"`
+}
+
+func (i *infraProjectModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"scanner_sa_email":               types.StringType,
+		"client_credentials_secret_name": types.StringType,
+		"network":                        types.ObjectType{AttrTypes: (&networkConfigModel{}).AttributeTypes()},
+	}
+}
+
+func (i *infraProjectModel) ToObject(ctx context.Context) (types.Object, diag.Diagnostics) {
+	return types.ObjectValueFrom(ctx, i.AttributeTypes(), i)
+}
+
+func (i *infraProjectModel) FromObject(ctx context.Context, obj types.Object) diag.Diagnostics {
+	return obj.As(ctx, i, basetypes.ObjectAsOptions{})
+}
+
+type networkConfigModel struct {
+	VpcName types.String `tfsdk:"vpc_name"`
+	Subnets types.Map    `tfsdk:"subnets"`
+}
+
+func (n *networkConfigModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"vpc_name": types.StringType,
+		"subnets":  types.MapType{ElemType: types.StringType},
+	}
+}
+
+func (n *networkConfigModel) ToObject(ctx context.Context) (types.Object, diag.Diagnostics) {
+	return types.ObjectValueFrom(ctx, n.AttributeTypes(), n)
+}
+
+func (n *networkConfigModel) FromObject(ctx context.Context, obj types.Object) diag.Diagnostics {
+	return obj.As(ctx, n, basetypes.ObjectAsOptions{})
 }
 
 func (r *cloudGoogleRegistrationSettingsResource) Schema(
@@ -139,13 +218,118 @@ func (r *cloudGoogleRegistrationSettingsResource) Schema(
 					validators.StringNotWhitespace(),
 				},
 			},
+			"agentless_scanning_settings": schema.SingleNestedAttribute{
+				Optional:    true,
+				Description: "Agentless scanning settings. Only configurable after the agentless scanning infrastructure has been created via Terraform.",
+				Attributes: map[string]schema.Attribute{
+					"wif_principal": schema.StringAttribute{
+						Required:    true,
+						Description: "The Workload Identity Federation principal for the agentless scanning.",
+						Validators: []validator.String{
+							validators.StringNotWhitespace(),
+						},
+					},
+					"deployment_version": schema.StringAttribute{
+						Required:    true,
+						Description: "The TF module deployment version for tracking.",
+					},
+					"regions": schema.SetAttribute{
+						Required:    true,
+						ElementType: types.StringType,
+						Description: "The GCP regions where agentless scanning infrastructure is deployed.",
+					},
+					"host_project_id": schema.StringAttribute{
+						Optional:    true,
+						Description: "The GCP project hosting shared scanning infrastructure. When set, indicates cross-project mode.",
+						Validators: []validator.String{
+							validators.StringNotWhitespace(),
+						},
+					},
+					"org_id": schema.StringAttribute{
+						Optional:    true,
+						Description: "The GCP organization ID. Required only for folder-scoped registrations.",
+						Validators: []validator.String{
+							validators.StringNotWhitespace(),
+						},
+					},
+					"network_configuration_type": schema.StringAttribute{
+						Required:    true,
+						Description: "Network configuration type for scanner VMs: managed (with NAT), managed_no_nat, or custom (BYO VPC).",
+						Validators: []validator.String{
+							stringvalidator.OneOf("managed", "managed_no_nat", "custom"),
+						},
+					},
+					"custom_network": schema.SingleNestedAttribute{
+						Optional:    true,
+						Description: "Custom (BYO) network configuration. Required when network_configuration_type is 'custom'.",
+						Attributes: map[string]schema.Attribute{
+							"vpc_name": schema.StringAttribute{
+								Required:    true,
+								Description: "The name of the customer-provided VPC network.",
+								Validators: []validator.String{
+									validators.StringNotWhitespace(),
+								},
+							},
+							"subnets": schema.MapAttribute{
+								Required:    true,
+								ElementType: types.StringType,
+								Description: "Map of region to subnet name within the custom VPC.",
+							},
+						},
+					},
+					"infra": schema.MapNestedAttribute{
+						Required:    true,
+						Description: "Per-project scanning infrastructure details, keyed by GCP project ID. In cross-project mode this contains a single entry for the host project.",
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"scanner_sa_email": schema.StringAttribute{
+									Required:    true,
+									Description: "The service account email used by the scanner in this project.",
+									Validators: []validator.String{
+										validators.StringNotWhitespace(),
+									},
+								},
+								"client_credentials_secret_name": schema.StringAttribute{
+									Required:    true,
+									Description: "The Secret Manager secret name containing Falcon client credentials for scanner authentication.",
+									Validators: []validator.String{
+										validators.StringNotWhitespace(),
+									},
+								},
+								"network": schema.SingleNestedAttribute{
+									Required:    true,
+									Description: "Network configuration for scanner VMs in this project.",
+									Attributes: map[string]schema.Attribute{
+										"vpc_name": schema.StringAttribute{
+											Required:    true,
+											Description: "The VPC network name used by scanner VMs.",
+											Validators: []validator.String{
+												validators.StringNotWhitespace(),
+											},
+										},
+										"subnets": schema.MapAttribute{
+											Required:    true,
+											ElementType: types.StringType,
+											Description: "Map of region to subnet name for scanner VMs.",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }
 
+// wrap maps the BE response to TF state.
 func (m *cloudGoogleRegistrationSettingsModel) wrap(
+	ctx context.Context,
 	registration *models.DtoGCPRegistration,
-) {
+) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	m.RegistrationID = types.StringValue(registration.RegistrationID)
 
 	var sinkName, topicID, subscriptionID string
@@ -165,6 +349,110 @@ func (m *cloudGoogleRegistrationSettingsModel) wrap(
 	}
 	m.WifPoolName = flex.StringValueToFramework(wifPoolName)
 	m.WifProviderName = flex.StringValueToFramework(wifProviderName)
+
+	// Both features share the same infra — read from whichever is set
+	agentlessSettings := registration.DspmSettings
+	if agentlessSettings == nil {
+		agentlessSettings = registration.VulnerabilityScanningSettings
+	}
+	d := m.wrapAgentlessScanningSettings(ctx, agentlessSettings)
+	diags.Append(d...)
+
+	return diags
+}
+
+// Maps BE agentless settings to TF state.
+// Both dspm_settings and vulnerability_scanning_settings share the same infra — we read from whichever is set.
+func (m *cloudGoogleRegistrationSettingsModel) wrapAgentlessScanningSettings(
+	ctx context.Context,
+	dspmSettings *models.GcpAgentlessScanningSettings,
+) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if dspmSettings == nil {
+		m.AgentlessScanningSettings = types.ObjectNull((&agentlessScanningSettingsModel{}).AttributeTypes())
+		return diags
+	}
+
+	settings := agentlessScanningSettingsModel{
+		WIFPrincipal:             flex.StringValueToFramework(dspmSettings.WifPrincipal),
+		DeploymentVersion:        flex.StringValueToFramework(dspmSettings.DeploymentVersion),
+		NetworkConfigurationType: flex.StringValueToFramework("managed"),
+	}
+
+	if dspmSettings.UserInputs != nil {
+		regionsSet, d := flex.FlattenStringValueSet(ctx, dspmSettings.UserInputs.Regions)
+		diags.Append(d...)
+		settings.Regions = regionsSet
+
+		settings.HostProjectID = flex.StringValueToFramework(dspmSettings.UserInputs.HostProjectID)
+		settings.OrgID = flex.StringValueToFramework(dspmSettings.UserInputs.OrgID)
+		settings.NetworkConfigurationType = flex.StringPointerToFramework(dspmSettings.UserInputs.NetworkConfigurationType)
+
+		if dspmSettings.UserInputs.CustomNetwork != nil {
+			subnetsMap, d := types.MapValueFrom(ctx, types.StringType, dspmSettings.UserInputs.CustomNetwork.Subnets)
+			diags.Append(d...)
+			cnModel := networkConfigModel{
+				VpcName: flex.StringPointerToFramework(dspmSettings.UserInputs.CustomNetwork.VpcName),
+				Subnets: subnetsMap,
+			}
+			cnObj, d := cnModel.ToObject(ctx)
+			diags.Append(d...)
+			settings.CustomNetwork = cnObj
+		} else {
+			settings.CustomNetwork = types.ObjectNull((&networkConfigModel{}).AttributeTypes())
+		}
+	} else {
+		settings.Regions = types.SetNull(types.StringType)
+		settings.HostProjectID = types.StringNull()
+		settings.OrgID = types.StringNull()
+		settings.CustomNetwork = types.ObjectNull((&networkConfigModel{}).AttributeTypes())
+	}
+
+	// Build infra map
+	infraMap := make(map[string]attr.Value)
+	for projectID, infraEntry := range dspmSettings.Infra {
+		var networkObj types.Object
+		if infraEntry.Network != nil {
+			subnetsMap, d := types.MapValueFrom(ctx, types.StringType, infraEntry.Network.Subnets)
+			diags.Append(d...)
+			netModel := networkConfigModel{
+				VpcName: flex.StringPointerToFramework(infraEntry.Network.VpcName),
+				Subnets: subnetsMap,
+			}
+			obj, d := netModel.ToObject(ctx)
+			diags.Append(d...)
+			networkObj = obj
+		} else {
+			networkObj = types.ObjectNull((&networkConfigModel{}).AttributeTypes())
+		}
+
+		projModel := infraProjectModel{
+			ScannerSAEmail:              flex.StringPointerToFramework(infraEntry.ScannerSaEmail),
+			ClientCredentialsSecretName: flex.StringPointerToFramework(infraEntry.ClientCredentialsSecretName),
+			Network:                     networkObj,
+		}
+		obj, d := projModel.ToObject(ctx)
+		diags.Append(d...)
+		infraMap[projectID] = obj
+	}
+
+	if len(infraMap) > 0 {
+		infraMapValue, d := types.MapValue(
+			types.ObjectType{AttrTypes: (&infraProjectModel{}).AttributeTypes()},
+			infraMap,
+		)
+		diags.Append(d...)
+		settings.Infra = infraMapValue
+	} else {
+		settings.Infra = types.MapNull(types.ObjectType{AttrTypes: (&infraProjectModel{}).AttributeTypes()})
+	}
+
+	settingsObj, d := settings.ToObject(ctx)
+	diags.Append(d...)
+	m.AgentlessScanningSettings = settingsObj
+
+	return diags
 }
 
 func (r *cloudGoogleRegistrationSettingsResource) Create(
@@ -200,10 +488,22 @@ func (r *cloudGoogleRegistrationSettingsResource) Create(
 		return
 	}
 
+	if !data.AgentlessScanningSettings.IsNull() && !isFeatureEnabled(registration, featureDSPM) && !isFeatureEnabled(registration, featureVulnerabilityScanning) {
+		resp.Diagnostics.AddError(
+			"Agentless Scanning Not Enabled",
+			fmt.Sprintf(
+				"Agentless scanning settings cannot be configured because neither DSPM nor vulnerability scanning is enabled for registration %s. Enable dspm or vulnerability_scanning in the cloud_google_registration resource first.",
+				data.RegistrationID.ValueString(),
+			),
+		)
+		return
+	}
+
 	diags = r.triggerHealthCheck(ctx, data.RegistrationID.ValueString())
 	resp.Diagnostics.Append(diags...)
 
-	data.wrap(registration)
+	d := data.wrap(ctx, registration)
+	resp.Diagnostics.Append(d...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -236,7 +536,8 @@ func (r *cloudGoogleRegistrationSettingsResource) Read(
 		return
 	}
 
-	data.wrap(registration)
+	d := data.wrap(ctx, registration)
+	resp.Diagnostics.Append(d...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -272,10 +573,22 @@ func (r *cloudGoogleRegistrationSettingsResource) Update(
 		return
 	}
 
+	if !data.AgentlessScanningSettings.IsNull() && !isFeatureEnabled(registration, featureDSPM) && !isFeatureEnabled(registration, featureVulnerabilityScanning) {
+		resp.Diagnostics.AddError(
+			"Agentless Scanning Not Enabled",
+			fmt.Sprintf(
+				"Agentless scanning settings cannot be configured because neither DSPM nor vulnerability scanning is enabled for registration %s. Enable dspm or vulnerability_scanning in the cloud_google_registration resource first.",
+				data.RegistrationID.ValueString(),
+			),
+		)
+		return
+	}
+
 	diags = r.triggerHealthCheck(ctx, data.RegistrationID.ValueString())
 	resp.Diagnostics.Append(diags...)
 
-	data.wrap(registration)
+	d := data.wrap(ctx, registration)
+	resp.Diagnostics.Append(d...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -295,6 +608,7 @@ func (r *cloudGoogleRegistrationSettingsResource) Delete(
 	data.LogIngestionSubscriptionName = types.StringValue("")
 	data.WifPoolName = types.StringValue("")
 	data.WifProviderName = types.StringValue("")
+	data.AgentlessScanningSettings = types.ObjectNull((&agentlessScanningSettingsModel{}).AttributeTypes())
 
 	registration, err := r.updateRegistration(ctx, &data)
 	resp.Diagnostics.Append(err...)
@@ -307,7 +621,8 @@ func (r *cloudGoogleRegistrationSettingsResource) Delete(
 		return
 	}
 
-	data.wrap(registration)
+	d := data.wrap(ctx, registration)
+	resp.Diagnostics.Append(d...)
 
 	if registration.LogIngestionProperties != nil {
 		if registration.LogIngestionProperties.SinkName != "" {
@@ -391,6 +706,24 @@ func (r *cloudGoogleRegistrationSettingsResource) isIOAEnabled(
 	return false
 }
 
+func isFeatureEnabled(registration *models.DtoGCPRegistration, feature string) bool {
+	if registration == nil {
+		return false
+	}
+
+	for _, product := range registration.Products {
+		if product.Product != nil && *product.Product == "cspm" {
+			for _, f := range product.Features {
+				if f == feature {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
 func (r *cloudGoogleRegistrationSettingsResource) getRegistration(
 	ctx context.Context,
 	registrationID string,
@@ -428,6 +761,7 @@ func (r *cloudGoogleRegistrationSettingsResource) getRegistration(
 	return res.Payload.Resources[0], diags
 }
 
+// updateRegistration sends settings (WIF, log ingestion, agentless scanning) to the BE.
 func (r *cloudGoogleRegistrationSettingsResource) updateRegistration(
 	ctx context.Context,
 	data *cloudGoogleRegistrationSettingsModel,
@@ -440,6 +774,12 @@ func (r *cloudGoogleRegistrationSettingsResource) updateRegistration(
 		LogIngestionSubscriptionName: flex.FrameworkToStringPointer(data.LogIngestionSubscriptionName),
 		WifPoolName:                  flex.FrameworkToStringPointer(data.WifPoolName),
 		WifProviderName:              flex.FrameworkToStringPointer(data.WifProviderName),
+	}
+
+	d := marshalAgentlessScanningSettings(ctx, data.AgentlessScanningSettings, updateReq)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nil, diags
 	}
 
 	params := &cloud_google_cloud_registration.CloudRegistrationGcpUpdateRegistrationParams{
@@ -478,6 +818,104 @@ func (r *cloudGoogleRegistrationSettingsResource) updateRegistration(
 	}
 
 	return res.Payload.Resources[0], diags
+}
+
+// marshalAgentlessScanningSettings maps TF state (agentlessScanningSettingsModel) → gofalcon update request.
+// Sends to both dspm_settings and vulnerability_scanning_settings — BE handles routing based on enabled features.
+func marshalAgentlessScanningSettings(
+	ctx context.Context,
+	settingsObj types.Object,
+	updateReq *models.DtoUpdateGCPRegistrationRequest,
+) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if settingsObj.IsNull() || settingsObj.IsUnknown() {
+		return diags
+	}
+
+	var settings agentlessScanningSettingsModel
+	diags.Append(settings.FromObject(ctx, settingsObj)...)
+	if diags.HasError() {
+		return diags
+	}
+
+	regions := flex.ExpandSetAs[string](ctx, settings.Regions, &diags)
+	if diags.HasError() {
+		return diags
+	}
+
+	userInputs := &models.GcpAgentlessScanningUserInputs{
+		Regions:                  regions,
+		HostProjectID:            settings.HostProjectID.ValueString(),
+		OrgID:                    settings.OrgID.ValueString(),
+		NetworkConfigurationType: settings.NetworkConfigurationType.ValueStringPointer(),
+	}
+
+	if !settings.CustomNetwork.IsNull() {
+		var cn networkConfigModel
+		diags.Append(cn.FromObject(ctx, settings.CustomNetwork)...)
+		if diags.HasError() {
+			return diags
+		}
+
+		subnets := make(map[string]string)
+		if !cn.Subnets.IsNull() {
+			diags.Append(cn.Subnets.ElementsAs(ctx, &subnets, false)...)
+		}
+
+		userInputs.CustomNetwork = &models.GcpNetworkConfig{
+			VpcName: cn.VpcName.ValueStringPointer(),
+			Subnets: subnets,
+		}
+	}
+
+	infraMap := make(map[string]models.GcpAgentlessScanningInfra)
+	if !settings.Infra.IsNull() {
+		var infraEntries map[string]infraProjectModel
+		diags.Append(settings.Infra.ElementsAs(ctx, &infraEntries, false)...)
+		if diags.HasError() {
+			return diags
+		}
+
+		for projectID, entry := range infraEntries {
+			infra := models.GcpAgentlessScanningInfra{
+				ScannerSaEmail:              entry.ScannerSAEmail.ValueStringPointer(),
+				ClientCredentialsSecretName: entry.ClientCredentialsSecretName.ValueStringPointer(),
+			}
+
+			if !entry.Network.IsNull() {
+				var net networkConfigModel
+				diags.Append(net.FromObject(ctx, entry.Network)...)
+				if diags.HasError() {
+					return diags
+				}
+
+				subnets := make(map[string]string)
+				if !net.Subnets.IsNull() {
+					diags.Append(net.Subnets.ElementsAs(ctx, &subnets, false)...)
+				}
+
+				infra.Network = &models.GcpNetworkConfig{
+					VpcName: net.VpcName.ValueStringPointer(),
+					Subnets: subnets,
+				}
+			}
+
+			infraMap[projectID] = infra
+		}
+	}
+
+	agentlessSettings := &models.GcpAgentlessScanningSettings{
+		WifPrincipal:      settings.WIFPrincipal.ValueString(),
+		DeploymentVersion: settings.DeploymentVersion.ValueString(),
+		UserInputs:        userInputs,
+		Infra:             infraMap,
+	}
+
+	updateReq.DspmSettings = agentlessSettings
+	updateReq.VulnerabilityScanningSettings = agentlessSettings
+
+	return diags
 }
 
 func (r *cloudGoogleRegistrationSettingsResource) triggerHealthCheck(

--- a/internal/cloud_google_registration/cloud_google_registration_settings.go
+++ b/internal/cloud_google_registration/cloud_google_registration_settings.go
@@ -365,35 +365,35 @@ func (m *cloudGoogleRegistrationSettingsModel) wrap(
 // Both dspm_settings and vulnerability_scanning_settings share the same infra — we read from whichever is set.
 func (m *cloudGoogleRegistrationSettingsModel) wrapAgentlessScanningSettings(
 	ctx context.Context,
-	dspmSettings *models.GcpAgentlessScanningSettings,
+	agentlessScanningSettings *models.GcpAgentlessScanningSettings,
 ) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	if dspmSettings == nil {
+	if agentlessScanningSettings == nil {
 		m.AgentlessScanningSettings = types.ObjectNull((&agentlessScanningSettingsModel{}).AttributeTypes())
 		return diags
 	}
 
 	settings := agentlessScanningSettingsModel{
-		WIFPrincipal:             flex.StringValueToFramework(dspmSettings.WifPrincipal),
-		DeploymentVersion:        flex.StringValueToFramework(dspmSettings.DeploymentVersion),
+		WIFPrincipal:             flex.StringValueToFramework(agentlessScanningSettings.WifPrincipal),
+		DeploymentVersion:        flex.StringValueToFramework(agentlessScanningSettings.DeploymentVersion),
 		NetworkConfigurationType: flex.StringValueToFramework("managed"),
 	}
 
-	if dspmSettings.UserInputs != nil {
-		regionsSet, d := flex.FlattenStringValueSet(ctx, dspmSettings.UserInputs.Regions)
+	if agentlessScanningSettings.UserInputs != nil {
+		regionsSet, d := flex.FlattenStringValueSet(ctx, agentlessScanningSettings.UserInputs.Regions)
 		diags.Append(d...)
 		settings.Regions = regionsSet
 
-		settings.HostProjectID = flex.StringValueToFramework(dspmSettings.UserInputs.HostProjectID)
-		settings.OrgID = flex.StringValueToFramework(dspmSettings.UserInputs.OrgID)
-		settings.NetworkConfigurationType = flex.StringPointerToFramework(dspmSettings.UserInputs.NetworkConfigurationType)
+		settings.HostProjectID = flex.StringValueToFramework(agentlessScanningSettings.UserInputs.HostProjectID)
+		settings.OrgID = flex.StringValueToFramework(agentlessScanningSettings.UserInputs.OrgID)
+		settings.NetworkConfigurationType = flex.StringPointerToFramework(agentlessScanningSettings.UserInputs.NetworkConfigurationType)
 
-		if dspmSettings.UserInputs.CustomNetwork != nil {
-			subnetsMap, d := types.MapValueFrom(ctx, types.StringType, dspmSettings.UserInputs.CustomNetwork.Subnets)
+		if agentlessScanningSettings.UserInputs.CustomNetwork != nil {
+			subnetsMap, d := types.MapValueFrom(ctx, types.StringType, agentlessScanningSettings.UserInputs.CustomNetwork.Subnets)
 			diags.Append(d...)
 			cnModel := networkConfigModel{
-				VpcName: flex.StringPointerToFramework(dspmSettings.UserInputs.CustomNetwork.VpcName),
+				VpcName: flex.StringPointerToFramework(agentlessScanningSettings.UserInputs.CustomNetwork.VpcName),
 				Subnets: subnetsMap,
 			}
 			cnObj, d := cnModel.ToObject(ctx)
@@ -411,7 +411,7 @@ func (m *cloudGoogleRegistrationSettingsModel) wrapAgentlessScanningSettings(
 
 	// Build infra map
 	infraMap := make(map[string]attr.Value)
-	for projectID, infraEntry := range dspmSettings.Infra {
+	for projectID, infraEntry := range agentlessScanningSettings.Infra {
 		var networkObj types.Object
 		if infraEntry.Network != nil {
 			subnetsMap, d := types.MapValueFrom(ctx, types.StringType, infraEntry.Network.Subnets)

--- a/internal/cloud_google_registration/cloud_google_registration_settings.go
+++ b/internal/cloud_google_registration/cloud_google_registration_settings.go
@@ -13,6 +13,8 @@ import (
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/framework/validators"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/tferrors"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/utils"
+	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -232,11 +234,18 @@ func (r *cloudGoogleRegistrationSettingsResource) Schema(
 					"deployment_version": schema.StringAttribute{
 						Required:    true,
 						Description: "The TF module deployment version for tracking.",
+						Validators: []validator.String{
+							validators.StringNotWhitespace(),
+						},
 					},
 					"regions": schema.SetAttribute{
 						Required:    true,
 						ElementType: types.StringType,
 						Description: "The GCP regions where agentless scanning infrastructure is deployed.",
+						Validators: []validator.Set{
+							setvalidator.SizeAtLeast(1),
+							setvalidator.ValueStringsAre(validators.StringNotWhitespace()),
+						},
 					},
 					"host_project_id": schema.StringAttribute{
 						Optional:    true,
@@ -274,12 +283,20 @@ func (r *cloudGoogleRegistrationSettingsResource) Schema(
 								Required:    true,
 								ElementType: types.StringType,
 								Description: "Map of region to subnet name within the custom VPC.",
+								Validators: []validator.Map{
+									mapvalidator.SizeAtLeast(1),
+									mapvalidator.KeysAre(validators.StringNotWhitespace()),
+									mapvalidator.ValueStringsAre(validators.StringNotWhitespace()),
+								},
 							},
 						},
 					},
 					"infra": schema.MapNestedAttribute{
 						Required:    true,
 						Description: "Per-project scanning infrastructure details, keyed by GCP project ID. In cross-project mode this contains a single entry for the host project.",
+						Validators: []validator.Map{
+							mapvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"scanner_sa_email": schema.StringAttribute{
@@ -311,6 +328,11 @@ func (r *cloudGoogleRegistrationSettingsResource) Schema(
 											Required:    true,
 											ElementType: types.StringType,
 											Description: "Map of region to subnet name for scanner VMs.",
+											Validators: []validator.Map{
+												mapvalidator.SizeAtLeast(1),
+												mapvalidator.KeysAre(validators.StringNotWhitespace()),
+												mapvalidator.ValueStringsAre(validators.StringNotWhitespace()),
+											},
 										},
 									},
 								},
@@ -683,6 +705,32 @@ func (r *cloudGoogleRegistrationSettingsResource) ValidateConfig(
 	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	if !config.AgentlessScanningSettings.IsNull() && !config.AgentlessScanningSettings.IsUnknown() {
+		var settings agentlessScanningSettingsModel
+		resp.Diagnostics.Append(config.AgentlessScanningSettings.As(ctx, &settings, basetypes.ObjectAsOptions{})...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		if utils.IsKnown(settings.NetworkConfigurationType) {
+			isCustom := settings.NetworkConfigurationType.ValueString() == "custom"
+			if isCustom && settings.CustomNetwork.IsNull() {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("agentless_scanning_settings").AtName("custom_network"),
+					"Missing Required Attribute",
+					"custom_network is required when network_configuration_type is 'custom'.",
+				)
+			}
+			if !isCustom && !settings.CustomNetwork.IsNull() {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("agentless_scanning_settings").AtName("custom_network"),
+					"Invalid Attribute Combination",
+					"custom_network can only be set when network_configuration_type is 'custom'.",
+				)
+			}
+		}
 	}
 }
 

--- a/internal/cloud_google_registration/cloud_google_registration_settings_test.go
+++ b/internal/cloud_google_registration/cloud_google_registration_settings_test.go
@@ -8,7 +8,10 @@ import (
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/acctest"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 func TestAccCloudGoogleRegistrationSettingsResource_Basic(t *testing.T) {
@@ -33,13 +36,15 @@ func TestAccCloudGoogleRegistrationSettingsResource_Basic(t *testing.T) {
 					registrationConfig,
 					testAccCloudGoogleRegistrationSettingsConfig_basic(),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(settingsResourceName, tfjsonpath.New("log_ingestion_sink_name"), knownvalue.StringExact("test-sink")),
+					statecheck.ExpectKnownValue(settingsResourceName, tfjsonpath.New("log_ingestion_topic_id"), knownvalue.StringExact("test-topic")),
+					statecheck.ExpectKnownValue(settingsResourceName, tfjsonpath.New("log_ingestion_subscription_name"), knownvalue.StringExact("test-subscription")),
+					statecheck.ExpectKnownValue(settingsResourceName, tfjsonpath.New("wif_pool_name"), knownvalue.StringExact("test-pool")),
+					statecheck.ExpectKnownValue(settingsResourceName, tfjsonpath.New("wif_provider_name"), knownvalue.StringExact("test-provider")),
+				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(settingsResourceName, "registration_id", projectResourceName, "id"),
-					resource.TestCheckResourceAttr(settingsResourceName, "log_ingestion_sink_name", "test-sink"),
-					resource.TestCheckResourceAttr(settingsResourceName, "log_ingestion_topic_id", "test-topic"),
-					resource.TestCheckResourceAttr(settingsResourceName, "log_ingestion_subscription_name", "test-subscription"),
-					resource.TestCheckResourceAttr(settingsResourceName, "wif_pool_name", "test-pool"),
-					resource.TestCheckResourceAttr(settingsResourceName, "wif_provider_name", "test-provider"),
 				),
 			},
 			{
@@ -74,13 +79,15 @@ func TestAccCloudGoogleRegistrationSettingsResource_Basic(t *testing.T) {
 					registrationConfig,
 					testAccCloudGoogleRegistrationSettingsConfig_updated(),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(settingsResourceName, tfjsonpath.New("log_ingestion_sink_name"), knownvalue.StringExact("test-sink-updated")),
+					statecheck.ExpectKnownValue(settingsResourceName, tfjsonpath.New("log_ingestion_topic_id"), knownvalue.StringExact("test-topic-updated")),
+					statecheck.ExpectKnownValue(settingsResourceName, tfjsonpath.New("log_ingestion_subscription_name"), knownvalue.StringExact("test-subscription-updated")),
+					statecheck.ExpectKnownValue(settingsResourceName, tfjsonpath.New("wif_pool_name"), knownvalue.StringExact("test-pool-updated")),
+					statecheck.ExpectKnownValue(settingsResourceName, tfjsonpath.New("wif_provider_name"), knownvalue.StringExact("test-provider-updated")),
+				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(settingsResourceName, "registration_id", projectResourceName, "id"),
-					resource.TestCheckResourceAttr(settingsResourceName, "log_ingestion_sink_name", "test-sink-updated"),
-					resource.TestCheckResourceAttr(settingsResourceName, "log_ingestion_topic_id", "test-topic-updated"),
-					resource.TestCheckResourceAttr(settingsResourceName, "log_ingestion_subscription_name", "test-subscription-updated"),
-					resource.TestCheckResourceAttr(settingsResourceName, "wif_pool_name", "test-pool-updated"),
-					resource.TestCheckResourceAttr(settingsResourceName, "wif_provider_name", "test-provider-updated"),
 				),
 			},
 		},
@@ -122,6 +129,179 @@ func TestAccCloudGoogleRegistrationSettingsResource_IOANotEnabled(t *testing.T) 
 					resource.TestCheckNoResourceAttr(settingsResourceName, "log_ingestion_topic_id"),
 					resource.TestCheckNoResourceAttr(settingsResourceName, "log_ingestion_subscription_name"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccCloudGoogleRegistrationSettingsResourceAgentlessScanning(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	projectID := generateGoogleCloudProjectID()
+	infraProjectID := generateGoogleCloudProjectID()
+	wifProjectID := generateGoogleCloudProjectID()
+	wifProjectNumber := generateGoogleCloudProjectNumber()
+
+	settingsResourceName := "crowdstrike_cloud_google_registration_settings.test"
+	projectResourceName := "crowdstrike_cloud_google_registration.test"
+
+	registrationConfig := cloudGoogleRegistrationConfigWithDSPM(rName, projectID, infraProjectID, wifProjectID, wifProjectNumber)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ConfigCompose(
+					registrationConfig,
+					testAccCloudGoogleRegistrationSettingsConfig_agentlessScanning(projectID),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(settingsResourceName, tfjsonpath.New("agentless_scanning_settings").AtMapKey("wif_principal"), knownvalue.StringExact("principal://test-wif-principal")),
+					statecheck.ExpectKnownValue(settingsResourceName, tfjsonpath.New("agentless_scanning_settings").AtMapKey("deployment_version"), knownvalue.StringExact("1.0.0")),
+					statecheck.ExpectKnownValue(settingsResourceName, tfjsonpath.New("agentless_scanning_settings").AtMapKey("network_configuration_type"), knownvalue.StringExact("managed")),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(settingsResourceName, "registration_id", projectResourceName, "id"),
+					resource.TestCheckResourceAttr(settingsResourceName, "agentless_scanning_settings.regions.#", "1"),
+					resource.TestCheckResourceAttr(settingsResourceName, "agentless_scanning_settings.infra.%", "1"),
+					resource.TestCheckResourceAttr(settingsResourceName, fmt.Sprintf("agentless_scanning_settings.infra.%s.scanner_sa_email", projectID), "scanner@test.iam.gserviceaccount.com"),
+					resource.TestCheckResourceAttr(settingsResourceName, fmt.Sprintf("agentless_scanning_settings.infra.%s.client_credentials_secret_name", projectID), "csscanning-falcon-credentials"),
+				),
+			},
+			{
+				Config: acctest.ConfigCompose(
+					registrationConfig,
+					testAccCloudGoogleRegistrationSettingsConfig_agentlessScanningUpdated(projectID),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(settingsResourceName, tfjsonpath.New("agentless_scanning_settings").AtMapKey("deployment_version"), knownvalue.StringExact("1.1.0")),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(settingsResourceName, "agentless_scanning_settings.regions.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudGoogleRegistrationSettingsResourceAgentlessScanningNotEnabled(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	projectID := generateGoogleCloudProjectID()
+	infraProjectID := generateGoogleCloudProjectID()
+	wifProjectID := generateGoogleCloudProjectID()
+	wifProjectNumber := generateGoogleCloudProjectNumber()
+	rtvdEnabled := false
+
+	registrationConfig := cloudGoogleRegistrationConfig(rName, projectID, infraProjectID, wifProjectID, wifProjectNumber, rtvdEnabled)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ConfigCompose(
+					registrationConfig,
+					testAccCloudGoogleRegistrationSettingsConfig_agentlessScanning(projectID),
+				),
+				ExpectError: regexp.MustCompile(`Agentless Scanning Not Enabled`),
+			},
+		},
+	})
+}
+
+func TestAccCloudGoogleRegistrationSettingsResourceAgentlessScanningCrossProject(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	projectID := generateGoogleCloudProjectID()
+	infraProjectID := generateGoogleCloudProjectID()
+	wifProjectID := generateGoogleCloudProjectID()
+	wifProjectNumber := generateGoogleCloudProjectNumber()
+
+	settingsResourceName := "crowdstrike_cloud_google_registration_settings.test"
+
+	registrationConfig := cloudGoogleRegistrationConfigWithDSPM(rName, projectID, infraProjectID, wifProjectID, wifProjectNumber)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ConfigCompose(
+					registrationConfig,
+					testAccCloudGoogleRegistrationSettingsConfig_agentlessScanningWithCrossProject(infraProjectID),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(settingsResourceName, tfjsonpath.New("agentless_scanning_settings").AtMapKey("host_project_id"), knownvalue.StringExact(infraProjectID)),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(settingsResourceName, "agentless_scanning_settings.infra.%", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudGoogleRegistrationSettingsResourceAgentlessScanningCustomNetwork(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	projectID := generateGoogleCloudProjectID()
+	infraProjectID := generateGoogleCloudProjectID()
+	wifProjectID := generateGoogleCloudProjectID()
+	wifProjectNumber := generateGoogleCloudProjectNumber()
+
+	settingsResourceName := "crowdstrike_cloud_google_registration_settings.test"
+
+	registrationConfig := cloudGoogleRegistrationConfigWithDSPM(rName, projectID, infraProjectID, wifProjectID, wifProjectNumber)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ConfigCompose(
+					registrationConfig,
+					testAccCloudGoogleRegistrationSettingsConfig_agentlessScanningWithCustomNetwork(projectID),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(settingsResourceName, tfjsonpath.New("agentless_scanning_settings").AtMapKey("network_configuration_type"), knownvalue.StringExact("custom")),
+					statecheck.ExpectKnownValue(settingsResourceName, tfjsonpath.New("agentless_scanning_settings").AtMapKey("custom_network").AtMapKey("vpc_name"), knownvalue.StringExact("customer-vpc")),
+				},
+			},
+		},
+	})
+}
+
+func TestAccCloudGoogleRegistrationSettingsResourceAgentlessScanningImport(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	projectID := generateGoogleCloudProjectID()
+	infraProjectID := generateGoogleCloudProjectID()
+	wifProjectID := generateGoogleCloudProjectID()
+	wifProjectNumber := generateGoogleCloudProjectNumber()
+
+	settingsResourceName := "crowdstrike_cloud_google_registration_settings.test"
+
+	registrationConfig := cloudGoogleRegistrationConfigWithDSPM(rName, projectID, infraProjectID, wifProjectID, wifProjectNumber)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ConfigCompose(
+					registrationConfig,
+					testAccCloudGoogleRegistrationSettingsConfig_agentlessScanning(projectID),
+				),
+			},
+			{
+				ResourceName:      settingsResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources[settingsResourceName]
+					if !ok {
+						return "", fmt.Errorf("Resource not found: %s", settingsResourceName)
+					}
+					return rs.Primary.Attributes["registration_id"], nil
+				},
+				ImportStateVerifyIdentifierAttribute: "registration_id",
 			},
 		},
 	})
@@ -188,4 +368,156 @@ resource "crowdstrike_cloud_google_registration_settings" "test" {
   depends_on = [crowdstrike_cloud_google_registration.test]
 }
 `
+}
+
+func cloudGoogleRegistrationConfigWithDSPM(
+	rName,
+	projectID,
+	infraProjectID,
+	wifProjectID,
+	wifProjectNumber string,
+) string {
+	return fmt.Sprintf(`
+resource "crowdstrike_cloud_google_registration" "test" {
+  name               = %[1]q
+  projects           = [%[2]q]
+  infra_project      = %[3]q
+  wif_project        = %[4]q
+  wif_project_number = %[5]q
+
+  dspm = {
+    enabled = true
+  }
+}
+`, rName, projectID, infraProjectID, wifProjectID, wifProjectNumber)
+}
+
+func testAccCloudGoogleRegistrationSettingsConfig_agentlessScanning(projectID string) string {
+	return fmt.Sprintf(`
+resource "crowdstrike_cloud_google_registration_settings" "test" {
+  registration_id = crowdstrike_cloud_google_registration.test.id
+  wif_pool_name   = "test-pool"
+  wif_provider_name = "test-provider"
+
+  agentless_scanning_settings = {
+    wif_principal              = "principal://test-wif-principal"
+    deployment_version         = "1.0.0"
+    regions                    = ["us-east1"]
+    network_configuration_type = "managed"
+
+    infra = {
+      %[1]q = {
+        scanner_sa_email               = "scanner@test.iam.gserviceaccount.com"
+        client_credentials_secret_name = "csscanning-falcon-credentials"
+        network = {
+          vpc_name = "test-vpc"
+          subnets  = { "us-east1" = "test-subnet-us-east1" }
+        }
+      }
+    }
+  }
+
+  depends_on = [crowdstrike_cloud_google_registration.test]
+}
+`, projectID)
+}
+
+func testAccCloudGoogleRegistrationSettingsConfig_agentlessScanningUpdated(projectID string) string {
+	return fmt.Sprintf(`
+resource "crowdstrike_cloud_google_registration_settings" "test" {
+  registration_id = crowdstrike_cloud_google_registration.test.id
+  wif_pool_name   = "test-pool"
+  wif_provider_name = "test-provider"
+
+  agentless_scanning_settings = {
+    wif_principal              = "principal://test-wif-principal"
+    deployment_version         = "1.1.0"
+    regions                    = ["us-east1", "us-west1"]
+    network_configuration_type = "managed"
+
+    infra = {
+      %[1]q = {
+        scanner_sa_email               = "scanner@test.iam.gserviceaccount.com"
+        client_credentials_secret_name = "csscanning-falcon-credentials"
+        network = {
+          vpc_name = "test-vpc"
+          subnets  = {
+            "us-east1" = "test-subnet-us-east1"
+            "us-west1" = "test-subnet-us-west1"
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [crowdstrike_cloud_google_registration.test]
+}
+`, projectID)
+}
+
+func testAccCloudGoogleRegistrationSettingsConfig_agentlessScanningWithCrossProject(infraProjectID string) string {
+	return fmt.Sprintf(`
+resource "crowdstrike_cloud_google_registration_settings" "test" {
+  registration_id = crowdstrike_cloud_google_registration.test.id
+  wif_pool_name   = "test-pool"
+  wif_provider_name = "test-provider"
+
+  agentless_scanning_settings = {
+    wif_principal              = "principal://test-wif-principal"
+    deployment_version         = "1.0.0"
+    regions                    = ["us-east1"]
+    host_project_id            = %[1]q
+    network_configuration_type = "managed"
+
+    infra = {
+      %[1]q = {
+        scanner_sa_email               = "scanner@test.iam.gserviceaccount.com"
+        client_credentials_secret_name = "csscanning-falcon-credentials"
+        network = {
+          vpc_name = "test-vpc"
+          subnets  = { "us-east1" = "test-subnet-us-east1" }
+        }
+      }
+    }
+  }
+
+  depends_on = [crowdstrike_cloud_google_registration.test]
+}
+`, infraProjectID)
+}
+
+func testAccCloudGoogleRegistrationSettingsConfig_agentlessScanningWithCustomNetwork(projectID string) string {
+	return fmt.Sprintf(`
+resource "crowdstrike_cloud_google_registration_settings" "test" {
+  registration_id = crowdstrike_cloud_google_registration.test.id
+  wif_pool_name   = "test-pool"
+  wif_provider_name = "test-provider"
+
+  agentless_scanning_settings = {
+    wif_principal              = "principal://test-wif-principal"
+    deployment_version         = "1.0.0"
+    regions                    = ["us-east1"]
+    host_project_id            = %[1]q
+    network_configuration_type = "custom"
+
+    custom_network = {
+      vpc_name = "customer-vpc"
+      subnets  = { "us-east1" = "customer-subnet-us-east1" }
+    }
+
+    infra = {
+      %[1]q = {
+        scanner_sa_email               = "scanner@test.iam.gserviceaccount.com"
+        client_credentials_secret_name = "csscanning-falcon-credentials"
+        network = {
+          vpc_name = "customer-vpc"
+          subnets  = { "us-east1" = "customer-subnet-us-east1" }
+        }
+      }
+    }
+  }
+
+  depends_on = [crowdstrike_cloud_google_registration.test]
+}
+`, projectID)
 }

--- a/internal/cloud_google_registration/cloud_google_registration_settings_test.go
+++ b/internal/cloud_google_registration/cloud_google_registration_settings_test.go
@@ -521,3 +521,85 @@ resource "crowdstrike_cloud_google_registration_settings" "test" {
 }
 `, projectID)
 }
+
+func TestAccCloudGoogleRegistrationSettingsResourceAgentlessScanningCustomNetworkValidation(t *testing.T) {
+	projectID := generateGoogleCloudProjectID()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCloudGoogleRegistrationSettingsConfig_customNetworkMissing(projectID),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`custom_network is required when network_configuration_type is 'custom'`),
+			},
+			{
+				Config:      testAccCloudGoogleRegistrationSettingsConfig_customNetworkNotAllowed(projectID),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`custom_network can only be set when network_configuration_type is 'custom'`),
+			},
+		},
+	})
+}
+
+func testAccCloudGoogleRegistrationSettingsConfig_customNetworkMissing(projectID string) string {
+	return fmt.Sprintf(`
+resource "crowdstrike_cloud_google_registration_settings" "test" {
+  registration_id   = "fake-reg-id"
+  wif_pool_name     = "test-pool"
+  wif_provider_name = "test-provider"
+
+  agentless_scanning_settings = {
+    wif_principal              = "principal://test-wif-principal"
+    deployment_version         = "1.0.0"
+    regions                    = ["us-east1"]
+    network_configuration_type = "custom"
+
+    infra = {
+      %[1]q = {
+        scanner_sa_email               = "scanner@test.iam.gserviceaccount.com"
+        client_credentials_secret_name = "csscanning-falcon-credentials"
+        network = {
+          vpc_name = "scanner-vpc"
+          subnets  = { "us-east1" = "scanner-subnet" }
+        }
+      }
+    }
+  }
+}
+`, projectID)
+}
+
+func testAccCloudGoogleRegistrationSettingsConfig_customNetworkNotAllowed(projectID string) string {
+	return fmt.Sprintf(`
+resource "crowdstrike_cloud_google_registration_settings" "test" {
+  registration_id   = "fake-reg-id"
+  wif_pool_name     = "test-pool"
+  wif_provider_name = "test-provider"
+
+  agentless_scanning_settings = {
+    wif_principal              = "principal://test-wif-principal"
+    deployment_version         = "1.0.0"
+    regions                    = ["us-east1"]
+    network_configuration_type = "managed"
+
+    custom_network = {
+      vpc_name = "customer-vpc"
+      subnets  = { "us-east1" = "customer-subnet" }
+    }
+
+    infra = {
+      %[1]q = {
+        scanner_sa_email               = "scanner@test.iam.gserviceaccount.com"
+        client_credentials_secret_name = "csscanning-falcon-credentials"
+        network = {
+          vpc_name = "scanner-vpc"
+          subnets  = { "us-east1" = "scanner-subnet" }
+        }
+      }
+    }
+  }
+}
+`, projectID)
+}

--- a/internal/cloud_google_registration/cloud_google_registration_test.go
+++ b/internal/cloud_google_registration/cloud_google_registration_test.go
@@ -9,7 +9,10 @@ import (
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/acctest"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 func generateGoogleCloudProjectID() string {
@@ -39,31 +42,31 @@ func TestAccCloudGoogleRegistrationResource_Complete(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCloudGoogleRegistrationConfig_complete(rName, projectID, infraProjectID, wifProjectID, wifProjectNumber),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "registration_scope", "project"),
-					resource.TestCheckResourceAttr(resourceName, "projects.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "deployment_method", "terraform-native"),
-					resource.TestCheckResourceAttr(resourceName, "infra_project", infraProjectID),
-					resource.TestCheckResourceAttr(resourceName, "wif_project", wifProjectID),
-					resource.TestCheckResourceAttr(resourceName, "wif_project_number", wifProjectNumber),
-					resource.TestCheckResourceAttr(resourceName, "excluded_project_patterns.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "excluded_project_patterns.0", "test-*"),
-					resource.TestCheckResourceAttr(resourceName, "excluded_project_patterns.1", "*-sandbox"),
-					resource.TestCheckResourceAttr(resourceName, "resource_name_prefix", "cs-"),
-					resource.TestCheckResourceAttr(resourceName, "resource_name_suffix", "-prod"),
-					resource.TestCheckResourceAttr(resourceName, "labels.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "labels.environment", "production"),
-					resource.TestCheckResourceAttr(resourceName, "labels.managed-by", "terraform"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.compliance", "required"),
-					resource.TestCheckResourceAttr(resourceName, "tags.owner", "security-team"),
-					resource.TestCheckResourceAttr(resourceName, "realtime_visibility.enabled", "true"),
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttrSet(resourceName, "status"),
-					resource.TestCheckResourceAttrSet(resourceName, "wif_pool_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "wif_provider_id"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("registration_scope"), knownvalue.StringExact("project")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("projects"), knownvalue.SetSizeExact(1)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("deployment_method"), knownvalue.StringExact("terraform-native")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("infra_project"), knownvalue.StringExact(infraProjectID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("wif_project"), knownvalue.StringExact(wifProjectID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("wif_project_number"), knownvalue.StringExact(wifProjectNumber)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("excluded_project_patterns"), knownvalue.ListSizeExact(2)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("excluded_project_patterns").AtSliceIndex(0), knownvalue.StringExact("test-*")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("excluded_project_patterns").AtSliceIndex(1), knownvalue.StringExact("*-sandbox")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("resource_name_prefix"), knownvalue.StringExact("cs-")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("resource_name_suffix"), knownvalue.StringExact("-prod")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("labels"), knownvalue.MapSizeExact(2)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("labels").AtMapKey("environment"), knownvalue.StringExact("production")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("labels").AtMapKey("managed-by"), knownvalue.StringExact("terraform")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("tags"), knownvalue.MapSizeExact(2)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("tags").AtMapKey("compliance"), knownvalue.StringExact("required")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("tags").AtMapKey("owner"), knownvalue.StringExact("security-team")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("realtime_visibility").AtMapKey("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("status"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("wif_pool_id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("wif_provider_id"), knownvalue.NotNull()),
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -72,29 +75,29 @@ func TestAccCloudGoogleRegistrationResource_Complete(t *testing.T) {
 			},
 			{
 				Config: testAccCloudGoogleRegistrationConfig_completeUpdated(rNameUpdated, projectID, infraProjectID, wifProjectID, wifProjectNumber),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
-					resource.TestCheckResourceAttr(resourceName, "registration_scope", "project"),
-					resource.TestCheckResourceAttr(resourceName, "projects.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "deployment_method", "infrastructure-manager"),
-					resource.TestCheckResourceAttr(resourceName, "infrastructure_manager_region", "us-central1"),
-					resource.TestCheckResourceAttr(resourceName, "infra_project", infraProjectID),
-					resource.TestCheckResourceAttr(resourceName, "wif_project", wifProjectID),
-					resource.TestCheckResourceAttr(resourceName, "excluded_project_patterns.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "excluded_project_patterns.0", "dev-*"),
-					resource.TestCheckResourceAttr(resourceName, "resource_name_prefix", "cs-"),
-					resource.TestCheckResourceAttr(resourceName, "resource_name_suffix", "-stg"),
-					resource.TestCheckResourceAttr(resourceName, "labels.%", "3"),
-					resource.TestCheckResourceAttr(resourceName, "labels.environment", "staging"),
-					resource.TestCheckResourceAttr(resourceName, "labels.managed-by", "terraform"),
-					resource.TestCheckResourceAttr(resourceName, "labels.team", "security"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.compliance", "optional"),
-					resource.TestCheckResourceAttr(resourceName, "realtime_visibility.enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "wif_project_number", wifProjectNumber),
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttrSet(resourceName, "status"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rNameUpdated)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("registration_scope"), knownvalue.StringExact("project")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("projects"), knownvalue.SetSizeExact(1)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("deployment_method"), knownvalue.StringExact("infrastructure-manager")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("infrastructure_manager_region"), knownvalue.StringExact("us-central1")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("infra_project"), knownvalue.StringExact(infraProjectID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("wif_project"), knownvalue.StringExact(wifProjectID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("excluded_project_patterns"), knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("excluded_project_patterns").AtSliceIndex(0), knownvalue.StringExact("dev-*")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("resource_name_prefix"), knownvalue.StringExact("cs-")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("resource_name_suffix"), knownvalue.StringExact("-stg")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("labels"), knownvalue.MapSizeExact(3)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("labels").AtMapKey("environment"), knownvalue.StringExact("staging")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("labels").AtMapKey("managed-by"), knownvalue.StringExact("terraform")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("labels").AtMapKey("team"), knownvalue.StringExact("security")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("tags"), knownvalue.MapSizeExact(1)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("tags").AtMapKey("compliance"), knownvalue.StringExact("optional")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("realtime_visibility").AtMapKey("enabled"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("wif_project_number"), knownvalue.StringExact(wifProjectNumber)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("status"), knownvalue.NotNull()),
+				},
 			},
 		},
 	})
@@ -115,19 +118,19 @@ func TestAccCloudGoogleRegistrationResource_Project(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCloudGoogleRegistrationConfig_project(rName, infraProjectID, wifProjectID, wifProjectNumber, projectID),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "registration_scope", "project"),
-					resource.TestCheckResourceAttr(resourceName, "projects.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "deployment_method", "terraform-native"),
-					resource.TestCheckResourceAttr(resourceName, "infra_project", infraProjectID),
-					resource.TestCheckResourceAttr(resourceName, "wif_project", wifProjectID),
-					resource.TestCheckResourceAttr(resourceName, "wif_project_number", wifProjectNumber),
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttrSet(resourceName, "status"),
-					resource.TestCheckResourceAttrSet(resourceName, "wif_pool_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "wif_provider_id"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("registration_scope"), knownvalue.StringExact("project")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("projects"), knownvalue.SetSizeExact(1)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("deployment_method"), knownvalue.StringExact("terraform-native")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("infra_project"), knownvalue.StringExact(infraProjectID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("wif_project"), knownvalue.StringExact(wifProjectID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("wif_project_number"), knownvalue.StringExact(wifProjectNumber)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("status"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("wif_pool_id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("wif_provider_id"), knownvalue.NotNull()),
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -136,19 +139,18 @@ func TestAccCloudGoogleRegistrationResource_Project(t *testing.T) {
 			},
 			{
 				Config: testAccCloudGoogleRegistrationConfig_project(rName, infraProjectID, wifProjectID, wifProjectNumber, projectID, projectID2),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "registration_scope", "project"),
-					resource.TestCheckResourceAttr(resourceName, "projects.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "deployment_method", "terraform-native"),
-					resource.TestCheckResourceAttr(resourceName, "infra_project", infraProjectID),
-					resource.TestCheckResourceAttr(resourceName, "wif_project", wifProjectID),
-					resource.TestCheckResourceAttr(resourceName, "wif_project_number", wifProjectNumber),
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttrSet(resourceName, "status"),
-					resource.TestCheckResourceAttrSet(resourceName, "wif_pool_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "wif_provider_id"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("registration_scope"), knownvalue.StringExact("project")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("projects"), knownvalue.SetSizeExact(2)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("infra_project"), knownvalue.StringExact(infraProjectID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("wif_project"), knownvalue.StringExact(wifProjectID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("wif_project_number"), knownvalue.StringExact(wifProjectNumber)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("status"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("wif_pool_id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("wif_provider_id"), knownvalue.NotNull()),
+				},
 			},
 		},
 	})
@@ -169,16 +171,16 @@ func TestAccCloudGoogleRegistrationResource_Organization(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCloudGoogleRegistrationConfig_organization(rName, orgID, infraProjectID, wifProjectID, wifProjectNumber),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "registration_scope", "organization"),
-					resource.TestCheckResourceAttr(resourceName, "organization", orgID),
-					resource.TestCheckResourceAttr(resourceName, "wif_project_number", wifProjectNumber),
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttrSet(resourceName, "status"),
-					resource.TestCheckResourceAttrSet(resourceName, "wif_pool_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "wif_provider_id"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("registration_scope"), knownvalue.StringExact("organization")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("organization"), knownvalue.StringExact(orgID)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("wif_project_number"), knownvalue.StringExact(wifProjectNumber)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("status"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("wif_pool_id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("wif_provider_id"), knownvalue.NotNull()),
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -187,16 +189,16 @@ func TestAccCloudGoogleRegistrationResource_Organization(t *testing.T) {
 			},
 			{
 				Config: testAccCloudGoogleRegistrationConfig_organization(rName, orgIDUpdated, infraProjectID, wifProjectID, wifProjectNumber),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "registration_scope", "organization"),
-					resource.TestCheckResourceAttr(resourceName, "organization", orgIDUpdated),
-					resource.TestCheckResourceAttr(resourceName, "wif_project_number", wifProjectNumber),
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttrSet(resourceName, "status"),
-					resource.TestCheckResourceAttrSet(resourceName, "wif_pool_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "wif_provider_id"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("registration_scope"), knownvalue.StringExact("organization")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("organization"), knownvalue.StringExact(orgIDUpdated)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("wif_project_number"), knownvalue.StringExact(wifProjectNumber)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("status"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("wif_pool_id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("wif_provider_id"), knownvalue.NotNull()),
+				},
 			},
 		},
 	})
@@ -215,15 +217,15 @@ func TestAccCloudGoogleRegistrationResource_RealtimeVisibility(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCloudGoogleRegistrationConfig_realtimeVisibility(rName, projectID, infraProjectID, wifProjectID, wifProjectNumber, true),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "realtime_visibility.enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "wif_project_number", wifProjectNumber),
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttrSet(resourceName, "status"),
-					resource.TestCheckResourceAttrSet(resourceName, "wif_pool_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "wif_provider_id"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("realtime_visibility").AtMapKey("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("wif_project_number"), knownvalue.StringExact(wifProjectNumber)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("status"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("wif_pool_id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("wif_provider_id"), knownvalue.NotNull()),
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -232,21 +234,23 @@ func TestAccCloudGoogleRegistrationResource_RealtimeVisibility(t *testing.T) {
 			},
 			{
 				Config: testAccCloudGoogleRegistrationConfig_realtimeVisibility(rName, projectID, infraProjectID, wifProjectID, wifProjectNumber, false),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "realtime_visibility.enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "wif_project_number", wifProjectNumber),
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttrSet(resourceName, "status"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("realtime_visibility").AtMapKey("enabled"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("wif_project_number"), knownvalue.StringExact(wifProjectNumber)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("status"), knownvalue.NotNull()),
+				},
 			},
 			{
 				Config: testAccCloudGoogleRegistrationConfig_project(rName, infraProjectID, wifProjectID, wifProjectNumber, projectID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("status"), knownvalue.NotNull()),
+				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckNoResourceAttr(resourceName, "realtime_visibility.enabled"),
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttrSet(resourceName, "status"),
 				),
 			},
 		},
@@ -272,19 +276,19 @@ func TestAccCloudGoogleRegistrationResource_RequiresReplace(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCloudGoogleRegistrationConfig_project(rName, infraProjectID, wifProjectID, wifProjectNumber, projectID),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "registration_scope", "project"),
-					resource.TestCheckResourceAttr(resourceName, "projects.#", "1"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("registration_scope"), knownvalue.StringExact("project")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("projects"), knownvalue.SetSizeExact(1)),
+				},
 			},
 			{
 				Config: testAccCloudGoogleRegistrationConfig_project(rName, infraProjectID, wifProjectID, wifProjectNumber, projectID, projectID2),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "registration_scope", "project"),
-					resource.TestCheckResourceAttr(resourceName, "projects.#", "2"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("registration_scope"), knownvalue.StringExact("project")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("projects"), knownvalue.SetSizeExact(2)),
+				},
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
@@ -293,11 +297,11 @@ func TestAccCloudGoogleRegistrationResource_RequiresReplace(t *testing.T) {
 			},
 			{
 				Config: testAccCloudGoogleRegistrationConfig_folder(rName, folderID, infraProjectID, wifProjectID, wifProjectNumber),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "registration_scope", "folder"),
-					resource.TestCheckResourceAttr(resourceName, "folders.#", "1"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("registration_scope"), knownvalue.StringExact("folder")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("folders"), knownvalue.SetSizeExact(1)),
+				},
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate),
@@ -306,11 +310,11 @@ func TestAccCloudGoogleRegistrationResource_RequiresReplace(t *testing.T) {
 			},
 			{
 				Config: testAccCloudGoogleRegistrationConfig_folder(rName, folderID2, infraProjectID, wifProjectID, wifProjectNumber),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "registration_scope", "folder"),
-					resource.TestCheckResourceAttr(resourceName, "folders.#", "1"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("registration_scope"), knownvalue.StringExact("folder")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("folders"), knownvalue.SetSizeExact(1)),
+				},
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
@@ -319,11 +323,11 @@ func TestAccCloudGoogleRegistrationResource_RequiresReplace(t *testing.T) {
 			},
 			{
 				Config: testAccCloudGoogleRegistrationConfig_organization(rName, orgID, infraProjectID, wifProjectID, wifProjectNumber),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "registration_scope", "organization"),
-					resource.TestCheckResourceAttr(resourceName, "organization", orgID),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("registration_scope"), knownvalue.StringExact("organization")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("organization"), knownvalue.StringExact(orgID)),
+				},
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate),
@@ -332,11 +336,11 @@ func TestAccCloudGoogleRegistrationResource_RequiresReplace(t *testing.T) {
 			},
 			{
 				Config: testAccCloudGoogleRegistrationConfig_organization(rName, orgID2, infraProjectID, wifProjectID, wifProjectNumber),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "registration_scope", "organization"),
-					resource.TestCheckResourceAttr(resourceName, "organization", orgID2),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("registration_scope"), knownvalue.StringExact("organization")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("organization"), knownvalue.StringExact(orgID2)),
+				},
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
@@ -412,22 +416,24 @@ func TestAccCloudGoogleRegistrationResource_RemoveResourceNamePrefixAndSuffix(t 
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCloudGoogleRegistrationConfig_withResourceNamePrefixAndSuffix(rName, projectID, infraProjectID, wifProjectID, wifProjectNumber),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "resource_name_prefix", "cs-"),
-					resource.TestCheckResourceAttr(resourceName, "resource_name_suffix", "-prod"),
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttrSet(resourceName, "status"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("resource_name_prefix"), knownvalue.StringExact("cs-")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("resource_name_suffix"), knownvalue.StringExact("-prod")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("status"), knownvalue.NotNull()),
+				},
 			},
 			{
 				Config: testAccCloudGoogleRegistrationConfig_project(rName, infraProjectID, wifProjectID, wifProjectNumber, projectID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("status"), knownvalue.NotNull()),
+				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckNoResourceAttr(resourceName, "resource_name_prefix"),
 					resource.TestCheckNoResourceAttr(resourceName, "resource_name_suffix"),
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttrSet(resourceName, "status"),
 				),
 			},
 		},
@@ -683,4 +689,153 @@ resource "crowdstrike_cloud_google_registration" "test" {
   excluded_project_patterns = %[6]s
 }
 `, rName, projectID, infraProjectID, wifProjectID, wifProjectNumber, patterns)
+}
+
+func TestAccCloudGoogleRegistrationResourceDSPM(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	projectID := generateGoogleCloudProjectID()
+	infraProjectID := generateGoogleCloudProjectID()
+	wifProjectID := generateGoogleCloudProjectID()
+	wifProjectNumber := generateGoogleCloudProjectNumber()
+	resourceName := "crowdstrike_cloud_google_registration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudGoogleRegistrationConfig_dspm(rName, projectID, infraProjectID, wifProjectID, wifProjectNumber, true),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("dspm").AtMapKey("enabled"), knownvalue.Bool(true)),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccCloudGoogleRegistrationConfig_dspm(rName, projectID, infraProjectID, wifProjectID, wifProjectNumber, false),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("dspm").AtMapKey("enabled"), knownvalue.Bool(false)),
+				},
+			},
+			{
+				Config: testAccCloudGoogleRegistrationConfig_project(rName, infraProjectID, wifProjectID, wifProjectNumber, projectID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rName)),
+				},
+			},
+		},
+	})
+}
+
+func TestAccCloudGoogleRegistrationResourceVulnerabilityScanning(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	projectID := generateGoogleCloudProjectID()
+	infraProjectID := generateGoogleCloudProjectID()
+	wifProjectID := generateGoogleCloudProjectID()
+	wifProjectNumber := generateGoogleCloudProjectNumber()
+	resourceName := "crowdstrike_cloud_google_registration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudGoogleRegistrationConfig_vulnerabilityScanning(rName, projectID, infraProjectID, wifProjectID, wifProjectNumber, true),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("vulnerability_scanning").AtMapKey("enabled"), knownvalue.Bool(true)),
+				},
+			},
+			{
+				Config: testAccCloudGoogleRegistrationConfig_vulnerabilityScanning(rName, projectID, infraProjectID, wifProjectID, wifProjectNumber, false),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("vulnerability_scanning").AtMapKey("enabled"), knownvalue.Bool(false)),
+				},
+			},
+		},
+	})
+}
+
+func TestAccCloudGoogleRegistrationResourceBothDSPMAndVulnScanning(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	projectID := generateGoogleCloudProjectID()
+	infraProjectID := generateGoogleCloudProjectID()
+	wifProjectID := generateGoogleCloudProjectID()
+	wifProjectNumber := generateGoogleCloudProjectNumber()
+	resourceName := "crowdstrike_cloud_google_registration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudGoogleRegistrationConfig_bothFeatures(rName, projectID, infraProjectID, wifProjectID, wifProjectNumber),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("dspm").AtMapKey("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("vulnerability_scanning").AtMapKey("enabled"), knownvalue.Bool(true)),
+				},
+			},
+			{
+				Config: testAccCloudGoogleRegistrationConfig_dspm(rName, projectID, infraProjectID, wifProjectID, wifProjectNumber, true),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("dspm").AtMapKey("enabled"), knownvalue.Bool(true)),
+				},
+			},
+		},
+	})
+}
+
+func testAccCloudGoogleRegistrationConfig_dspm(rName, projectID, infraProjectID, wifProjectID, wifProjectNumber string, enabled bool) string {
+	return acctest.ProviderConfig + fmt.Sprintf(`
+resource "crowdstrike_cloud_google_registration" "test" {
+  name               = %[1]q
+  projects           = [%[2]q]
+  infra_project      = %[3]q
+  wif_project        = %[4]q
+  wif_project_number = %[5]q
+
+  dspm = {
+    enabled = %[6]t
+  }
+}
+`, rName, projectID, infraProjectID, wifProjectID, wifProjectNumber, enabled)
+}
+
+func testAccCloudGoogleRegistrationConfig_vulnerabilityScanning(rName, projectID, infraProjectID, wifProjectID, wifProjectNumber string, enabled bool) string {
+	return acctest.ProviderConfig + fmt.Sprintf(`
+resource "crowdstrike_cloud_google_registration" "test" {
+  name               = %[1]q
+  projects           = [%[2]q]
+  infra_project      = %[3]q
+  wif_project        = %[4]q
+  wif_project_number = %[5]q
+
+  vulnerability_scanning = {
+    enabled = %[6]t
+  }
+}
+`, rName, projectID, infraProjectID, wifProjectID, wifProjectNumber, enabled)
+}
+
+func testAccCloudGoogleRegistrationConfig_bothFeatures(rName, projectID, infraProjectID, wifProjectID, wifProjectNumber string) string {
+	return acctest.ProviderConfig + fmt.Sprintf(`
+resource "crowdstrike_cloud_google_registration" "test" {
+  name               = %[1]q
+  projects           = [%[2]q]
+  infra_project      = %[3]q
+  wif_project        = %[4]q
+  wif_project_number = %[5]q
+
+  dspm = {
+    enabled = true
+  }
+
+  vulnerability_scanning = {
+    enabled = true
+  }
+}
+`, rName, projectID, infraProjectID, wifProjectID, wifProjectNumber)
 }


### PR DESCRIPTION
## Summary

Adds DSPM and vulnerability scanning (agentless scanning) support for GCP to the
`crowdstrike_cloud_google_registration` and
`crowdstrike_cloud_google_registration_settings` resources.

## What's included

* **Registration resource**: new `dspm` and `vulnerability_scanning` Optional
  nested attributes to enable/disable features per registration.
* **Settings resource**: new `agentless_scanning_settings` Optional nested
  attribute for configuring agentless scanning infrastructure (WIF principal,
  regions, network configuration, per-project infra map).
* Feature name constants (`featureDSPM`, `featureVulnerabilityScanning`).
* 8 new acceptance tests covering DSPM-only, vulnerability-only, both,
  cross-project, custom network, not-enabled error, and import.

## Testing

Acceptance tests verified green against dodo-red. Full suite:
`TF_ACC=1 go test ./internal/cloud_google_registration/... -v -timeout 120m -count=1`.
Build and unit tests pass (`go build ./...`, `go test ./... -short`).
All changes are additive — existing users unaffected.
