### PR TITLE
fix(response_policy): scope precedence to caller CID in Flight Control

### DIFF
--- a/docs/resources/response_policy_precedence.md
+++ b/docs/resources/response_policy_precedence.md
@@ -3,20 +3,24 @@ page_title: "crowdstrike_response_policy_precedence Resource - crowdstrike"
 subcategory: "Host Setup and Management"
 description: |-
   This resource allows you set the precedence of Response Policies based on the order of IDs.
+  In a Flight Control (MSSP) environment the precedence API only manages the policies that belong to the CID authenticated by the provider. Policies belonging to other CIDs (parent or child) are returned by the API but cannot be reordered, so they are excluded automatically. Resolving the authenticated CID requires the Sensor Download: Read scope; without it, precedence can only be managed for tenants that are not part of a Flight Control hierarchy.
   API Scopes
   The following API scopes are required:
-  Response Policies | Read & Write
+  Response Policies | Read & WriteSensor Download | Read
 ---
 
 # crowdstrike_response_policy_precedence (Resource)
 
 This resource allows you set the precedence of Response Policies based on the order of IDs.
 
+In a Flight Control (MSSP) environment the precedence API only manages the policies that belong to the CID authenticated by the provider. Policies belonging to other CIDs (parent or child) are returned by the API but cannot be reordered, so they are excluded automatically. Resolving the authenticated CID requires the `Sensor Download: Read` scope; without it, precedence can only be managed for tenants that are not part of a Flight Control hierarchy.
+
 ## API Scopes
 
 The following API scopes are required:
 
 - Response Policies | Read & Write
+- Sensor Download | Read
 
 
 ## Example Usage

--- a/internal/response_policy/export_test.go
+++ b/internal/response_policy/export_test.go
@@ -1,0 +1,14 @@
+package responsepolicy
+
+type PolicyRef = policyRef
+
+var (
+	FilterPoliciesByCID = filterPoliciesByCID
+	DistinctCIDs        = distinctCIDs
+	StripChecksum       = stripChecksum
+)
+
+// NewPolicyRef builds a policyRef for tests in the external test package.
+func NewPolicyRef(id, cid, name string) policyRef {
+	return policyRef{id: id, cid: cid, name: name}
+}

--- a/internal/response_policy/response_policy_precedence.go
+++ b/internal/response_policy/response_policy_precedence.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/crowdstrike/gofalcon/falcon/client"
 	"github.com/crowdstrike/gofalcon/falcon/client/response_policies"
+	"github.com/crowdstrike/gofalcon/falcon/client/sensor_download"
 	"github.com/crowdstrike/gofalcon/falcon/models"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/config"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/scopes"
@@ -21,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
@@ -31,9 +33,12 @@ var (
 )
 
 var (
-	precedenceDocumentationSection string         = "Host Setup and Management"
-	precedenceMarkdownDescription  string         = "This resource allows you set the precedence of Response Policies based on the order of IDs."
-	precedenceRequiredScopes       []scopes.Scope = apiScopesReadWrite
+	precedenceDocumentationSection string = "Host Setup and Management"
+	precedenceMarkdownDescription  string = "This resource allows you set the precedence of Response Policies based on the order of IDs.\n\n" +
+		"In a Flight Control (MSSP) environment the precedence API only manages the policies that belong to the CID authenticated by the provider. " +
+		"Policies belonging to other CIDs (parent or child) are returned by the API but cannot be reordered, so they are excluded automatically. " +
+		"Resolving the authenticated CID requires the `Sensor Download: Read` scope; without it, precedence can only be managed for tenants that are not part of a Flight Control hierarchy."
+	precedenceRequiredScopes []scopes.Scope = precedenceAPIScopes
 
 	dynamicEnforcement = "dynamic"
 )
@@ -289,39 +294,178 @@ func (r *responsePolicyPrecedenceResource) Delete(
 ) {
 }
 
