### PR TITLE
fix(filevantage_policy): scope precedence to caller CID in Flight Control

### DIFF
--- a/docs/resources/filevantage_policy_precedence.md
+++ b/docs/resources/filevantage_policy_precedence.md
@@ -3,20 +3,24 @@ page_title: "crowdstrike_filevantage_policy_precedence Resource - crowdstrike"
 subcategory: "FileVantage"
 description: |-
   This resource allows you to set the precedence of FileVantage Policies based on the order of IDs.
+  In a Flight Control (MSSP) environment the precedence API only manages the policies that belong to the CID authenticated by the provider. Policies belonging to other CIDs (parent or child) are returned by the API but cannot be reordered, so they are excluded automatically. Resolving the authenticated CID requires the Sensor Download: Read scope; without it, precedence can only be managed for tenants that are not part of a Flight Control hierarchy.
   API Scopes
   The following API scopes are required:
-  Falcon FileVantage | Read & Write
+  Falcon FileVantage | Read & WriteSensor Download | Read
 ---
 
 # crowdstrike_filevantage_policy_precedence (Resource)
 
 This resource allows you to set the precedence of FileVantage Policies based on the order of IDs.
 
+In a Flight Control (MSSP) environment the precedence API only manages the policies that belong to the CID authenticated by the provider. Policies belonging to other CIDs (parent or child) are returned by the API but cannot be reordered, so they are excluded automatically. Resolving the authenticated CID requires the `Sensor Download: Read` scope; without it, precedence can only be managed for tenants that are not part of a Flight Control hierarchy.
+
 ## API Scopes
 
 The following API scopes are required:
 
 - Falcon FileVantage | Read & Write
+- Sensor Download | Read
 
 
 ## Example Usage

--- a/internal/fim/export_test.go
+++ b/internal/fim/export_test.go
@@ -3,6 +3,19 @@ package fim
 type (
 	FilevantagePoliciesDataSource      = filevantagePoliciesDataSource
 	FilevantagePoliciesDataSourceModel = filevantagePoliciesDataSourceModel
+	PolicyRef                          = policyRef
 )
 
-var FilterPoliciesByAttributes = filterPoliciesByAttributes
+var (
+	FilterPoliciesByAttributes = filterPoliciesByAttributes
+
+	FilterPoliciesByCID = filterPoliciesByCID
+	DistinctCIDs        = distinctCIDs
+	StripChecksum       = stripChecksum
+	DefaultPolicyName   = defaultPolicyName
+)
+
+// NewPolicyRef builds a policyRef for tests in the external test package.
+func NewPolicyRef(id, cid, name string) policyRef {
+	return policyRef{id: id, cid: cid, name: name}
+}

--- a/internal/fim/filevantage_policy_precedence.go
+++ b/internal/fim/filevantage_policy_precedence.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/crowdstrike/gofalcon/falcon/client"
 	"github.com/crowdstrike/gofalcon/falcon/client/filevantage"
+	"github.com/crowdstrike/gofalcon/falcon/client/sensor_download"
+	"github.com/crowdstrike/gofalcon/falcon/models"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/config"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -31,7 +33,10 @@ var (
 
 var (
 	precedenceDocumentationSection string = "FileVantage"
-	precedenceMarkdownDescription  string = "This resource allows you to set the precedence of FileVantage Policies based on the order of IDs."
+	precedenceMarkdownDescription  string = "This resource allows you to set the precedence of FileVantage Policies based on the order of IDs.\n\n" +
+		"In a Flight Control (MSSP) environment the precedence API only manages the policies that belong to the CID authenticated by the provider. " +
+		"Policies belonging to other CIDs (parent or child) are returned by the API but cannot be reordered, so they are excluded automatically. " +
+		"Resolving the authenticated CID requires the `Sensor Download: Read` scope; without it, precedence can only be managed for tenants that are not part of a Flight Control hierarchy."
 
 	dynamicEnforcement = "dynamic"
 )
@@ -108,7 +113,7 @@ func (r *filevantagePolicyPrecedenceResource) Schema(
 	resp *resource.SchemaResponse,
 ) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: utils.MarkdownDescription(precedenceDocumentationSection, precedenceMarkdownDescription, apiScopesReadWrite),
