### PR TITLE
Fix precedence policy

### DIFF
--- a/internal/prevention_policy/prevention_policy_precedence.go
+++ b/internal/prevention_policy/prevention_policy_precedence.go
@@ -190,10 +190,8 @@ func (r *preventionPolicyPrecedenceResource) Create(
 		return
 	}
 
-	if strings.EqualFold(plan.Enforcement.ValueString(), dynamicEnforcement) {
-		if len(policies) > len(plan.IDs.Elements()) {
-			policies = policies[:len(plan.IDs.Elements())]
-		}
+	if len(policies) > len(plan.IDs.Elements()) {
+		policies = policies[:len(plan.IDs.Elements())]
 	}
 
 	plan.LastUpdated = utils.GenerateUpdateTimestamp()
@@ -218,10 +216,8 @@ func (r *preventionPolicyPrecedenceResource) Read(
 		return
 	}
 
-	if strings.EqualFold(state.Enforcement.ValueString(), dynamicEnforcement) {
-		if len(policies) > len(state.IDs.Elements()) {
-			policies = policies[:len(state.IDs.Elements())]
-		}
+	if len(policies) > len(state.IDs.Elements()) {
+		policies = policies[:len(state.IDs.Elements())]
 	}
 
 	resp.Diagnostics.Append(state.wrap(ctx, policies)...)
@@ -271,10 +267,8 @@ func (r *preventionPolicyPrecedenceResource) Update(
 		return
 	}
 
-	if strings.EqualFold(plan.Enforcement.ValueString(), dynamicEnforcement) {
-		if len(policies) > len(plan.IDs.Elements()) {
-			policies = policies[:len(plan.IDs.Elements())]
-		}
+	if len(policies) > len(plan.IDs.Elements()) {
+		policies = policies[:len(plan.IDs.Elements())]
 	}
 
 	plan.LastUpdated = utils.GenerateUpdateTimestamp()


### PR DESCRIPTION
The issue. When running terraform precedence policy in strict mode, there is a bug that causes terraform to incorrectly detect a nonexistent drift in state in applying.
````
error: Provider produced inconsistent result after apply
│ 
│ When applying changes to `crowdstrike_prevention_policy_precedence.prevention_policy_precedence, provider "provider[\"registry.terraform.io/crowdstrike/crowdstrike\"]" produced an unexpected new value: .ids: new element X has appeared.

````
Sample code:

```
platform_name: Linux
enforcement: strict
names:
  - 1
  - 2 
  - 3
```

What we believe is the issue:

When running on strict mode, getPreventionPoliciesByPrecedence reads CrowdStrike's full list hence incorrectly recognising a state drift due to existence of default policies.  
.

We suggest an alternative to this PR which when running on strict mode, QueryCombinedPreventionPoliciesParams() applies a different filter but above appears sufficient.
I reran the terraform plan with multiple prevention policies containing both default and non-default ones and the result was:
1. The above bug is not reprodueced.
2. Rerunning terraform doesn't create inconsistency  