-// getResponsePoliciesByPrecedence returns response policy ids ordered by precedence excluding the default response policy.
+// defaultPolicyName is the name of the default response policy that exists in every CID.
+const defaultPolicyName = "platform_default"
+
+// policyRef holds the fields needed to scope precedence policies to the caller's CID.
+type policyRef struct {
+	id   string
+	cid  string
+	name string
+}
+
+// getResponsePoliciesByPrecedence returns response policy ids ordered by precedence,
+// scoped to the caller's own CID and excluding the default response policy.
+//
+// The combined response policy endpoint returns policies from every CID visible to the
+// caller (parent and children in a Flight Control hierarchy). The precedence API only
+// manages the caller's own-CID policies, so policies belonging to other CIDs and the
+// per-CID default policy are excluded here.
 func (r *responsePolicyPrecedenceResource) getResponsePoliciesByPrecedence(
 	ctx context.Context,
 	platformName string,
 ) ([]string, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	var policies []string
+	var refs []policyRef
 
 	caser := cases.Title(language.English)
 
 	filter := fmt.Sprintf("platform_name:'%s'", caser.String(platformName))
 	sort := "precedence.asc"
-	res, err := r.client.ResponsePolicies.QueryCombinedRTResponsePolicies(
-		&response_policies.QueryCombinedRTResponsePoliciesParams{
-			Context: ctx,
-			Filter:  &filter,
-			Sort:    &sort,
-		},
-	)
-	if err != nil {
-		diags.Append(tferrors.NewDiagnosticFromAPIError(tferrors.Read, err, apiScopesReadWrite))
-		return policies, diags
-	}
+	limit := int64(5000)
+	offset := int64(0)
 
-	if res != nil && res.Payload != nil {
-		for i, policy := range res.Payload.Resources {
-			if i != len(res.Payload.Resources)-1 {
-				policies = append(policies, *policy.ID)
+	for {
+		res, err := r.client.ResponsePolicies.QueryCombinedRTResponsePolicies(
+			&response_policies.QueryCombinedRTResponsePoliciesParams{
+				Context: ctx,
+				Filter:  &filter,
+				Sort:    &sort,
+				Limit:   &limit,
+				Offset:  &offset,
+			},
+		)
+		if err != nil {
+			diags.Append(tferrors.NewDiagnosticFromAPIError(tferrors.Read, err, precedenceAPIScopes))
+			return nil, diags
+		}
+
+		if res == nil || res.Payload == nil || len(res.Payload.Resources) == 0 {
+			break
+		}
+
+		for _, policy := range res.Payload.Resources {
+			if policy == nil || policy.ID == nil {
+				continue
 			}
+
+			ref := policyRef{id: *policy.ID}
+			if policy.Cid != nil {
+				ref.cid = *policy.Cid
+			}
+			if policy.Name != nil {
+				ref.name = *policy.Name
+			}
+			refs = append(refs, ref)
+		}
+
+		if res.Payload.Meta == nil || res.Payload.Meta.Pagination == nil ||
+			res.Payload.Meta.Pagination.Offset == nil || res.Payload.Meta.Pagination.Total == nil {
+
+			tflog.Warn(ctx, "Missing pagination metadata in API response, using offset+limit for next page",
+				map[string]interface{}{
+					"meta": res.Payload.Meta,
+				})
+			offset += limit
+			continue
+		}
+
+		offset = int64(*res.Payload.Meta.Pagination.Offset)
+		if offset >= *res.Payload.Meta.Pagination.Total {
+			break
 		}
 	}
 
-	return policies, diags
+	nonDefault := make([]policyRef, 0, len(refs))
+	for _, ref := range refs {
+		if ref.name == defaultPolicyName {
+			continue
+		}
+		nonDefault = append(nonDefault, ref)
+	}
+
+	distinct := distinctCIDs(nonDefault)
+	var ownCID string
+	switch len(distinct) {
+	case 0:
+		return []string{}, diags
+	case 1:
+		ownCID = distinct[0]
+	default:
+		cid, err := r.getCallerCID(ctx)
+		if err != nil {
+			tflog.Warn(ctx, "Could not resolve authenticated CID from the sensor installers CCID endpoint",
+				map[string]interface{}{
+					"error": err.Error(),
+				})
+			diags.AddError(
+				"Unable to determine the authenticated CID",
+				"Response policies from multiple CIDs were returned, which happens in a Flight Control (MSSP) environment. "+
+					"The provider could not determine which CID it is authenticated as to scope precedence correctly. "+
+					"Grant the `Sensor Download: Read` scope to the API client so the authenticated CID can be resolved.",
+			)
+			return nil, diags
+		}
+		ownCID = cid
+	}
+
+	return filterPoliciesByCID(nonDefault, ownCID), diags
+}
+
+// getCallerCID returns the CID authenticated by the provider, normalized to the
+// lowercase 32-character form used in policy responses. It reads the sensor installers
+// CCID endpoint, which requires the Sensor Download: Read scope.
+func (r *responsePolicyPrecedenceResource) getCallerCID(ctx context.Context) (string, error) {
+	res, err := r.client.SensorDownload.GetSensorInstallersCCIDByQuery(
+		sensor_download.NewGetSensorInstallersCCIDByQueryParamsWithContext(ctx),
+	)
+	if err != nil {
+		return "", err
+	}
+	if res == nil || res.Payload == nil || len(res.Payload.Resources) == 0 {
+		return "", fmt.Errorf("ccid query returned no data")
+	}
+
+	return stripChecksum(res.Payload.Resources[0]), nil
+}
+
+// filterPoliciesByCID returns the ids of policies belonging to cid, preserving order.
+func filterPoliciesByCID(policies []policyRef, cid string) []string {
+	ids := make([]string, 0, len(policies))
+	for _, p := range policies {
+		if strings.EqualFold(p.cid, cid) {
+			ids = append(ids, p.id)
+		}
+	}
+	return ids
+}
+
+// distinctCIDs returns the unique, non-empty CIDs across policies, preserving first-seen order.
+func distinctCIDs(policies []policyRef) []string {
+	seen := make(map[string]struct{}, len(policies))
+	var cids []string
+	for _, p := range policies {
+		if p.cid == "" {
+			continue
+		}
+		key := strings.ToLower(p.cid)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		cids = append(cids, key)
+	}
+	return cids
+}
+
+// stripChecksum normalizes a CCID (32-character CID plus a "-YY" checksum) to the
+// lowercase 32-character CID used in policy responses.
+func stripChecksum(ccid string) string {
+	idx := strings.LastIndex(ccid, "-")
+	if idx < 0 {
+		return strings.ToLower(ccid)
+	}
+	return strings.ToLower(ccid[:idx])
 }
 
 // generateDynamicPolicyOrder takes the dynamic managed policies and returns a slice of all policies in the correct order.

--- a/internal/response_policy/response_policy_precedence_test.go
+++ b/internal/response_policy/response_policy_precedence_test.go
@@ -1,0 +1,292 @@
+package responsepolicy_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/crowdstrike/gofalcon/falcon/client/response_policies"
+	"github.com/crowdstrike/gofalcon/falcon/client/sensor_download"
+	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/acctest"
+	responsepolicy "github.com/crowdstrike/terraform-provider-crowdstrike/internal/response_policy"
+	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/testconfig"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccResponsePolicyPrecedenceResource_strict(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("Acceptance tests skipped unless env 'TF_ACC' set")
+	}
+	acctest.PreCheck(t)
+
+	platformName := "Linux"
+	ids := getNonDefaultResponsePolicyIDs(t, platformName)
+	if len(ids) == 0 {
+		t.Skipf("no non-default %s response policies in tenant; nothing to test", platformName)
+	}
+
+	resourceName := "crowdstrike_response_policy_precedence.test"
+
+	idChecks := make([]knownvalue.Check, len(ids))
+	for i, id := range ids {
+		idChecks[i] = knownvalue.StringExact(id)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResponsePolicyPrecedenceStrictConfig(platformName, ids),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("ids"),
+						knownvalue.ListExact(idChecks),
+					),
+				},
+			},
+		},
+	})
+}
+
+// getNonDefaultResponsePolicyIDs returns every non-default response policy id
+// for a platform that belongs to the authenticated CID, ordered by precedence.asc.
+// It mirrors what the resource reads back so the strict test can assert against the
+// live tenant without hardcoding ids. In a Flight Control environment the combined
+// endpoint also returns other CIDs' policies and one platform_default per CID; those
+// are excluded here just as the resource does.
+func getNonDefaultResponsePolicyIDs(t *testing.T, platformName string) []string {
+	t.Helper()
+
+	c := testconfig.GetTestClient()
+	if c == nil {
+		t.Fatal("test client not initialized; PreCheck must run first")
+	}
+
+	ccidRes, err := c.SensorDownload.GetSensorInstallersCCIDByQuery(
+		sensor_download.NewGetSensorInstallersCCIDByQueryParamsWithContext(context.Background()),
+	)
+	if err != nil {
+		t.Fatalf("failed to query ccid: %s", err)
+	}
+	if ccidRes == nil || ccidRes.Payload == nil || len(ccidRes.Payload.Resources) == 0 {
+		t.Fatal("ccid query returned no data")
+	}
+	ownCID := ccidRes.Payload.Resources[0]
+	if idx := strings.LastIndex(ownCID, "-"); idx >= 0 {
+		ownCID = ownCID[:idx]
+	}
+	ownCID = strings.ToLower(ownCID)
+
+	filter := fmt.Sprintf("platform_name:'%s'", platformName)
+	sort := "precedence.asc"
+	limit := int64(5000)
+	offset := int64(0)
+
+	var ids []string
+	for {
+		res, err := c.ResponsePolicies.QueryCombinedRTResponsePolicies(
+			&response_policies.QueryCombinedRTResponsePoliciesParams{
+				Context: context.Background(),
+				Filter:  &filter,
+				Sort:    &sort,
+				Limit:   &limit,
+				Offset:  &offset,
+			},
+		)
+		if err != nil {
+			t.Fatalf("failed to query response policies: %s", err)
+		}
+
+		if res == nil || res.Payload == nil || len(res.Payload.Resources) == 0 {
+			break
+		}
+
+		for _, policy := range res.Payload.Resources {
+			if policy == nil || policy.ID == nil {
+				continue
+			}
+			if policy.Name != nil && *policy.Name == "platform_default" {
+				continue
+			}
+			if policy.Cid == nil || !strings.EqualFold(*policy.Cid, ownCID) {
+				continue
+			}
+			ids = append(ids, *policy.ID)
+		}
+
+		if res.Payload.Meta == nil || res.Payload.Meta.Pagination == nil ||
+			res.Payload.Meta.Pagination.Offset == nil || res.Payload.Meta.Pagination.Total == nil {
+			offset += limit
+			continue
+		}
+
+		offset = int64(*res.Payload.Meta.Pagination.Offset)
+		if offset >= *res.Payload.Meta.Pagination.Total {
+			break
+		}
+	}
+
+	return ids
+}
+
+func testAccResponsePolicyPrecedenceStrictConfig(platformName string, ids []string) string {
+	quoted := ""
+	for _, id := range ids {
+		quoted += fmt.Sprintf("    %q,\n", id)
+	}
+
+	return acctest.ProviderConfig + fmt.Sprintf(`
+resource "crowdstrike_response_policy_precedence" "test" {
+  platform_name = %q
+  enforcement   = "strict"
+  ids = [
+%s  ]
+}
+`, platformName, quoted)
+}
+
+func TestFilterPoliciesByCID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		policies []responsepolicy.PolicyRef
+		cid      string
+		want     []string
+	}{
+		{
+			name: "keeps only matching cid preserving order",
+			policies: []responsepolicy.PolicyRef{
+				responsepolicy.NewPolicyRef("a", "010abf4b", ""),
+				responsepolicy.NewPolicyRef("b", "2436580c", ""),
+				responsepolicy.NewPolicyRef("c", "010abf4b", ""),
+			},
+			cid:  "010abf4b",
+			want: []string{"a", "c"},
+		},
+		{
+			name: "case insensitive cid match",
+			policies: []responsepolicy.PolicyRef{
+				responsepolicy.NewPolicyRef("a", "010ABF4B", ""),
+			},
+			cid:  "010abf4b",
+			want: []string{"a"},
+		},
+		{
+			name: "no matches returns empty",
+			policies: []responsepolicy.PolicyRef{
+				responsepolicy.NewPolicyRef("a", "2436580c", ""),
+			},
+			cid:  "010abf4b",
+			want: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := responsepolicy.FilterPoliciesByCID(tt.policies, tt.cid)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("got %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestDistinctCIDs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		policies []responsepolicy.PolicyRef
+		want     []string
+	}{
+		{
+			name: "single cid",
+			policies: []responsepolicy.PolicyRef{
+				responsepolicy.NewPolicyRef("a", "010abf4b", ""),
+				responsepolicy.NewPolicyRef("b", "010abf4b", ""),
+			},
+			want: []string{"010abf4b"},
+		},
+		{
+			name: "multiple distinct cids first-seen order",
+			policies: []responsepolicy.PolicyRef{
+				responsepolicy.NewPolicyRef("a", "2436580c", ""),
+				responsepolicy.NewPolicyRef("b", "010abf4b", ""),
+				responsepolicy.NewPolicyRef("c", "2436580c", ""),
+			},
+			want: []string{"2436580c", "010abf4b"},
+		},
+		{
+			name: "empty cids skipped",
+			policies: []responsepolicy.PolicyRef{
+				responsepolicy.NewPolicyRef("a", "", ""),
+				responsepolicy.NewPolicyRef("b", "010abf4b", ""),
+			},
+			want: []string{"010abf4b"},
+		},
+		{
+			name:     "no policies",
+			policies: []responsepolicy.PolicyRef{},
+			want:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := responsepolicy.DistinctCIDs(tt.policies)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("got %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestStripChecksum(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "uppercase ccid with checksum",
+			in:   "010ABF4B1BA04B7DA3F240A4C56657AC-C1",
+			want: "010abf4b1ba04b7da3f240a4c56657ac",
+		},
+		{
+			name: "no checksum suffix",
+			in:   "010ABF4B1BA04B7DA3F240A4C56657AC",
+			want: "010abf4b1ba04b7da3f240a4c56657ac",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := responsepolicy.StripChecksum(tt.in); got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/response_policy/response_policy_precedence_test.go
+++ b/internal/response_policy/response_policy_precedence_test.go
@@ -24,35 +24,38 @@ func TestAccResponsePolicyPrecedenceResource_strict(t *testing.T) {
 	}
 	acctest.PreCheck(t)
 
-	platformName := "Linux"
-	ids := getNonDefaultResponsePolicyIDs(t, platformName)
-	if len(ids) == 0 {
-		t.Skipf("no non-default %s response policies in tenant; nothing to test", platformName)
-	}
-
 	resourceName := "crowdstrike_response_policy_precedence.test"
 
-	idChecks := make([]knownvalue.Check, len(ids))
-	for i, id := range ids {
-		idChecks[i] = knownvalue.StringExact(id)
-	}
+	for _, platformName := range []string{"Windows", "Linux", "Mac"} {
+		t.Run(platformName, func(t *testing.T) {
+			ids := getNonDefaultResponsePolicyIDs(t, platformName)
+			if len(ids) == 0 {
+				t.Skipf("no non-default %s response policies in tenant; nothing to test", platformName)
+			}
 
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		Steps: []resource.TestStep{
-			{
-				Config: testAccResponsePolicyPrecedenceStrictConfig(platformName, ids),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(
-						resourceName,
-						tfjsonpath.New("ids"),
-						knownvalue.ListExact(idChecks),
-					),
+			idChecks := make([]knownvalue.Check, len(ids))
+			for i, id := range ids {
+				idChecks[i] = knownvalue.StringExact(id)
+			}
+
+			resource.Test(t, resource.TestCase{
+				ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+				PreCheck:                 func() { acctest.PreCheck(t) },
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResponsePolicyPrecedenceStrictConfig(platformName, ids),
+						ConfigStateChecks: []statecheck.StateCheck{
+							statecheck.ExpectKnownValue(
+								resourceName,
+								tfjsonpath.New("ids"),
+								knownvalue.ListExact(idChecks),
+							),
+						},
+					},
 				},
-			},
-		},
-	})
+			})
+		})
+	}
 }
 
 // getNonDefaultResponsePolicyIDs returns every non-default response policy id

--- a/internal/response_policy/scopes.go
+++ b/internal/response_policy/scopes.go
@@ -9,3 +9,15 @@ var apiScopesReadWrite = []scopes.Scope{
 		Write: true,
 	},
 }
+
+var precedenceAPIScopes = []scopes.Scope{
+	{
+		Name:  "Response Policies",
+		Read:  true,
+		Write: true,
+	},
+	{
+		Name: "Sensor Download",
+		Read: true,
+	},
+}


### PR DESCRIPTION
The precedence resource read all response policies sorted by precedence and assumed only the last policy was the default. In a Flight Control (MSSP) environment the combined endpoint returns policies from every visible CID interleaved, with one platform_default per CID, so chopping the last element left extra defaults and cross-CID policies in state. The set-precedence API is strictly own-CID scoped and rejects cross-CID ids, so this caused perpetual drift and failed writes for parent and child CIDs.

Scope the read to the caller's own non-default policies: strip all platform_default policies by name and keep only policies matching the authenticated CID. The CID is resolved via the sensor installers CCID endpoint, falling back to the policies' own CID when a single CID is present and erroring when multiple CIDs are ambiguous.

Requires the Sensor Download: Read scope to resolve the authenticated CID in Flight Control environments.

Fixes #439