+		MarkdownDescription: utils.MarkdownDescription(precedenceDocumentationSection, precedenceMarkdownDescription, precedenceRequiredScopes),
 		Attributes: map[string]schema.Attribute{
 			"ids": schema.ListAttribute{
 				Required:            true,
@@ -292,12 +297,38 @@ func (r *filevantagePolicyPrecedenceResource) ValidateConfig(
 	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 }
 
+// defaultPolicyName returns the name of the per-CID default filevantage policy
+// for a platform. FileVantage identifies the default policy only by this name;
+// there is no is_default flag or platform_default marker.
+func defaultPolicyName(platform string) string {
+	return fmt.Sprintf("Default Policy (%s)", platform)
+}
+
+// policyRef holds the fields needed to scope precedence policies to the caller's CID.
+type policyRef struct {
+	id   string
+	cid  string
+	name string
+}
+
+// getFilevantagePoilciesByPrecedence returns filevantage policy ids ordered by
+// precedence, scoped to the caller's own CID and excluding the default policy.
+//
+// The filevantage query endpoint returns policies from every CID visible to the
+// caller (parent and children in a Flight Control hierarchy) interleaved with one
+// default policy per CID. The precedence API only manages the caller's own-CID
+// policies, so policies belonging to other CIDs and the per-CID default policy are
+// excluded here.
+//
+// Policy details are fetched in a second call because the query endpoint returns
+// ids only. Ordering comes from the query (sort=precedence|asc); the precedence
+// field on the details is null, so the query order is preserved by mapping details
+// back onto the ordered id list.
 func (r *filevantagePolicyPrecedenceResource) getFilevantagePoilciesByPrecedence(
 	ctx context.Context,
 	platformName string,
 ) ([]string, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	var policies []string
 
 	caser := cases.Title(language.English)
 	platform := caser.String(platformName)
@@ -306,6 +337,7 @@ func (r *filevantagePolicyPrecedenceResource) getFilevantagePoilciesByPrecedence
 	limit := int64(500)
 	offset := int64(0)
 
+	var orderedIDs []string
 	for {
 		res, err := r.client.Filevantage.QueryPolicies(
 			&filevantage.QueryPoliciesParams{
@@ -324,14 +356,14 @@ func (r *filevantagePolicyPrecedenceResource) getFilevantagePoilciesByPrecedence
 					err.Error(),
 				),
 			)
-			return policies, diags
+			return nil, diags
 		}
 
 		if res == nil || res.Payload == nil || len(res.Payload.Resources) == 0 {
 			break
 		}
 
-		policies = append(policies, res.Payload.Resources...)
+		orderedIDs = append(orderedIDs, res.Payload.Resources...)
 
 		if res.Payload.Meta == nil || res.Payload.Meta.Pagination == nil ||
 			res.Payload.Meta.Pagination.Offset == nil || res.Payload.Meta.Pagination.Total == nil {
@@ -349,11 +381,162 @@ func (r *filevantagePolicyPrecedenceResource) getFilevantagePoilciesByPrecedence
 		}
 	}
 
-	if len(policies) > 0 {
-		policies = policies[:len(policies)-1]
+	if len(orderedIDs) == 0 {
+		return []string{}, diags
 	}
 
-	return policies, diags
+	details, err := r.getPolicyDetails(ctx, orderedIDs)
+	if err != nil {
+		diags.AddError(
+			"Error reading CrowdStrike filevantage policies",
+			fmt.Sprintf(
+				"Could not read CrowdStrike filevantage policies\n\n %s",
+				err.Error(),
+			),
+		)
+		return nil, diags
+	}
+
+	defaultName := defaultPolicyName(platform)
+	nonDefault := make([]policyRef, 0, len(orderedIDs))
+	for _, id := range orderedIDs {
+		policy, ok := details[id]
+		if !ok || policy == nil {
+			continue
+		}
+		ref := policyRef{id: id, name: policy.Name}
+		if policy.Cid != nil {
+			ref.cid = *policy.Cid
+		}
+		if ref.name == defaultName {
+			continue
+		}
+		nonDefault = append(nonDefault, ref)
+	}
+
+	distinct := distinctCIDs(nonDefault)
+	var ownCID string
+	switch len(distinct) {
+	case 0:
+		return []string{}, diags
+	case 1:
+		ownCID = distinct[0]
+	default:
+		cid, err := r.getCallerCID(ctx)
+		if err != nil {
+			tflog.Warn(ctx, "Could not resolve authenticated CID from the sensor installers CCID endpoint",
+				map[string]interface{}{
+					"error": err.Error(),
+				})
+			diags.AddError(
+				"Unable to determine the authenticated CID",
+				"FileVantage policies from multiple CIDs were returned, which happens in a Flight Control (MSSP) environment. "+
+					"The provider could not determine which CID it is authenticated as to scope precedence correctly. "+
+					"Grant the `Sensor Download: Read` scope to the API client so the authenticated CID can be resolved.",
+			)
+			return nil, diags
+		}
+		ownCID = cid
+	}
+
+	return filterPoliciesByCID(nonDefault, ownCID), diags
+}
+
+// getPolicyDetails fetches filevantage policy details for the given ids and returns
+// them keyed by id. It batches requests since the details endpoint accepts at most
+// 500 ids per call.
+func (r *filevantagePolicyPrecedenceResource) getPolicyDetails(
+	ctx context.Context,
+	ids []string,
+) (map[string]*models.PoliciesPolicy, error) {
+	details := make(map[string]*models.PoliciesPolicy, len(ids))
+
+	const batchSize = 500
+	for start := 0; start < len(ids); start += batchSize {
+		end := start + batchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+
+		res, err := r.client.Filevantage.GetPolicies(
+			&filevantage.GetPoliciesParams{
+				Context: ctx,
+				Ids:     ids[start:end],
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		if res == nil || res.Payload == nil {
+			continue
+		}
+
+		for _, policy := range res.Payload.Resources {
+			if policy == nil || policy.ID == nil {
+				continue
+			}
+			details[*policy.ID] = policy
+		}
+	}
+
+	return details, nil
+}
+
+// getCallerCID returns the CID authenticated by the provider, normalized to the
+// lowercase 32-character form used in policy responses. It reads the sensor installers
+// CCID endpoint, which requires the Sensor Download: Read scope.
+func (r *filevantagePolicyPrecedenceResource) getCallerCID(ctx context.Context) (string, error) {
+	res, err := r.client.SensorDownload.GetSensorInstallersCCIDByQuery(
+		sensor_download.NewGetSensorInstallersCCIDByQueryParamsWithContext(ctx),
+	)
+	if err != nil {
+		return "", err
+	}
+	if res == nil || res.Payload == nil || len(res.Payload.Resources) == 0 {
+		return "", fmt.Errorf("ccid query returned no data")
+	}
+
+	return stripChecksum(res.Payload.Resources[0]), nil
+}
+
+// filterPoliciesByCID returns the ids of policies belonging to cid, preserving order.
+func filterPoliciesByCID(policies []policyRef, cid string) []string {
+	ids := make([]string, 0, len(policies))
+	for _, p := range policies {
+		if strings.EqualFold(p.cid, cid) {
+			ids = append(ids, p.id)
+		}
+	}
+	return ids
+}
+
+// distinctCIDs returns the unique, non-empty CIDs across policies, preserving first-seen order.
+func distinctCIDs(policies []policyRef) []string {
+	seen := make(map[string]struct{}, len(policies))
+	var cids []string
+	for _, p := range policies {
+		if p.cid == "" {
+			continue
+		}
+		key := strings.ToLower(p.cid)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		cids = append(cids, key)
+	}
+	return cids
+}
+
+// stripChecksum normalizes a CCID (32-character CID plus a "-YY" checksum) to the
+// lowercase 32-character CID used in policy responses.
+func stripChecksum(ccid string) string {
+	idx := strings.LastIndex(ccid, "-")
+	if idx < 0 {
+		return strings.ToLower(ccid)
+	}
+	return strings.ToLower(ccid[:idx])
 }
 
 // generateDynamicPolicyOrder takes the dynamic managed policies and returns a slice of all policies in the correct order.

--- a/internal/fim/filevantage_policy_precedence_acc_test.go
+++ b/internal/fim/filevantage_policy_precedence_acc_test.go
@@ -23,42 +23,38 @@ func TestAccFilevantagePolicyPrecedenceResource_strict(t *testing.T) {
 	}
 	acctest.PreCheck(t)
 
-	var platformName string
-	var ids []string
-	for _, p := range []string{"Windows", "Linux", "Mac"} {
-		if candidate := getNonDefaultFilevantagePolicyIDs(t, p); len(candidate) > 0 {
-			platformName = p
-			ids = candidate
-			break
-		}
-	}
-	if len(ids) == 0 {
-		t.Skip("no non-default filevantage policies in tenant for any platform; nothing to test")
-	}
-
 	resourceName := "crowdstrike_filevantage_policy_precedence.test"
 
-	idChecks := make([]knownvalue.Check, len(ids))
-	for i, id := range ids {
-		idChecks[i] = knownvalue.StringExact(id)
-	}
+	for _, platformName := range []string{"Windows", "Linux", "Mac"} {
+		t.Run(platformName, func(t *testing.T) {
+			ids := getNonDefaultFilevantagePolicyIDs(t, platformName)
+			if len(ids) == 0 {
+				t.Skipf("no non-default %s filevantage policies in tenant; nothing to test", platformName)
+			}
 
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		Steps: []resource.TestStep{
-			{
-				Config: testAccFilevantagePolicyPrecedenceStrictConfig(platformName, ids),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(
-						resourceName,
-						tfjsonpath.New("ids"),
-						knownvalue.ListExact(idChecks),
-					),
+			idChecks := make([]knownvalue.Check, len(ids))
+			for i, id := range ids {
+				idChecks[i] = knownvalue.StringExact(id)
+			}
+
+			resource.Test(t, resource.TestCase{
+				ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+				PreCheck:                 func() { acctest.PreCheck(t) },
+				Steps: []resource.TestStep{
+					{
+						Config: testAccFilevantagePolicyPrecedenceStrictConfig(platformName, ids),
+						ConfigStateChecks: []statecheck.StateCheck{
+							statecheck.ExpectKnownValue(
+								resourceName,
+								tfjsonpath.New("ids"),
+								knownvalue.ListExact(idChecks),
+							),
+						},
+					},
 				},
-			},
-		},
-	})
+			})
+		})
+	}
 }
 
 // getNonDefaultFilevantagePolicyIDs returns every non-default filevantage policy id

--- a/internal/fim/filevantage_policy_precedence_acc_test.go
+++ b/internal/fim/filevantage_policy_precedence_acc_test.go
@@ -1,0 +1,197 @@
+package fim_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/crowdstrike/gofalcon/falcon/client/filevantage"
+	"github.com/crowdstrike/gofalcon/falcon/client/sensor_download"
+	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/acctest"
+	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/testconfig"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccFilevantagePolicyPrecedenceResource_strict(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("Acceptance tests skipped unless env 'TF_ACC' set")
+	}
+	acctest.PreCheck(t)
+
+	var platformName string
+	var ids []string
+	for _, p := range []string{"Windows", "Linux", "Mac"} {
+		if candidate := getNonDefaultFilevantagePolicyIDs(t, p); len(candidate) > 0 {
+			platformName = p
+			ids = candidate
+			break
+		}
+	}
+	if len(ids) == 0 {
+		t.Skip("no non-default filevantage policies in tenant for any platform; nothing to test")
+	}
+
+	resourceName := "crowdstrike_filevantage_policy_precedence.test"
+
+	idChecks := make([]knownvalue.Check, len(ids))
+	for i, id := range ids {
+		idChecks[i] = knownvalue.StringExact(id)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFilevantagePolicyPrecedenceStrictConfig(platformName, ids),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("ids"),
+						knownvalue.ListExact(idChecks),
+					),
+				},
+			},
+		},
+	})
+}
+
+// getNonDefaultFilevantagePolicyIDs returns every non-default filevantage policy id
+// for a platform that belongs to the authenticated CID, ordered by precedence|asc.
+// It mirrors what the resource reads back so the strict test can assert against the
+// live tenant without hardcoding ids. In a Flight Control environment the query
+// endpoint also returns other CIDs' policies and one "Default Policy (<platform>)"
+// per CID; those are excluded here just as the resource does.
+func getNonDefaultFilevantagePolicyIDs(t *testing.T, platformName string) []string {
+	t.Helper()
+
+	c := testconfig.GetTestClient()
+	if c == nil {
+		t.Fatal("test client not initialized; PreCheck must run first")
+	}
+
+	ccidRes, err := c.SensorDownload.GetSensorInstallersCCIDByQuery(
+		sensor_download.NewGetSensorInstallersCCIDByQueryParamsWithContext(context.Background()),
+	)
+	if err != nil {
+		t.Fatalf("failed to query ccid: %s", err)
+	}
+	if ccidRes == nil || ccidRes.Payload == nil || len(ccidRes.Payload.Resources) == 0 {
+		t.Fatal("ccid query returned no data")
+	}
+	ownCID := ccidRes.Payload.Resources[0]
+	if idx := strings.LastIndex(ownCID, "-"); idx >= 0 {
+		ownCID = ownCID[:idx]
+	}
+	ownCID = strings.ToLower(ownCID)
+
+	sort := "precedence|asc"
+	limit := int64(500)
+	offset := int64(0)
+
+	var orderedIDs []string
+	for {
+		res, err := c.Filevantage.QueryPolicies(
+			&filevantage.QueryPoliciesParams{
+				Context: context.Background(),
+				Type:    platformName,
+				Sort:    &sort,
+				Limit:   &limit,
+				Offset:  &offset,
+			},
+		)
+		if err != nil {
+			t.Fatalf("failed to query filevantage policies: %s", err)
+		}
+
+		if res == nil || res.Payload == nil || len(res.Payload.Resources) == 0 {
+			break
+		}
+
+		orderedIDs = append(orderedIDs, res.Payload.Resources...)
+
+		if res.Payload.Meta == nil || res.Payload.Meta.Pagination == nil ||
+			res.Payload.Meta.Pagination.Offset == nil || res.Payload.Meta.Pagination.Total == nil {
+			offset += limit
+			continue
+		}
+
+		offset = int64(*res.Payload.Meta.Pagination.Offset) + int64(*res.Payload.Meta.Pagination.Limit)
+		if offset >= *res.Payload.Meta.Pagination.Total {
+			break
+		}
+	}
+
+	if len(orderedIDs) == 0 {
+		return nil
+	}
+
+	detailsRes, err := c.Filevantage.GetPolicies(
+		&filevantage.GetPoliciesParams{
+			Context: context.Background(),
+			Ids:     orderedIDs,
+		},
+	)
+	if err != nil {
+		t.Fatalf("failed to get filevantage policies: %s", err)
+	}
+
+	byID := make(map[string]struct {
+		cid  string
+		name string
+	}, len(orderedIDs))
+	if detailsRes != nil && detailsRes.Payload != nil {
+		for _, policy := range detailsRes.Payload.Resources {
+			if policy == nil || policy.ID == nil {
+				continue
+			}
+			cid := ""
+			if policy.Cid != nil {
+				cid = *policy.Cid
+			}
+			byID[*policy.ID] = struct {
+				cid  string
+				name string
+			}{cid: cid, name: policy.Name}
+		}
+	}
+
+	defaultName := fmt.Sprintf("Default Policy (%s)", platformName)
+	var ids []string
+	for _, id := range orderedIDs {
+		p, ok := byID[id]
+		if !ok {
+			continue
+		}
+		if p.name == defaultName {
+			continue
+		}
+		if !strings.EqualFold(p.cid, ownCID) {
+			continue
+		}
+		ids = append(ids, id)
+	}
+
+	return ids
+}
+
+func testAccFilevantagePolicyPrecedenceStrictConfig(platformName string, ids []string) string {
+	quoted := ""
+	for _, id := range ids {
+		quoted += fmt.Sprintf("    %q,\n", id)
+	}
+
+	return acctest.ProviderConfig + fmt.Sprintf(`
+resource "crowdstrike_filevantage_policy_precedence" "test" {
+  platform_name = %q
+  enforcement   = "strict"
+  ids = [
+%s  ]
+}
+`, platformName, quoted)
+}

