### PR TITLE
fix(firewall_policy): scope precedence to caller CID in Flight Control

### DIFF
--- a/docs/resources/firewall_policy_precedence.md
+++ b/docs/resources/firewall_policy_precedence.md
@@ -3,20 +3,24 @@ page_title: "crowdstrike_firewall_policy_precedence Resource - crowdstrike"
 subcategory: "Firewall Management"
 description: |-
   This resource allows you to set the precedence of Firewall Policies based on the order of IDs.
+  In a Flight Control (MSSP) environment the precedence API only manages the policies that belong to the CID authenticated by the provider. Policies belonging to other CIDs (parent or child) are returned by the API but cannot be reordered, so they are excluded automatically. Resolving the authenticated CID requires the Sensor Download: Read scope; without it, precedence can only be managed for tenants that are not part of a Flight Control hierarchy.
   API Scopes
   The following API scopes are required:
-  Firewall management | Read & Write
+  Firewall management | Read & WriteSensor Download | Read
 ---
 
 # crowdstrike_firewall_policy_precedence (Resource)
 
 This resource allows you to set the precedence of Firewall Policies based on the order of IDs.
 
+In a Flight Control (MSSP) environment the precedence API only manages the policies that belong to the CID authenticated by the provider. Policies belonging to other CIDs (parent or child) are returned by the API but cannot be reordered, so they are excluded automatically. Resolving the authenticated CID requires the `Sensor Download: Read` scope; without it, precedence can only be managed for tenants that are not part of a Flight Control hierarchy.
+
 ## API Scopes
 
 The following API scopes are required:
 
 - Firewall management | Read & Write
+- Sensor Download | Read
 
 
 ## Example Usage

--- a/internal/firewall/export_test.go
+++ b/internal/firewall/export_test.go
@@ -1,0 +1,14 @@
+package firewall
+
+type PolicyRef = policyRef
+
+var (
+	FilterPoliciesByCID = filterPoliciesByCID
+	DistinctCIDs        = distinctCIDs
+	StripChecksum       = stripChecksum
+)
+
+// NewPolicyRef builds a policyRef for tests in the external test package.
+func NewPolicyRef(id, cid, name string) policyRef {
+	return policyRef{id: id, cid: cid, name: name}
+}

