### PR TITLE
fix(prevention_policy): paginate prevention policy precedence read

### DIFF
--- a/internal/prevention_policy/prevention_policy_precedence.go
+++ b/internal/prevention_policy/prevention_policy_precedence.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
@@ -310,30 +311,59 @@ func (r *preventionPolicyPrecedenceResource) getPreventionPoliciesByPrecedence(
 
 	filter := fmt.Sprintf("platform_name:'%s'", caser.String(platformName))
 	sort := "precedence.asc"
-	res, err := r.client.PreventionPolicies.QueryCombinedPreventionPolicies(
-		&prevention_policies.QueryCombinedPreventionPoliciesParams{
-			Context: ctx,
-			Filter:  &filter,
-			Sort:    &sort,
-		},
-	)
-	if err != nil {
-		diags.AddError(
-			"Error reading CrowdStrike prevention policies",
-			fmt.Sprintf(
-				"Could not read CrowdStrike prevention policies\n\n %s",
-				err.Error(),
-			),
-		)
-		return policies, diags
-	}
+	limit := int64(5000)
+	offset := int64(0)
 
-	if res != nil && res.Payload != nil {
-		for i, policy := range res.Payload.Resources {
-			if i != len(res.Payload.Resources)-1 {
+	for {
+		res, err := r.client.PreventionPolicies.QueryCombinedPreventionPolicies(
+			&prevention_policies.QueryCombinedPreventionPoliciesParams{
+				Context: ctx,
+				Filter:  &filter,
+				Sort:    &sort,
+				Limit:   &limit,
+				Offset:  &offset,
+			},
+		)
+		if err != nil {
+			diags.AddError(
+				"Error reading CrowdStrike prevention policies",
+				fmt.Sprintf(
+					"Could not read CrowdStrike prevention policies\n\n %s",
+					err.Error(),
+				),
+			)
+			return policies, diags
+		}
+
+		if res == nil || res.Payload == nil || len(res.Payload.Resources) == 0 {
+			break
+		}
+
+		for _, policy := range res.Payload.Resources {
+			if policy != nil && policy.ID != nil {
 				policies = append(policies, *policy.ID)
 			}
 		}
+
+		if res.Payload.Meta == nil || res.Payload.Meta.Pagination == nil ||
+			res.Payload.Meta.Pagination.Offset == nil || res.Payload.Meta.Pagination.Total == nil {
+
+			tflog.Warn(ctx, "Missing pagination metadata in API response, using offset+limit for next page",
+				map[string]interface{}{
+					"meta": res.Payload.Meta,
+				})
+			offset += limit
+			continue
+		}
+
+		offset = int64(*res.Payload.Meta.Pagination.Offset)
+		if offset >= *res.Payload.Meta.Pagination.Total {
+			break
+		}
+	}
+
+	if len(policies) > 0 {
+		policies = policies[:len(policies)-1]
 	}
 
 	return policies, diags

--- a/internal/prevention_policy/prevention_policy_precedence_test.go
+++ b/internal/prevention_policy/prevention_policy_precedence_test.go
@@ -3,6 +3,7 @@ package preventionpolicy_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/crowdstrike/gofalcon/falcon/client/prevention_policies"
@@ -15,6 +16,9 @@ import (
 )
 
 func TestAccPreventionPolicyPrecedenceResource_strict(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("Acceptance tests skipped unless env 'TF_ACC' set")
+	}
 	acctest.PreCheck(t)
 
 	platformName := "Linux"

--- a/internal/prevention_policy/prevention_policy_precedence_test.go
+++ b/internal/prevention_policy/prevention_policy_precedence_test.go
@@ -1,0 +1,126 @@
+package preventionpolicy_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/crowdstrike/gofalcon/falcon/client/prevention_policies"
+	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/acctest"
+	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/testconfig"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccPreventionPolicyPrecedenceResource_strict(t *testing.T) {
+	acctest.PreCheck(t)
+
+	platformName := "Linux"
+	ids := getNonDefaultPreventionPolicyIDs(t, platformName)
+	if len(ids) == 0 {
+		t.Skipf("no non-default %s prevention policies in tenant; nothing to test", platformName)
+	}
+
+	resourceName := "crowdstrike_prevention_policy_precedence.test"
+
+	idChecks := make([]knownvalue.Check, len(ids))
+	for i, id := range ids {
+		idChecks[i] = knownvalue.StringExact(id)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPreventionPolicyPrecedenceStrictConfig(platformName, ids),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("ids"),
+						knownvalue.ListExact(idChecks),
+					),
+				},
+			},
+		},
+	})
+}
+
+// getNonDefaultPreventionPolicyIDs returns every non-default prevention policy id
+// for a platform, ordered by precedence.asc. It mirrors what the resource reads
+// back so the strict test can assert against the live tenant without hardcoding
+// ids. The platform_default policy sorts last and is excluded.
+func getNonDefaultPreventionPolicyIDs(t *testing.T, platformName string) []string {
+	t.Helper()
+
+	c := testconfig.GetTestClient()
+	if c == nil {
+		t.Fatal("test client not initialized; PreCheck must run first")
+	}
+
+	filter := fmt.Sprintf("platform_name:'%s'", platformName)
+	sort := "precedence.asc"
+	limit := int64(5000)
+	offset := int64(0)
+
+	var ids []string
+	for {
+		res, err := c.PreventionPolicies.QueryCombinedPreventionPolicies(
+			&prevention_policies.QueryCombinedPreventionPoliciesParams{
+				Context: context.Background(),
+				Filter:  &filter,
+				Sort:    &sort,
+				Limit:   &limit,
+				Offset:  &offset,
+			},
+		)
+		if err != nil {
+			t.Fatalf("failed to query prevention policies: %s", err)
+		}
+
+		if res == nil || res.Payload == nil || len(res.Payload.Resources) == 0 {
+			break
+		}
+
+		for _, policy := range res.Payload.Resources {
+			if policy != nil && policy.ID != nil {
+				ids = append(ids, *policy.ID)
+			}
+		}
+
+		if res.Payload.Meta == nil || res.Payload.Meta.Pagination == nil ||
+			res.Payload.Meta.Pagination.Offset == nil || res.Payload.Meta.Pagination.Total == nil {
+			offset += limit
+			continue
+		}
+
+		offset = int64(*res.Payload.Meta.Pagination.Offset)
+		if offset >= *res.Payload.Meta.Pagination.Total {
+			break
+		}
+	}
+
+	if len(ids) > 0 {
+		ids = ids[:len(ids)-1]
+	}
+
+	return ids
+}
+
+func testAccPreventionPolicyPrecedenceStrictConfig(platformName string, ids []string) string {
+	quoted := ""
+	for _, id := range ids {
+		quoted += fmt.Sprintf("    %q,\n", id)
+	}
+
+	return acctest.ProviderConfig + fmt.Sprintf(`
+resource "crowdstrike_prevention_policy_precedence" "test" {
+  platform_name = %q
+  enforcement   = "strict"
+  ids = [
+%s  ]
+}
+`, platformName, quoted)
+}


### PR DESCRIPTION
getPreventionPoliciesByPrecedence issued a single QueryCombinedPreventionPolicies call with no Limit, so the API capped results at its default page size of 100 and the remaining pages were never read. Platforms with more than 100 prevention policies read a truncated list, breaking strict enforcement and surfacing as Terraform inconsistent-result / drift errors.

Loop over all pages using Limit/Offset and meta.pagination.total, then drop the default policy once after collecting every page. Add a strict-enforcement acceptance test that fetches the platform's policy ids dynamically and asserts the resource reconstructs the full ordered list.

Fixes #428