--- a/internal/fim/filevantage_policy_precedence_cid_test.go
+++ b/internal/fim/filevantage_policy_precedence_cid_test.go
@@ -1,0 +1,168 @@
+package fim_test
+
+import (
+	"testing"
+
+	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/fim"
+)
+
+func TestFilterPoliciesByCID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		policies []fim.PolicyRef
+		cid      string
+		want     []string
+	}{
+		{
+			name: "keeps only matching cid preserving order",
+			policies: []fim.PolicyRef{
+				fim.NewPolicyRef("a", "010abf4b", ""),
+				fim.NewPolicyRef("b", "2436580c", ""),
+				fim.NewPolicyRef("c", "010abf4b", ""),
+			},
+			cid:  "010abf4b",
+			want: []string{"a", "c"},
+		},
+		{
+			name: "case insensitive cid match",
+			policies: []fim.PolicyRef{
+				fim.NewPolicyRef("a", "010ABF4B", ""),
+			},
+			cid:  "010abf4b",
+			want: []string{"a"},
+		},
+		{
+			name: "no matches returns empty",
+			policies: []fim.PolicyRef{
+				fim.NewPolicyRef("a", "2436580c", ""),
+			},
+			cid:  "010abf4b",
+			want: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := fim.FilterPoliciesByCID(tt.policies, tt.cid)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("got %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestDistinctCIDs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		policies []fim.PolicyRef
+		want     []string
+	}{
+		{
+			name: "single cid",
+			policies: []fim.PolicyRef{
+				fim.NewPolicyRef("a", "010abf4b", ""),
+				fim.NewPolicyRef("b", "010abf4b", ""),
+			},
+			want: []string{"010abf4b"},
+		},
+		{
+			name: "multiple distinct cids first-seen order",
+			policies: []fim.PolicyRef{
+				fim.NewPolicyRef("a", "2436580c", ""),
+				fim.NewPolicyRef("b", "010abf4b", ""),
+				fim.NewPolicyRef("c", "2436580c", ""),
+			},
+			want: []string{"2436580c", "010abf4b"},
+		},
+		{
+			name: "empty cids skipped",
+			policies: []fim.PolicyRef{
+				fim.NewPolicyRef("a", "", ""),
+				fim.NewPolicyRef("b", "010abf4b", ""),
+			},
+			want: []string{"010abf4b"},
+		},
+		{
+			name:     "no policies",
+			policies: []fim.PolicyRef{},
+			want:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := fim.DistinctCIDs(tt.policies)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("got %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestStripChecksum(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "uppercase ccid with checksum",
+			in:   "010ABF4B1BA04B7DA3F240A4C56657AC-C1",
+			want: "010abf4b1ba04b7da3f240a4c56657ac",
+		},
+		{
+			name: "no checksum suffix",
+			in:   "010ABF4B1BA04B7DA3F240A4C56657AC",
+			want: "010abf4b1ba04b7da3f240a4c56657ac",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := fim.StripChecksum(tt.in); got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultPolicyName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		platform string
+		want     string
+	}{
+		{platform: "Windows", want: "Default Policy (Windows)"},
+		{platform: "Linux", want: "Default Policy (Linux)"},
+		{platform: "Mac", want: "Default Policy (Mac)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.platform, func(t *testing.T) {
+			t.Parallel()
+			if got := fim.DefaultPolicyName(tt.platform); got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/fim/scopes.go
+++ b/internal/fim/scopes.go
@@ -17,3 +17,15 @@ var apiScopesReadWrite = []scopes.Scope{
 		Write: true,
 	},
 }
+
+var precedenceRequiredScopes = []scopes.Scope{
+	{
+		Name:  "Falcon FileVantage",
+		Read:  true,
+		Write: true,
+	},
+	{
+		Name: "Sensor Download",
+		Read: true,
+	},
+}


### PR DESCRIPTION
The precedence resource read all FileVantage policies sorted by precedence and assumed only the last policy was the default. In a Flight Control (MSSP) environment the combined endpoint returns policies from every visible CID interleaved, with one Default Policy (<platform>) per CID, so chopping the last element left extra defaults and cross-CID policies in state. The set-precedence API is strictly own-CID scoped and rejects cross-CID ids, so this caused perpetual drift and failed writes for parent and child CIDs.

Scope the read to the caller's own non-default policies: strip all Default Policy (<platform>) policies by name and keep only policies matching the authenticated CID. The CID is resolved via the sensor installers CCID endpoint, falling back to the policies' own CID when a single CID is present and erroring when multiple CIDs are ambiguous.

Requires the Sensor Download: Read scope to resolve the authenticated CID in Flight Control environments.

Fixes #437