### PR TITLE
fix(policies): drop empty-ID host and rule groups from Flight Control

### DIFF
--- a/internal/content_update_policy/content_update_policy_attachment.go
+++ b/internal/content_update_policy/content_update_policy_attachment.go
@@ -88,7 +88,7 @@ func (m *contentUpdatePolicyAttachmentResourceModel) wrap(
 	} else {
 		existingHostGroups := make(map[string]bool)
 		for _, hg := range policy.Groups {
-			if hg != nil && hg.ID != nil {
+			if hg != nil && hg.ID != nil && *hg.ID != "" {
 				existingHostGroups[*hg.ID] = true
 			}
 		}

--- a/internal/fim/filevantage_policies_data_source.go
+++ b/internal/fim/filevantage_policies_data_source.go
@@ -144,7 +144,7 @@ func (m *filevantagePoliciesDataSourceModel) wrap(ctx context.Context, policies 
 		// Convert host groups
 		var hostGroupIDs []string
 		for _, hostGroup := range policy.HostGroups {
-			if hostGroup.ID != nil {
+			if hostGroup != nil && hostGroup.ID != nil && *hostGroup.ID != "" {
 				hostGroupIDs = append(hostGroupIDs, *hostGroup.ID)
 			}
 		}
@@ -158,7 +158,7 @@ func (m *filevantagePoliciesDataSourceModel) wrap(ctx context.Context, policies 
 		// Convert rule groups
 		var ruleGroupIDs []string
 		for _, ruleGroup := range policy.RuleGroups {
-			if ruleGroup != nil && ruleGroup.ID != nil {
+			if ruleGroup != nil && ruleGroup.ID != nil && *ruleGroup.ID != "" {
 				ruleGroupIDs = append(ruleGroupIDs, *ruleGroup.ID)
 			}
 		}

--- a/internal/fim/filevantage_policy_attachment.go
+++ b/internal/fim/filevantage_policy_attachment.go
@@ -652,7 +652,7 @@ func convertHostGroupsToSet(
 ) (types.Set, diag.Diagnostics) {
 	var hostGroups []string
 	for _, hostGroup := range groups {
-		if hostGroup != nil && hostGroup.ID != nil {
+		if hostGroup != nil && hostGroup.ID != nil && *hostGroup.ID != "" {
 			hostGroups = append(hostGroups, *hostGroup.ID)
 		}
 	}
@@ -666,7 +666,7 @@ func convertRuleGroupsToSet(
 ) (types.Set, diag.Diagnostics) {
 	var ruleGroups []string
 	for _, ruleGroup := range groups {
-		if ruleGroup != nil && ruleGroup.ID != nil {
+		if ruleGroup != nil && ruleGroup.ID != nil && *ruleGroup.ID != "" {
 			ruleGroups = append(ruleGroups, *ruleGroup.ID)
 		}
 	}

--- a/internal/fim/fim.go
+++ b/internal/fim/fim.go
@@ -931,6 +931,9 @@ func (r *fimPolicyResource) assignHostGroups(
 ) diag.Diagnostics {
 	var hostGroups []string
 	for _, hostGroup := range groups {
+		if hostGroup == nil || hostGroup.ID == nil || *hostGroup.ID == "" {
+			continue
+		}
 		hostGroups = append(hostGroups, *hostGroup.ID)
 	}
 
@@ -1043,6 +1046,9 @@ func (r *fimPolicyResource) assignRuleGroups(
 ) diag.Diagnostics {
 	var ruleGroups []string
 	for _, ruleGroup := range groups {
+		if ruleGroup == nil || ruleGroup.ID == nil || *ruleGroup.ID == "" {
+			continue
+		}
 		ruleGroups = append(ruleGroups, *ruleGroup.ID)
 	}
 

--- a/internal/framework/flex/hostgroups.go
+++ b/internal/framework/flex/hostgroups.go
@@ -9,7 +9,9 @@ import (
 )
 
 // FlattenHostGroupsToSet converts []*models.HostGroupsHostGroupV1 to a Terraform set of host group IDs.
-// Returns null if there are no groups or all groups are nil/have nil IDs.
+// Groups with a nil or empty ID are skipped; in Flight Control setups the API can return
+// placeholder groups with an empty ID for host groups assigned in a child CID.
+// Returns null if there are no groups or all groups are nil/have nil or empty IDs.
 func FlattenHostGroupsToSet(
 	ctx context.Context,
 	groups []*models.HostGroupsHostGroupV1,
@@ -20,7 +22,7 @@ func FlattenHostGroupsToSet(
 
 	groupIDs := make([]string, 0, len(groups))
 	for _, group := range groups {
-		if group != nil && group.ID != nil {
+		if group != nil && group.ID != nil && *group.ID != "" {
 			groupIDs = append(groupIDs, *group.ID)
 		}
 	}
@@ -29,7 +31,9 @@ func FlattenHostGroupsToSet(
 }
 
 // FlattenHostGroupsToList converts []*models.HostGroupsHostGroupV1 to a Terraform list of host group IDs.
-// Returns null if there are no groups or all groups are nil/have nil IDs.
+// Groups with a nil or empty ID are skipped; in Flight Control setups the API can return
+// placeholder groups with an empty ID for host groups assigned in a child CID.
+// Returns null if there are no groups or all groups are nil/have nil or empty IDs.
 func FlattenHostGroupsToList(
 	ctx context.Context,
 	groups []*models.HostGroupsHostGroupV1,
@@ -40,7 +44,7 @@ func FlattenHostGroupsToList(
 
 	groupIDs := make([]string, 0, len(groups))
 	for _, group := range groups {
-		if group != nil && group.ID != nil {
+		if group != nil && group.ID != nil && *group.ID != "" {
 			groupIDs = append(groupIDs, *group.ID)
 		}
 	}

--- a/internal/framework/flex/hostgroups_test.go
+++ b/internal/framework/flex/hostgroups_test.go
@@ -55,6 +55,23 @@ func TestFlattenHostGroupsToSet(t *testing.T) {
 			},
 			expected: acctest.StringSetOrNull("group1", "group2"),
 		},
+		{
+			name: "groups with empty IDs returns null",
+			groups: []*models.HostGroupsHostGroupV1{
+				{ID: utils.Addr("")},
+				{ID: utils.Addr("")},
+			},
+			expected: acctest.StringSetOrNull(),
+		},
+		{
+			name: "mixed empty-ID placeholders and valid IDs returns set with valid IDs",
+			groups: []*models.HostGroupsHostGroupV1{
+				{ID: utils.Addr("group1")},
+				{ID: utils.Addr("")},
+				{ID: utils.Addr("group2")},
+			},
+			expected: acctest.StringSetOrNull("group1", "group2"),
+		},
 	}
 
 	for _, tc := range testCases {
@@ -107,6 +124,23 @@ func TestFlattenHostGroupsToList(t *testing.T) {
 			groups: []*models.HostGroupsHostGroupV1{
 				{ID: utils.Addr("group1")},
 				{ID: nil},
+				{ID: utils.Addr("group2")},
+			},
+			expected: acctest.StringListOrNull("group1", "group2"),
+		},
+		{
+			name: "groups with empty IDs returns null",
+			groups: []*models.HostGroupsHostGroupV1{
+				{ID: utils.Addr("")},
+				{ID: utils.Addr("")},
+			},
+			expected: acctest.StringListOrNull(),
+		},
+		{
+			name: "mixed empty-ID placeholders and valid IDs returns list with valid IDs",
+			groups: []*models.HostGroupsHostGroupV1{
+				{ID: utils.Addr("group1")},
+				{ID: utils.Addr("")},
 				{ID: utils.Addr("group2")},
 			},
 			expected: acctest.StringListOrNull("group1", "group2"),

--- a/internal/host_groups/host_groups.go
+++ b/internal/host_groups/host_groups.go
@@ -23,11 +23,13 @@ func (h HostGroupAction) String() string {
 }
 
 // convertHostGroupsToIDs converts []*models.HostGroupsHostGroupV1 to a slice of types.String.
+// Groups with a nil or empty ID are skipped; in Flight Control setups the API can return
+// placeholder groups with an empty ID for host groups assigned in a child CID.
 // The returned []types.String will never be null.
 func convertHostGroupsToIDs(groups []*models.HostGroupsHostGroupV1) []types.String {
 	groupIDs := make([]types.String, 0, len(groups))
 	for _, group := range groups {
-		if group != nil && group.ID != nil {
+		if group != nil && group.ID != nil && *group.ID != "" {
 			groupIDs = append(groupIDs, types.StringPointerValue(group.ID))
 		}
 	}

--- a/internal/host_groups/host_groups_test.go
+++ b/internal/host_groups/host_groups_test.go
@@ -1,4 +1,4 @@
-package ioarulegroup
+package hostgroups
 
 import (
 	"testing"
@@ -9,15 +9,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestConvertIOARuleGroupsToIDs(t *testing.T) {
+func TestConvertHostGroupsToIDs(t *testing.T) {
 	tests := []struct {
 		name     string
-		groups   []*models.IoaRuleGroupsRuleGroupV1
+		groups   []*models.HostGroupsHostGroupV1
 		expected []types.String
 	}{
 		{
 			name:     "empty slice",
-			groups:   []*models.IoaRuleGroupsRuleGroupV1{},
+			groups:   []*models.HostGroupsHostGroupV1{},
 			expected: []types.String{},
 		},
 		{
@@ -27,35 +27,35 @@ func TestConvertIOARuleGroupsToIDs(t *testing.T) {
 		},
 		{
 			name: "nil entry",
-			groups: []*models.IoaRuleGroupsRuleGroupV1{
+			groups: []*models.HostGroupsHostGroupV1{
 				nil,
 			},
 			expected: []types.String{},
 		},
 		{
 			name: "entry with nil ID",
-			groups: []*models.IoaRuleGroupsRuleGroupV1{
+			groups: []*models.HostGroupsHostGroupV1{
 				{ID: nil},
 			},
 			expected: []types.String{},
 		},
 		{
 			name: "entry with empty ID (flight control placeholder)",
-			groups: []*models.IoaRuleGroupsRuleGroupV1{
+			groups: []*models.HostGroupsHostGroupV1{
 				{ID: utils.Addr("")},
 			},
 			expected: []types.String{},
 		},
 		{
 			name: "single valid entry",
-			groups: []*models.IoaRuleGroupsRuleGroupV1{
+			groups: []*models.HostGroupsHostGroupV1{
 				{ID: utils.Addr("id-1")},
 			},
 			expected: []types.String{types.StringValue("id-1")},
 		},
 		{
 			name: "multiple valid entries",
-			groups: []*models.IoaRuleGroupsRuleGroupV1{
+			groups: []*models.HostGroupsHostGroupV1{
 				{ID: utils.Addr("id-1")},
 				{ID: utils.Addr("id-2")},
 				{ID: utils.Addr("id-3")},
@@ -68,7 +68,7 @@ func TestConvertIOARuleGroupsToIDs(t *testing.T) {
 		},
 		{
 			name: "mixed nil and valid entries",
-			groups: []*models.IoaRuleGroupsRuleGroupV1{
+			groups: []*models.HostGroupsHostGroupV1{
 				{ID: utils.Addr("id-1")},
 				nil,
 				{ID: nil},
@@ -81,7 +81,7 @@ func TestConvertIOARuleGroupsToIDs(t *testing.T) {
 		},
 		{
 			name: "mixed empty-ID placeholders and valid entries",
-			groups: []*models.IoaRuleGroupsRuleGroupV1{
+			groups: []*models.HostGroupsHostGroupV1{
 				{ID: utils.Addr("id-1")},
 				{ID: utils.Addr("")},
 				{ID: utils.Addr("id-2")},
@@ -96,26 +96,26 @@ func TestConvertIOARuleGroupsToIDs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := convertIOARuleGroupsToIDs(tt.groups)
+			result := convertHostGroupsToIDs(tt.groups)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
 }
 
-func TestConvertIOARuleGroupToSet(t *testing.T) {
+func TestConvertHostGroupsToSet(t *testing.T) {
 	tests := []struct {
 		name          string
-		groups        []*models.IoaRuleGroupsRuleGroupV1
+		groups        []*models.HostGroupsHostGroupV1
 		expectedCount int
 	}{
 		{
 			name:          "empty slice",
-			groups:        []*models.IoaRuleGroupsRuleGroupV1{},
+			groups:        []*models.HostGroupsHostGroupV1{},
 			expectedCount: 0,
 		},
 		{
 			name: "valid entries",
-			groups: []*models.IoaRuleGroupsRuleGroupV1{
+			groups: []*models.HostGroupsHostGroupV1{
 				{ID: utils.Addr("id-1")},
 				{ID: utils.Addr("id-2")},
 			},
@@ -123,7 +123,7 @@ func TestConvertIOARuleGroupToSet(t *testing.T) {
 		},
 		{
 			name: "skips nil entries",
-			groups: []*models.IoaRuleGroupsRuleGroupV1{
+			groups: []*models.HostGroupsHostGroupV1{
 				{ID: utils.Addr("id-1")},
 				nil,
 				{ID: utils.Addr("id-2")},
@@ -132,7 +132,7 @@ func TestConvertIOARuleGroupToSet(t *testing.T) {
 		},
 		{
 			name: "skips empty-ID placeholders",
-			groups: []*models.IoaRuleGroupsRuleGroupV1{
+			groups: []*models.HostGroupsHostGroupV1{
 				{ID: utils.Addr("id-1")},
 				{ID: utils.Addr("")},
 				{ID: utils.Addr("id-2")},
@@ -143,29 +143,30 @@ func TestConvertIOARuleGroupToSet(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, diags := ConvertIOARuleGroupToSet(t.Context(), tt.groups)
+			result, diags := ConvertHostGroupsToSet(t.Context(), tt.groups)
 			assert.False(t, diags.HasError())
+			assert.False(t, result.IsNull())
 			assert.Len(t, result.Elements(), tt.expectedCount)
 		})
 	}
 }
 
-func TestConvertIOARuleGroupToList(t *testing.T) {
+func TestConvertHostGroupsToList(t *testing.T) {
 	tests := []struct {
 		name          string
-		groups        []*models.IoaRuleGroupsRuleGroupV1
+		groups        []*models.HostGroupsHostGroupV1
 		expectedCount int
 		expectedIDs   []string
 	}{
 		{
 			name:          "empty slice",
-			groups:        []*models.IoaRuleGroupsRuleGroupV1{},
+			groups:        []*models.HostGroupsHostGroupV1{},
 			expectedCount: 0,
 			expectedIDs:   []string{},
 		},
 		{
 			name: "preserves order",
-			groups: []*models.IoaRuleGroupsRuleGroupV1{
+			groups: []*models.HostGroupsHostGroupV1{
 				{ID: utils.Addr("id-b")},
 				{ID: utils.Addr("id-a")},
 			},
@@ -174,7 +175,7 @@ func TestConvertIOARuleGroupToList(t *testing.T) {
 		},
 		{
 			name: "drops empty-ID placeholders and preserves order",
-			groups: []*models.IoaRuleGroupsRuleGroupV1{
+			groups: []*models.HostGroupsHostGroupV1{
 				{ID: utils.Addr("id-b")},
 				{ID: utils.Addr("")},
 				{ID: utils.Addr("id-a")},
@@ -186,7 +187,7 @@ func TestConvertIOARuleGroupToList(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, diags := ConvertIOARuleGroupToList(t.Context(), tt.groups)
+			result, diags := ConvertHostGroupsToList(t.Context(), tt.groups)
 			assert.False(t, diags.HasError())
 			assert.Len(t, result.Elements(), tt.expectedCount)
 

--- a/internal/ioa_rule_group/ioa_rule_group.go
+++ b/internal/ioa_rule_group/ioa_rule_group.go
@@ -10,11 +10,13 @@ import (
 )
 
 // convertIOARuleGroupsToIDs converts []*models.IoaRuleGroupsRuleGroupV1 to a slice of types.String.
+// Groups with a nil or empty ID are skipped; in Flight Control setups the API can return
+// placeholder groups with an empty ID for rule groups assigned in a child CID.
 // The returned []types.String will never be null.
 func convertIOARuleGroupsToIDs(ioaRuleGroups []*models.IoaRuleGroupsRuleGroupV1) []types.String {
 	ioaIDs := make([]types.String, 0, len(ioaRuleGroups))
 	for _, group := range ioaRuleGroups {
-		if group != nil && group.ID != nil {
+		if group != nil && group.ID != nil && *group.ID != "" {
 			ioaIDs = append(ioaIDs, types.StringPointerValue(group.ID))
 		}
 	}

--- a/internal/prevention_policy/api.go
+++ b/internal/prevention_policy/api.go
@@ -186,6 +186,9 @@ func updateRuleGroups(
 			groups := r.IoaRuleGroups
 
 			for _, group := range groups {
+				if group == nil || group.ID == nil || *group.ID == "" {
+					continue
+				}
 				returnedRuleGroups[*group.ID] = true
 			}
 		}
@@ -542,6 +545,9 @@ func updateHostGroups(
 			groups := r.Groups
 
 			for _, group := range groups {
+				if group == nil || group.ID == nil || *group.ID == "" {
+					continue
+				}
 				returnedHostGroups[*group.ID] = true
 			}
 		}

--- a/internal/prevention_policy/linux.go
+++ b/internal/prevention_policy/linux.go
@@ -9,6 +9,8 @@ import (
 	"github.com/crowdstrike/gofalcon/falcon/models"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/config"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/framework/flex"
+	hostgroups "github.com/crowdstrike/terraform-provider-crowdstrike/internal/host_groups"
+	ioarulegroup "github.com/crowdstrike/terraform-provider-crowdstrike/internal/ioa_rule_group"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/utils"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -447,12 +449,7 @@ func (r *preventionPolicyLinuxResource) assignRuleGroups(
 	config *preventionPolicyLinuxResourceModel,
 	groups []*models.IoaRuleGroupsRuleGroupV1,
 ) diag.Diagnostics {
-	ruleGroups := make([]types.String, 0, len(groups))
-	for _, ruleGroup := range groups {
-		ruleGroups = append(ruleGroups, types.StringValue(*ruleGroup.ID))
-	}
-
-	ruleGroupIDs, diags := types.SetValueFrom(ctx, types.StringType, ruleGroups)
+	ruleGroupIDs, diags := ioarulegroup.ConvertIOARuleGroupToSet(ctx, groups)
 	config.RuleGroups = ruleGroupIDs
 
 	return diags
@@ -464,12 +461,7 @@ func (r *preventionPolicyLinuxResource) assignHostGroups(
 	config *preventionPolicyLinuxResourceModel,
 	groups []*models.HostGroupsHostGroupV1,
 ) diag.Diagnostics {
-	hostGroups := make([]types.String, 0, len(groups))
-	for _, hostGroup := range groups {
-		hostGroups = append(hostGroups, types.StringValue(*hostGroup.ID))
-	}
-
-	hostGroupIDs, diags := types.SetValueFrom(ctx, types.StringType, hostGroups)
+	hostGroupIDs, diags := hostgroups.ConvertHostGroupsToSet(ctx, groups)
 	config.HostGroups = hostGroupIDs
 
 	return diags

--- a/internal/prevention_policy/mac.go
+++ b/internal/prevention_policy/mac.go
@@ -10,6 +10,8 @@ import (
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/config"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/framework/flex"
 	fwvalidators "github.com/crowdstrike/terraform-provider-crowdstrike/internal/framework/validators"
+	hostgroups "github.com/crowdstrike/terraform-provider-crowdstrike/internal/host_groups"
+	ioarulegroup "github.com/crowdstrike/terraform-provider-crowdstrike/internal/ioa_rule_group"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/utils"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -481,12 +483,7 @@ func (r *preventionPolicyMacResource) assignRuleGroups(
 	config *preventionPolicyMacResourceModel,
 	groups []*models.IoaRuleGroupsRuleGroupV1,
 ) diag.Diagnostics {
-	ruleGroups := make([]types.String, 0, len(groups))
-	for _, ruleGroup := range groups {
-		ruleGroups = append(ruleGroups, types.StringValue(*ruleGroup.ID))
-	}
-
-	ruleGroupIDs, diags := types.SetValueFrom(ctx, types.StringType, ruleGroups)
+	ruleGroupIDs, diags := ioarulegroup.ConvertIOARuleGroupToSet(ctx, groups)
 	config.RuleGroups = ruleGroupIDs
 
 	return diags
@@ -498,12 +495,7 @@ func (r *preventionPolicyMacResource) assignHostGroups(
 	config *preventionPolicyMacResourceModel,
 	groups []*models.HostGroupsHostGroupV1,
 ) diag.Diagnostics {
-	hostGroups := make([]types.String, 0, len(groups))
-	for _, hostGroup := range groups {
-		hostGroups = append(hostGroups, types.StringValue(*hostGroup.ID))
-	}
-
-	hostGroupIDs, diags := types.SetValueFrom(ctx, types.StringType, hostGroups)
+	hostGroupIDs, diags := hostgroups.ConvertHostGroupsToSet(ctx, groups)
 	config.HostGroups = hostGroupIDs
 
 	return diags

--- a/internal/prevention_policy/prevention_policy_attachment.go
+++ b/internal/prevention_policy/prevention_policy_attachment.go
@@ -90,14 +90,14 @@ func (m *preventionPolicyAttachmentResourceModel) wrap(
 	} else {
 		existingHostGroups := make(map[string]bool)
 		for _, hg := range policy.Groups {
-			if hg != nil && hg.ID != nil {
+			if hg != nil && hg.ID != nil && *hg.ID != "" {
 				existingHostGroups[*hg.ID] = true
 			}
 		}
 
 		existingRuleGroups := make(map[string]bool)
 		for _, rg := range policy.IoaRuleGroups {
-			if rg != nil && rg.ID != nil {
+			if rg != nil && rg.ID != nil && *rg.ID != "" {
 				existingRuleGroups[*rg.ID] = true
 			}
 		}

--- a/internal/prevention_policy/windows.go
+++ b/internal/prevention_policy/windows.go
@@ -10,6 +10,8 @@ import (
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/config"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/framework/flex"
 	fwvalidators "github.com/crowdstrike/terraform-provider-crowdstrike/internal/framework/validators"
+	hostgroups "github.com/crowdstrike/terraform-provider-crowdstrike/internal/host_groups"
+	ioarulegroup "github.com/crowdstrike/terraform-provider-crowdstrike/internal/ioa_rule_group"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/utils"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -700,12 +702,7 @@ func (r *preventionPolicyWindowsResource) assignRuleGroups(
 	config *preventionPolicyWindowsResourceModel,
 	groups []*models.IoaRuleGroupsRuleGroupV1,
 ) diag.Diagnostics {
-	ruleGroups := make([]types.String, 0, len(groups))
-	for _, ruleGroup := range groups {
-		ruleGroups = append(ruleGroups, types.StringValue(*ruleGroup.ID))
-	}
-
-	ruleGroupIDs, diags := types.SetValueFrom(ctx, types.StringType, ruleGroups)
+	ruleGroupIDs, diags := ioarulegroup.ConvertIOARuleGroupToSet(ctx, groups)
 	config.RuleGroups = ruleGroupIDs
 
 	return diags
@@ -717,12 +714,7 @@ func (r *preventionPolicyWindowsResource) assignHostGroups(
 	config *preventionPolicyWindowsResourceModel,
 	groups []*models.HostGroupsHostGroupV1,
 ) diag.Diagnostics {
-	hostGroups := make([]types.String, 0, len(groups))
-	for _, hostGroup := range groups {
-		hostGroups = append(hostGroups, types.StringValue(*hostGroup.ID))
-	}
-
-	hostGroupIDs, diags := types.SetValueFrom(ctx, types.StringType, hostGroups)
+	hostGroupIDs, diags := hostgroups.ConvertHostGroupsToSet(ctx, groups)
 	config.HostGroups = hostGroupIDs
 
 	return diags

--- a/internal/sensor_update_policy/export_test.go
+++ b/internal/sensor_update_policy/export_test.go
@@ -3,9 +3,11 @@ package sensorupdatepolicy
 type (
 	SensorUpdatePoliciesDataSource      = sensorUpdatePoliciesDataSource
 	SensorUpdatePoliciesDataSourceModel = sensorUpdatePoliciesDataSourceModel
+	SensorUpdatePolicyResourceModel     = sensorUpdatePolicyResourceModel
 )
 
 var (
 	FilterPoliciesByIDs        = filterPoliciesByIDs
 	FilterPoliciesByAttributes = filterPoliciesByAttributes
+	WrapSensorUpdatePolicy     = (*sensorUpdatePolicyResourceModel).wrap
 )

--- a/internal/sensor_update_policy/sensor_update_policy_host_group_attachment.go
+++ b/internal/sensor_update_policy/sensor_update_policy_host_group_attachment.go
@@ -79,7 +79,7 @@ func (d *sensorUpdatePolicyHostGroupAttachmentResourceModel) wrap(
 	} else {
 		existingHostGroups := make(map[string]bool)
 		for _, hg := range policy.Groups {
-			if hg != nil && hg.ID != nil {
+			if hg != nil && hg.ID != nil && *hg.ID != "" {
 				existingHostGroups[*hg.ID] = true
 			}
 		}

--- a/internal/sensor_update_policy/sensor_update_policy_resource.go
+++ b/internal/sensor_update_policy/sensor_update_policy_resource.go
@@ -100,6 +100,9 @@ func (d *sensorUpdatePolicyResourceModel) wrap(
 
 		if len(policy.Groups) > 0 {
 			for _, hostGroup := range policy.Groups {
+				if hostGroup == nil || hostGroup.ID == nil || *hostGroup.ID == "" {
+					continue
+				}
 				policyGroups = append(policyGroups, *hostGroup.ID)
 			}
 		}

--- a/internal/sensor_update_policy/sensor_update_policy_resource_test.go
+++ b/internal/sensor_update_policy/sensor_update_policy_resource_test.go
@@ -9,9 +9,12 @@ import (
 	"testing"
 	"text/template"
 
+	"github.com/crowdstrike/gofalcon/falcon/models"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/acctest"
+	sensorupdatepolicy "github.com/crowdstrike/terraform-provider-crowdstrike/internal/sensor_update_policy"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/utils"
 
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -1520,4 +1523,44 @@ resource "crowdstrike_sensor_update_policy" "test" {
 			},
 		},
 	})
+}
+
+// TestWrapDropsFlightControlPlaceholderGroups verifies that empty-ID host group
+// placeholders returned by the API in Flight Control setups do not trigger a
+// spurious "Host group mismatch" error and are dropped from state.
+func TestWrapDropsFlightControlPlaceholderGroups(t *testing.T) {
+	build := "1234"
+
+	policy := models.SensorUpdatePolicyV2{
+		ID:           utils.Addr("policy-1"),
+		Name:         utils.Addr("test"),
+		Description:  utils.Addr("test"),
+		Enabled:      utils.Addr(true),
+		PlatformName: utils.Addr("Windows"),
+		Settings: &models.SensorUpdateSettingsRespV2{
+			Build:               utils.Addr(build),
+			UninstallProtection: utils.Addr("DISABLED"),
+		},
+		Groups: []*models.HostGroupsHostGroupV1{
+			{ID: utils.Addr("real-group")},
+			{ID: utils.Addr("")}, // flight control placeholder assigned in a child CID
+		},
+	}
+
+	hostGroups, _ := types.SetValueFrom(t.Context(), types.StringType, []string{"real-group"})
+	model := sensorupdatepolicy.SensorUpdatePolicyResourceModel{
+		Build:      types.StringValue(build),
+		HostGroups: hostGroups,
+	}
+
+	diags := sensorupdatepolicy.WrapSensorUpdatePolicy(&model, t.Context(), policy, false, true)
+	if diags.HasError() {
+		t.Fatalf("expected no diagnostics, got: %v", diags.Errors())
+	}
+
+	var got []string
+	model.HostGroups.ElementsAs(t.Context(), &got, false)
+	if len(got) != 1 || got[0] != "real-group" {
+		t.Fatalf("expected host_groups=[real-group], got %v", got)
+	}
 }

--- a/internal/sensor_visibility_exclusion/export_test.go
+++ b/internal/sensor_visibility_exclusion/export_test.go
@@ -1,4 +1,7 @@
 package sensorvisibilityexclusion
 
 // Export for testing.
-var FilterExclusionsByAttributes = filterExclusionsByAttributes
+var (
+	FilterExclusionsByAttributes = filterExclusionsByAttributes
+	WrapExclusion                = (*SensorVisibilityExclusionResourceModel).wrap
+)

--- a/internal/sensor_visibility_exclusion/sensor_visibility_exclusion.go
+++ b/internal/sensor_visibility_exclusion/sensor_visibility_exclusion.go
@@ -107,6 +107,9 @@ func (m *SensorVisibilityExclusionResourceModel) wrap(
 
 		if len(exclusion.Groups) > 0 {
 			for _, hostGroup := range exclusion.Groups {
+				if hostGroup == nil || hostGroup.ID == nil || *hostGroup.ID == "" {
+					continue
+				}
 				exclusionGroups = append(exclusionGroups, *hostGroup.ID)
 			}
 		}

--- a/internal/sensor_visibility_exclusion/sensor_visibility_exclusion_attachment.go
+++ b/internal/sensor_visibility_exclusion/sensor_visibility_exclusion_attachment.go
@@ -396,13 +396,13 @@ func (r *sensorVisibilityExclusionAttachmentResource) syncHostGroups(
 
 		existingGroups := make(map[string]bool)
 		for _, hg := range currentExclusion.Groups {
-			if hg != nil && hg.ID != nil {
+			if hg != nil && hg.ID != nil && *hg.ID != "" {
 				existingGroups[*hg.ID] = true
 			}
 		}
 
 		for _, existingGroup := range currentExclusion.Groups {
-			if existingGroup != nil && existingGroup.ID != nil {
+			if existingGroup != nil && existingGroup.ID != nil && *existingGroup.ID != "" {
 				shouldRemove := false
 				for _, removeGroup := range groupsToRemove {
 					if *existingGroup.ID == removeGroup {

--- a/internal/sensor_visibility_exclusion/sensor_visibility_exclusion_resource_test.go
+++ b/internal/sensor_visibility_exclusion/sensor_visibility_exclusion_resource_test.go
@@ -6,8 +6,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/crowdstrike/gofalcon/falcon/models"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/acctest"
+	sensorvisibilityexclusion "github.com/crowdstrike/terraform-provider-crowdstrike/internal/sensor_visibility_exclusion"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/utils"
+	"github.com/go-openapi/strfmt"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
@@ -562,4 +566,41 @@ func TestAccSensorVisibilityExclusionResource_AllPermutations(t *testing.T) {
 			return steps
 		}(),
 	})
+}
+
+// TestWrapDropsFlightControlPlaceholderGroups verifies that empty-ID host group
+// placeholders returned by the API in Flight Control setups do not trigger a
+// spurious "Host group mismatch" error and are dropped from state.
+func TestWrapDropsFlightControlPlaceholderGroups(t *testing.T) {
+	now := strfmt.DateTime{}
+
+	exclusion := &models.SvExclusionsSVExclusionV1{
+		ID:              utils.Addr("exclusion-1"),
+		Value:           utils.Addr("/tmp/example"),
+		AppliedGlobally: utils.Addr(false),
+		LastModified:    &now,
+		CreatedOn:       &now,
+		ModifiedBy:      utils.Addr("tester"),
+		CreatedBy:       utils.Addr("tester"),
+		Groups: []*models.HostGroupsHostGroupV1{
+			{ID: utils.Addr("real-group")},
+			{ID: utils.Addr("")}, // flight control placeholder assigned in a child CID
+		},
+	}
+
+	hostGroups, _ := types.SetValueFrom(t.Context(), types.StringType, []string{"real-group"})
+	model := sensorvisibilityexclusion.SensorVisibilityExclusionResourceModel{
+		HostGroups: hostGroups,
+	}
+
+	diags := sensorvisibilityexclusion.WrapExclusion(&model, t.Context(), exclusion, true)
+	if diags.HasError() {
+		t.Fatalf("expected no diagnostics, got: %v", diags.Errors())
+	}
+
+	var got []string
+	model.HostGroups.ElementsAs(t.Context(), &got, false)
+	if len(got) != 1 || got[0] != "real-group" {
+		t.Fatalf("expected host_groups=[real-group], got %v", got)
+	}
 }


### PR DESCRIPTION
In Flight Control (MSSP) setups, the API returns placeholder host/rule
group objects with an empty ID for groups assigned in a child CID when
the policy is read from the parent CID. The provider wrote these empty
IDs into state, so Terraform saw perpetual drift and never converged.

Guard the shared group-conversion helpers (host_groups, ioa_rule_group,
framework/flex) against nil and empty IDs, and route the prevention
policy linux/windows/mac assign methods through those helpers instead of
hand-rolled loops. Apply the same guard to the sensor update and sensor
visibility exclusion validation loops (which otherwise raised a spurious
"Host group mismatch" error), the FIM assign/data-source/attachment
loops, and the prevention/sensor/content attachment rebuild loops.

Add unit tests covering the empty-ID case for each helper and wrap-level
tests for the sensor update and sensor visibility resources.