### PR TITLE
fix(it_automation): import schedules without start_time

### DIFF
--- a/docs/resources/it_automation_scheduled_task.md
+++ b/docs/resources/it_automation_scheduled_task.md
@@ -123,7 +123,6 @@ resource "crowdstrike_it_automation_scheduled_task" "weekly_example" {
 Required:
 
 - `frequency` (String) Frequency of runs. One of: `One-Time`, `Minutes`, `Hourly`, `Daily`, `Weekly`, `Monthly`.
-- `start_time` (String) RFC3339 timestamp for when the schedule first runs. The timezone offset embedded in this value determines the local timezone for recurring runs.
 
 Optional:
 
@@ -131,6 +130,7 @@ Optional:
 - `day_of_week` (String) Day of week for `Weekly` frequency. One of `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday`, `Saturday`, `Sunday`. Required when `frequency = "Weekly"`. Not allowed for other frequencies.
 - `end_time` (String) RFC3339 timestamp when the schedule stops running.
 - `interval` (Number) Run interval. Required when `frequency = "Minutes"` (range 60-10080, in minutes) or `frequency = "Hourly"` (range 1-168, in hours). Not allowed for other frequencies. Meaning depends on `frequency`.
+- `start_time` (String) RFC3339 timestamp for when the schedule first runs. Required when creating or modifying a schedule. Existing imported schedules may omit this value when the API does not return it. The timezone offset embedded in this value determines the local timezone for recurring runs.
 
 
 <a id="nestedatt--trigger_condition"></a>

--- a/internal/it_automation/it_automation_scheduled_task_resource.go
+++ b/internal/it_automation/it_automation_scheduled_task_resource.go
@@ -40,6 +40,7 @@ var (
 	_ resource.Resource                   = &itAutomationScheduledTaskResource{}
 	_ resource.ResourceWithConfigure      = &itAutomationScheduledTaskResource{}
 	_ resource.ResourceWithImportState    = &itAutomationScheduledTaskResource{}
+	_ resource.ResourceWithModifyPlan     = &itAutomationScheduledTaskResource{}
 	_ resource.ResourceWithValidateConfig = &itAutomationScheduledTaskResource{}
 )
 
@@ -313,9 +314,11 @@ func (r *itAutomationScheduledTaskResource) Schema(
 					},
 					"start_time": schema.StringAttribute{
 						CustomType: fwtypes.RFC3339Type{},
-						Required:   true,
-						Description: "RFC3339 timestamp for when the schedule first runs. The timezone offset " +
-							"embedded in this value determines the local timezone for recurring runs.",
+						Optional:   true,
+						Description: "RFC3339 timestamp for when the schedule first runs. Required when creating " +
+							"or modifying a schedule. Existing imported schedules may omit this value when the API " +
+							"does not return it. The timezone offset embedded in this value determines the local " +
+							"timezone for recurring runs.",
 					},
 					"end_time": schema.StringAttribute{
 						CustomType:  fwtypes.RFC3339Type{},
@@ -527,6 +530,58 @@ func (r *itAutomationScheduledTaskResource) ValidateConfig(
 	}
 }
 
+func (r *itAutomationScheduledTaskResource) ModifyPlan(
+	ctx context.Context,
+	req resource.ModifyPlanRequest,
+	resp *resource.ModifyPlanResponse,
+) {
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var plan itAutomationScheduledTaskResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if !utils.IsKnown(plan.Schedule) {
+		return
+	}
+
+	var planSchedule scheduleModel
+	resp.Diagnostics.Append(plan.Schedule.As(ctx, &planSchedule, basetypes.ObjectAsOptions{})...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if req.State.Raw.IsNull() {
+		if planSchedule.StartTime.IsNull() {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("schedule").AtName("start_time"),
+				"Missing start_time",
+				"`schedule.start_time` is required when creating an IT Automation scheduled task.",
+			)
+		}
+		return
+	}
+
+	var state itAutomationScheduledTaskResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !plan.Schedule.Equal(state.Schedule) && planSchedule.StartTime.IsNull() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("schedule").AtName("start_time"),
+			"Missing start_time",
+			"`schedule.start_time` is required when modifying schedule details. Existing imported "+
+				"schedules whose API response omits `start_time` may be managed as long as their "+
+				"schedule remains unchanged.",
+		)
+	}
+}
+
 func validateSchedule(sched *scheduleModel, diags *diag.Diagnostics) {
 	if !utils.IsKnown(sched.Frequency) {
 		return
@@ -727,6 +782,10 @@ func buildScheduleFromPlan(
 	frequency := sched.Frequency.ValueString()
 	apiSched := &models.FalconforitapiSchedule{
 		Frequency: &frequency,
+	}
+
+	if sched.StartTime.IsNull() {
+		return nil, diags
 	}
 
 	if startTimeT, parseDiags := sched.StartTime.ValueRFC3339Time(); !parseDiags.HasError() {
@@ -1074,6 +1133,14 @@ func (r *itAutomationScheduledTaskResource) Create(
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	if apiSched == nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("schedule").AtName("start_time"),
+			"Missing start_time",
+			"`schedule.start_time` is required when creating an IT Automation scheduled task.",
+		)
+		return
+	}
 
 	target := plan.Target.ValueString()
 	taskID := plan.TaskID.ValueString()
@@ -1200,12 +1267,25 @@ func (r *itAutomationScheduledTaskResource) Update(
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	var state itAutomationScheduledTaskResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	id := plan.ID.ValueString()
 
 	apiSched, schedDiags := buildScheduleFromPlan(ctx, plan.Schedule)
 	resp.Diagnostics.Append(schedDiags...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+	if apiSched == nil && !plan.Schedule.Equal(state.Schedule) {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("schedule").AtName("start_time"),
+			"Missing start_time",
+			"`schedule.start_time` is required when modifying schedule details.",
+		)
 		return
 	}
 
@@ -1481,12 +1561,13 @@ func (p *createScheduledTaskParams) WriteToRequest(r runtime.ClientRequest, _ st
 	return nil
 }
 
-// updateScheduledTaskRequest is the PATCH body for an update. Every field is
-// declared without `omitempty` (unlike the generated
+// updateScheduledTaskRequest is the PATCH body for an update. Fields that can
+// be cleared are declared without `omitempty` (unlike the generated
 // models.ItautomationUpdateScheduledTaskRequest, which strips zero values) so
 // that clearing an optional field actually sends the cleared value to the
-// server instead of being silently dropped. The API treats an omitted/null
-// field as "keep current", so:
+// server instead of being silently dropped. Schedule keeps `omitempty` so an
+// unchanged imported schedule with no API start_time can be preserved. The API
+// treats an omitted/null field as "keep current", so:
 //   - bools are sent explicitly so a flip to false sticks.
 //   - execution_args sends an empty map to clear (null keeps).
 //   - guardrails sends an empty object to clear the run-time limit (null keeps).
@@ -1504,7 +1585,7 @@ type updateScheduledTaskRequest struct {
 	DiscoverNewHosts     bool                                   `json:"discover_new_hosts"`
 	DiscoverOfflineHosts bool                                   `json:"discover_offline_hosts"`
 	Distribute           bool                                   `json:"distribute"`
-	Schedule             *scheduleRequest                       `json:"schedule"`
+	Schedule             *scheduleRequest                       `json:"schedule,omitempty"`
 	ScheduleName         *string                                `json:"schedule_name"`
 	ExpirationInterval   *string                                `json:"expiration_interval"`
 	ExecutionArgs        map[string]string                      `json:"execution_args"`

--- a/internal/it_automation/it_automation_scheduled_task_resource_internal_test.go
+++ b/internal/it_automation/it_automation_scheduled_task_resource_internal_test.go
@@ -1,0 +1,78 @@
+package itautomation
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/crowdstrike/gofalcon/falcon/models"
+	fwtypes "github.com/crowdstrike/terraform-provider-crowdstrike/internal/framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+func TestFlattenScheduleAllowsMissingStartTime(t *testing.T) {
+	t.Parallel()
+
+	frequency := frequencyDaily
+	interval := int32(0)
+	got, diags := flattenSchedule(context.Background(), &models.FalconforitapiSchedule{
+		Frequency: &frequency,
+		Interval:  &interval,
+		Time:      "09:00",
+		Timezone:  "+0000",
+	})
+	if diags.HasError() {
+		t.Fatalf("flattenSchedule returned diagnostics: %v", diags)
+	}
+
+	var schedule scheduleModel
+	diags = got.As(context.Background(), &schedule, basetypes.ObjectAsOptions{})
+	if diags.HasError() {
+		t.Fatalf("converting flattened schedule returned diagnostics: %v", diags)
+	}
+	if !schedule.StartTime.IsNull() {
+		t.Fatalf("expected start_time to be null, got %q", schedule.StartTime.ValueString())
+	}
+}
+
+func TestBuildScheduleFromPlanAllowsMissingStartTime(t *testing.T) {
+	t.Parallel()
+
+	schedule, diags := types.ObjectValueFrom(
+		context.Background(),
+		scheduledTaskScheduleAttrTypes(),
+		scheduleModel{
+			Frequency:  types.StringValue(frequencyDaily),
+			StartTime:  fwtypes.NewRFC3339Null(),
+			EndTime:    fwtypes.NewRFC3339Null(),
+			DayOfWeek:  types.StringNull(),
+			DayOfMonth: types.Int64Null(),
+			Interval:   types.Int64Null(),
+		},
+	)
+	if diags.HasError() {
+		t.Fatalf("creating schedule object returned diagnostics: %v", diags)
+	}
+
+	got, diags := buildScheduleFromPlan(context.Background(), schedule)
+	if diags.HasError() {
+		t.Fatalf("buildScheduleFromPlan returned diagnostics: %v", diags)
+	}
+	if got != nil {
+		t.Fatalf("expected no schedule request, got %#v", got)
+	}
+}
+
+func TestUpdateScheduledTaskRequestOmitsNilSchedule(t *testing.T) {
+	t.Parallel()
+
+	got, err := json.Marshal(updateScheduledTaskRequest{})
+	if err != nil {
+		t.Fatalf("marshaling update request: %v", err)
+	}
+	if strings.Contains(string(got), `"schedule"`) {
+		t.Fatalf("expected nil schedule to be omitted, got %s", got)
+	}
+}

--- a/internal/it_automation/it_automation_scheduled_task_resource_test.go
+++ b/internal/it_automation/it_automation_scheduled_task_resource_test.go
@@ -488,6 +488,33 @@ func TestAccITAutomationScheduledTaskResource_boolOmitemptyRegression(t *testing
 	})
 }
 
+func TestAccITAutomationScheduledTaskResource_startTimeUnknown(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: scheduledTaskFixtureConfig(rName) + `
+resource "crowdstrike_it_automation_scheduled_task" "test" {
+  task_id = crowdstrike_it_automation_task.action.id
+  enabled = true
+  target  = "platform_name:'Linux'"
+
+  schedule = {
+    frequency  = "Daily"
+    start_time = crowdstrike_it_automation_task.action.last_updated
+  }
+}
+`,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 // TestAccITAutomationScheduledTaskResource_startTimeOffset verifies the
 // custom RFC3339 type's semantic equality is preserved when the user writes
 // a non-UTC offset. No spurious diff should appear after apply.
@@ -884,6 +911,12 @@ func TestAccITAutomationScheduledTaskResource_validateConfigNegative(t *testing.
 		schedule    string
 		expectError *regexp.Regexp
 	}{
+		{
+			name: "missing_start_time",
+			schedule: `
+    frequency = "Daily"`,
+			expectError: regexp.MustCompile(`(?i)start_time|required.*creating`),
+		},
 		{
 			name: "day_of_week_with_daily",
 			schedule: `


### PR DESCRIPTION
Allow `crowdstrike_it_automation_scheduled_task` imports when Falcon omits `schedule.start_time`, while still requiring a start time for resource creation and schedule changes.

Unchanged imported schedules without a start time are omitted from PATCH requests, with focused regression coverage for null and unknown timestamp values.

---

Fixes #415
