### PR TITLE
fix(docs): clarify RTR script/put-file import needs compound ID

### DIFF
--- a/docs/resources/rtr_put_file.md
+++ b/docs/resources/rtr_put_file.md
@@ -80,6 +80,6 @@ output "rtr_put_file_id" {
 Import is supported using the following syntax:
 
 ```shell
-# Rtr Put File can be imported by specifying the compound ID "<file_id>_<cid>".
+# Rtr Put File can be imported by specifying the compound ID "<file_id>_<suffix>".
 terraform import crowdstrike_rtr_put_file.example 7fb858a949034a0cbca175f660f1e769_1234567890abcdef
 ```

--- a/docs/resources/rtr_put_file.md
+++ b/docs/resources/rtr_put_file.md
@@ -80,6 +80,6 @@ output "rtr_put_file_id" {
 Import is supported using the following syntax:
 
 ```shell
-# Rtr Put File can be imported by specifying the id.
-terraform import crowdstrike_rtr_put_file.example 7fb858a949034a0cbca175f660f1e769
+# Rtr Put File can be imported by specifying the compound ID "<file_id>_<cid>".
+terraform import crowdstrike_rtr_put_file.example 7fb858a949034a0cbca175f660f1e769_1234567890abcdef
 ```

--- a/docs/resources/rtr_script.md
+++ b/docs/resources/rtr_script.md
@@ -79,6 +79,6 @@ output "rtr_script" {
 Import is supported using the following syntax:
 
 ```shell
-# RTR Script can be imported by specifying the script ID.
-terraform import crowdstrike_rtr_script.example 7fb858a949034a0cbca175f660f1e769
+# RTR Script can be imported by specifying the compound ID "<script_id>_<cid>".
+terraform import crowdstrike_rtr_script.example 7fb858a949034a0cbca175f660f1e769_1234567890abcdef
 ```

--- a/docs/resources/rtr_script.md
+++ b/docs/resources/rtr_script.md
@@ -79,6 +79,6 @@ output "rtr_script" {
 Import is supported using the following syntax:
 
 ```shell
-# RTR Script can be imported by specifying the compound ID "<script_id>_<cid>".
+# RTR Script can be imported by specifying the compound ID "<script_id>_<suffix>".
 terraform import crowdstrike_rtr_script.example 7fb858a949034a0cbca175f660f1e769_1234567890abcdef
 ```

--- a/examples/resources/crowdstrike_rtr_put_file/import.sh
+++ b/examples/resources/crowdstrike_rtr_put_file/import.sh
@@ -1,2 +1,2 @@
-# Rtr Put File can be imported by specifying the compound ID "<file_id>_<cid>".
+# Rtr Put File can be imported by specifying the compound ID "<file_id>_<suffix>".
 terraform import crowdstrike_rtr_put_file.example 7fb858a949034a0cbca175f660f1e769_1234567890abcdef

--- a/examples/resources/crowdstrike_rtr_put_file/import.sh
+++ b/examples/resources/crowdstrike_rtr_put_file/import.sh
@@ -1,2 +1,2 @@
-# Rtr Put File can be imported by specifying the id.
-terraform import crowdstrike_rtr_put_file.example 7fb858a949034a0cbca175f660f1e769
+# Rtr Put File can be imported by specifying the compound ID "<file_id>_<cid>".
+terraform import crowdstrike_rtr_put_file.example 7fb858a949034a0cbca175f660f1e769_1234567890abcdef

--- a/examples/resources/crowdstrike_rtr_script/import.sh
+++ b/examples/resources/crowdstrike_rtr_script/import.sh
@@ -1,2 +1,2 @@
-# RTR Script can be imported by specifying the compound ID "<script_id>_<cid>".
+# RTR Script can be imported by specifying the compound ID "<script_id>_<suffix>".
 terraform import crowdstrike_rtr_script.example 7fb858a949034a0cbca175f660f1e769_1234567890abcdef

--- a/examples/resources/crowdstrike_rtr_script/import.sh
+++ b/examples/resources/crowdstrike_rtr_script/import.sh
@@ -1,2 +1,2 @@
-# RTR Script can be imported by specifying the script ID.
-terraform import crowdstrike_rtr_script.example 7fb858a949034a0cbca175f660f1e769
+# RTR Script can be imported by specifying the compound ID "<script_id>_<cid>".
+terraform import crowdstrike_rtr_script.example 7fb858a949034a0cbca175f660f1e769_1234567890abcdef


### PR DESCRIPTION
## Summary
The import docs for [`crowdstrike_rtr_script`](https://registry.terraform.io/providers/CrowdStrike/crowdstrike/latest/docs/resources/rtr_script#import) & [`crowdstrike_rtr_put_file`](https://registry.terraform.io/providers/CrowdStrike/crowdstrike/latest/docs/resources/rtr_put_file#import) show a bare resource ID as the import ID, e.g.:

    terraform import crowdstrike_rtr_put_file.example 7fb858a949034a0cbca175f660f1e769

In practice, both resources require a **compound** ID: `<id>_<suffix>`, where `<suffix>` is a second identifier visible in the browser URL when a script or put file is selected in the Falcon UI. This suffix is the same across every script/put file in a tenant. The bare `<id>` alone resolves inconsistently.

In my case, `crowdstrike_rtr_put_file` returned "not found" for the bare ID, and `crowdstrike_rtr_script` (imported via a Terraform `import` block) always returned an "API call succeeded but returned no data" read error on the bare ID. Appending the `_<suffix>` to every import ID resolved both.

This PR updates the import examples (`examples/resources/crowdstrike_rtr_put_file/import.sh` & `examples/resources/crowdstrike_rtr_script/import.sh`) and regenerates the corresponding docs via `make gen` to show the correct compound-ID format.