--- a/internal/firewall/policy_precedence.go
+++ b/internal/firewall/policy_precedence.go
@@ -334,19 +334,28 @@ func (r *firewallPolicyPrecedenceResource) getFirewallPoliciesByPrecedence(
 
 	filter := fmt.Sprintf("platform_name:'%s'", caser.String(platformName))
 	sort := "precedence.asc"
-	res, err := r.client.FirewallPolicies.QueryCombinedFirewallPolicies(
-		&firewall_policies.QueryCombinedFirewallPoliciesParams{
-			Context: ctx,
-			Filter:  &filter,
-			Sort:    &sort,
-		},
-	)
-	if err != nil {
-		diags.Append(tferrors.NewDiagnosticFromAPIError(tferrors.Read, err, apiScopesRead))
-		return nil, diags
-	}
+	limit := int64(5000)
+	offset := int64(0)
 
-	if res != nil && res.Payload != nil {
+	for {
+		res, err := r.client.FirewallPolicies.QueryCombinedFirewallPolicies(
+			&firewall_policies.QueryCombinedFirewallPoliciesParams{
+				Context: ctx,
+				Filter:  &filter,
+				Sort:    &sort,
+				Limit:   &limit,
+				Offset:  &offset,
+			},
+		)
+		if err != nil {
+			diags.Append(tferrors.NewDiagnosticFromAPIError(tferrors.Read, err, apiScopesRead))
+			return nil, diags
+		}
+
+		if res == nil || res.Payload == nil || len(res.Payload.Resources) == 0 {
+			break
+		}
+
 		for _, policy := range res.Payload.Resources {
 			if policy == nil || policy.ID == nil {
 				continue
@@ -360,6 +369,22 @@ func (r *firewallPolicyPrecedenceResource) getFirewallPoliciesByPrecedence(
 				ref.name = *policy.Name
 			}
 			refs = append(refs, ref)
+		}
+
+		if res.Payload.Meta == nil || res.Payload.Meta.Pagination == nil ||
+			res.Payload.Meta.Pagination.Offset == nil || res.Payload.Meta.Pagination.Total == nil {
+
+			tflog.Warn(ctx, "Missing pagination metadata in API response, using offset+limit for next page",
+				map[string]interface{}{
+					"meta": res.Payload.Meta,
+				})
+			offset += limit
+			continue
+		}
+
+		offset = int64(*res.Payload.Meta.Pagination.Offset)
+		if offset >= *res.Payload.Meta.Pagination.Total {
+			break
 		}
 	}
 

--- a/internal/firewall/policy_precedence.go
+++ b/internal/firewall/policy_precedence.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/crowdstrike/gofalcon/falcon/client"
 	"github.com/crowdstrike/gofalcon/falcon/client/firewall_policies"
+	"github.com/crowdstrike/gofalcon/falcon/client/sensor_download"
 	"github.com/crowdstrike/gofalcon/falcon/models"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/config"
+	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/scopes"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/tferrors"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -20,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
@@ -31,6 +34,23 @@ var (
 )
 
 const dynamicEnforcement = "dynamic"
+
+var precedenceMarkdownDescription = "This resource allows you to set the precedence of Firewall Policies based on the order of IDs.\n\n" +
+	"In a Flight Control (MSSP) environment the precedence API only manages the policies that belong to the CID authenticated by the provider. " +
+	"Policies belonging to other CIDs (parent or child) are returned by the API but cannot be reordered, so they are excluded automatically. " +
+	"Resolving the authenticated CID requires the `Sensor Download: Read` scope; without it, precedence can only be managed for tenants that are not part of a Flight Control hierarchy."
+
+var precedenceRequiredScopes = []scopes.Scope{
+	{
+		Name:  "Firewall management",
+		Read:  true,
+		Write: true,
+	},
+	{
+		Name: "Sensor Download",
+		Read: true,
+	},
+}
 
 // NewFirewallPolicyPrecedenceResource is a helper function to simplify the provider implementation.
 func NewFirewallPolicyPrecedenceResource() resource.Resource {
@@ -110,8 +130,8 @@ func (r *firewallPolicyPrecedenceResource) Schema(
 	resp.Schema = schema.Schema{
 		MarkdownDescription: utils.MarkdownDescription(
 			"Firewall Management",
-			"This resource allows you to set the precedence of Firewall Policies based on the order of IDs.",
-			apiScopesReadWrite,
+			precedenceMarkdownDescription,
+			precedenceRequiredScopes,
 		),
 		Attributes: map[string]schema.Attribute{
 			"ids": schema.ListAttribute{
@@ -286,13 +306,29 @@ func (r *firewallPolicyPrecedenceResource) Delete(
 	// Precedence resources don't have a delete operation - removing from state only
 }
 
-// getFirewallPoliciesByPrecedence returns firewall policy IDs ordered by precedence excluding the default policy.
+// defaultPolicyName is the name of the default firewall policy that exists in every CID.
+const defaultPolicyName = "platform_default"
+
+// policyRef holds the fields needed to scope precedence policies to the caller's CID.
+type policyRef struct {
+	id   string
+	cid  string
+	name string
+}
+
+// getFirewallPoliciesByPrecedence returns firewall policy IDs ordered by precedence,
+// scoped to the caller's own CID and excluding the default firewall policy.
+//
+// The combined firewall policy endpoint returns policies from every CID visible to the
+// caller (parent and children in a Flight Control hierarchy). The precedence API only
+// manages the caller's own-CID policies, so policies belonging to other CIDs and the
+// per-CID default policy are excluded here.
 func (r *firewallPolicyPrecedenceResource) getFirewallPoliciesByPrecedence(
 	ctx context.Context,
 	platformName string,
 ) ([]string, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	var policies []string
+	var refs []policyRef
 
 	caser := cases.Title(language.English)
 
@@ -307,19 +343,116 @@ func (r *firewallPolicyPrecedenceResource) getFirewallPoliciesByPrecedence(
 	)
 	if err != nil {
 		diags.Append(tferrors.NewDiagnosticFromAPIError(tferrors.Read, err, apiScopesRead))
-		return policies, diags
+		return nil, diags
 	}
 
 	if res != nil && res.Payload != nil {
-		for i, policy := range res.Payload.Resources {
-			// Exclude the default policy (last in the list)
-			if i != len(res.Payload.Resources)-1 {
-				policies = append(policies, *policy.ID)
+		for _, policy := range res.Payload.Resources {
+			if policy == nil || policy.ID == nil {
+				continue
 			}
+
+			ref := policyRef{id: *policy.ID}
+			if policy.Cid != nil {
+				ref.cid = *policy.Cid
+			}
+			if policy.Name != nil {
+				ref.name = *policy.Name
+			}
+			refs = append(refs, ref)
 		}
 	}
 
-	return policies, diags
+	nonDefault := make([]policyRef, 0, len(refs))
+	for _, ref := range refs {
+		if ref.name == defaultPolicyName {
+			continue
+		}
+		nonDefault = append(nonDefault, ref)
+	}
+
+	distinct := distinctCIDs(nonDefault)
+	var ownCID string
+	switch len(distinct) {
+	case 0:
+		return []string{}, diags
+	case 1:
+		ownCID = distinct[0]
+	default:
+		cid, err := r.getCallerCID(ctx)
+		if err != nil {
+			tflog.Warn(ctx, "Could not resolve authenticated CID from the sensor installers CCID endpoint",
+				map[string]interface{}{
+					"error": err.Error(),
+				})
+			diags.AddError(
+				"Unable to determine the authenticated CID",
+				"Firewall policies from multiple CIDs were returned, which happens in a Flight Control (MSSP) environment. "+
+					"The provider could not determine which CID it is authenticated as to scope precedence correctly. "+
+					"Grant the `Sensor Download: Read` scope to the API client so the authenticated CID can be resolved.",
+			)
+			return nil, diags
+		}
+		ownCID = cid
+	}
+
+	return filterPoliciesByCID(nonDefault, ownCID), diags
+}
+
+// getCallerCID returns the CID authenticated by the provider, normalized to the
+// lowercase 32-character form used in policy responses. It reads the sensor installers
+// CCID endpoint, which requires the Sensor Download: Read scope.
+func (r *firewallPolicyPrecedenceResource) getCallerCID(ctx context.Context) (string, error) {
+	res, err := r.client.SensorDownload.GetSensorInstallersCCIDByQuery(
+		sensor_download.NewGetSensorInstallersCCIDByQueryParamsWithContext(ctx),
+	)
+	if err != nil {
+		return "", err
+	}
+	if res == nil || res.Payload == nil || len(res.Payload.Resources) == 0 {
+		return "", fmt.Errorf("ccid query returned no data")
+	}
+
+	return stripChecksum(res.Payload.Resources[0]), nil
+}
+
+// filterPoliciesByCID returns the ids of policies belonging to cid, preserving order.
+func filterPoliciesByCID(policies []policyRef, cid string) []string {
+	ids := make([]string, 0, len(policies))
+	for _, p := range policies {
+		if strings.EqualFold(p.cid, cid) {
+			ids = append(ids, p.id)
+		}
+	}
+	return ids
+}
+
+// distinctCIDs returns the unique, non-empty CIDs across policies, preserving first-seen order.
+func distinctCIDs(policies []policyRef) []string {
+	seen := make(map[string]struct{}, len(policies))
+	var cids []string
+	for _, p := range policies {
+		if p.cid == "" {
+			continue
+		}
+		key := strings.ToLower(p.cid)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		cids = append(cids, key)
+	}
+	return cids
+}
+
+// stripChecksum normalizes a CCID (32-character CID plus a "-YY" checksum) to the
+// lowercase 32-character CID used in policy responses.
+func stripChecksum(ccid string) string {
+	idx := strings.LastIndex(ccid, "-")
+	if idx < 0 {
+		return strings.ToLower(ccid)
+	}
+	return strings.ToLower(ccid[:idx])
 }
 
 // generateDynamicPolicyOrder takes the dynamic managed policies and returns a slice of all policies in the correct order.

--- a/internal/firewall/policy_precedence_test.go
+++ b/internal/firewall/policy_precedence_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/acctest"
+	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/firewall"
 	"github.com/hashicorp/terraform-plugin-testing/compare"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -152,4 +153,143 @@ resource "crowdstrike_firewall_policy_precedence" "test" {
   ]
 }
 `, rName)
+}
+
+func TestFilterPoliciesByCID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		policies []firewall.PolicyRef
+		cid      string
+		want     []string
+	}{
+		{
+			name: "keeps only matching cid preserving order",
+			policies: []firewall.PolicyRef{
+				firewall.NewPolicyRef("a", "010abf4b", ""),
+				firewall.NewPolicyRef("b", "2436580c", ""),
+				firewall.NewPolicyRef("c", "010abf4b", ""),
+			},
+			cid:  "010abf4b",
+			want: []string{"a", "c"},
+		},
+		{
+			name: "case insensitive cid match",
+			policies: []firewall.PolicyRef{
+				firewall.NewPolicyRef("a", "010ABF4B", ""),
+			},
+			cid:  "010abf4b",
+			want: []string{"a"},
+		},
+		{
+			name: "no matches returns empty",
+			policies: []firewall.PolicyRef{
+				firewall.NewPolicyRef("a", "2436580c", ""),
+			},
+			cid:  "010abf4b",
+			want: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := firewall.FilterPoliciesByCID(tt.policies, tt.cid)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("got %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestDistinctCIDs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		policies []firewall.PolicyRef
+		want     []string
+	}{
+		{
+			name: "single cid",
+			policies: []firewall.PolicyRef{
+				firewall.NewPolicyRef("a", "010abf4b", ""),
+				firewall.NewPolicyRef("b", "010abf4b", ""),
+			},
+			want: []string{"010abf4b"},
+		},
+		{
+			name: "multiple distinct cids first-seen order",
+			policies: []firewall.PolicyRef{
+				firewall.NewPolicyRef("a", "2436580c", ""),
+				firewall.NewPolicyRef("b", "010abf4b", ""),
+				firewall.NewPolicyRef("c", "2436580c", ""),
+			},
+			want: []string{"2436580c", "010abf4b"},
+		},
+		{
+			name: "empty cids skipped",
+			policies: []firewall.PolicyRef{
+				firewall.NewPolicyRef("a", "", ""),
+				firewall.NewPolicyRef("b", "010abf4b", ""),
+			},
+			want: []string{"010abf4b"},
+		},
+		{
+			name:     "no policies",
+			policies: []firewall.PolicyRef{},
+			want:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := firewall.DistinctCIDs(tt.policies)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("got %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestStripChecksum(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "uppercase ccid with checksum",
+			in:   "010ABF4B1BA04B7DA3F240A4C56657AC-C1",
+			want: "010abf4b1ba04b7da3f240a4c56657ac",
+		},
+		{
+			name: "no checksum suffix",
+			in:   "010ABF4B1BA04B7DA3F240A4C56657AC",
+			want: "010abf4b1ba04b7da3f240a4c56657ac",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := firewall.StripChecksum(tt.in); got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
The precedence resource read all firewall policies sorted by precedence and assumed only the last policy was the default. In a Flight Control (MSSP) environment the combined endpoint returns policies from every visible CID interleaved, with one platform_default per CID, so chopping the last element left extra defaults and cross-CID policies in state. The set-precedence API is strictly own-CID scoped and rejects cross-CID ids, so this caused perpetual drift and failed writes for parent and child CIDs.

Scope the read to the caller's own non-default policies: strip all platform_default policies by name and keep only policies matching the authenticated CID. The CID is resolved via the sensor installers CCID endpoint, falling back to the policies' own CID when a single CID is present and erroring when multiple CIDs are ambiguous.

Requires the Sensor Download: Read scope to resolve the authenticated CID in Flight Control environments.

Fixes #436