### PR TITLE
fix(container_registry): defer acr credential validation on unknown values

### DIFF
--- a/internal/container_registry/container_registry_resource.go
+++ b/internal/container_registry/container_registry_resource.go
@@ -682,6 +682,13 @@ func (r *containerRegistryResource) ValidateConfig(
 		requireObjectField(&resp.Diagnostics, credPath.AtName("service_account_json"), cred.ServiceAccountJSON, "service_account_json", registryType)
 		validateServiceAccountJSON(ctx, &resp.Diagnostics, credPath.AtName("service_account_json"), cred.ServiceAccountJSON, registryType)
 	case "acr":
+		// cert and password select the auth method. Skip validation until both
+		// are known: a value derived from another resource is unknown here and
+		// may still resolve to null, so we cannot yet tell which method was
+		// chosen without risking a false error.
+		if cred.Cert.IsUnknown() || cred.Password.IsUnknown() {
+			break
+		}
 		hasCert := utils.IsKnown(cred.Cert)
 		hasPassword := utils.IsKnown(cred.Password)
 		switch {

--- a/internal/container_registry/container_registry_resource_test.go
+++ b/internal/container_registry/container_registry_resource_test.go
@@ -112,6 +112,10 @@ func TestAccContainerRegistryResource_ValidateConfig(t *testing.T) {
 	testCases := map[string]struct {
 		config      string
 		expectError *regexp.Regexp
+		// nonEmptyPlan is set for success-path cases that create resources, so
+		// a PlanOnly step produces a non-empty (create) plan rather than an
+		// error.
+		nonEmptyPlan bool
 	}{
 		"dockerhub_missing_password": {
 			config: acctest.ProviderConfig + `
@@ -244,6 +248,71 @@ resource "crowdstrike_container_registry" "test" {
 `,
 			expectError: regexp.MustCompile(`username is required for acr registry type`),
 		},
+		// Regression for #418: a password derived from another resource is
+		// unknown at plan time. acr validation must not fire while cert or
+		// password is unknown, so this config plans without a false "Invalid
+		// Credential for acr" error.
+		"acr_password_derived_value": {
+			config: acctest.ProviderConfig + `
+resource "terraform_data" "pw" {
+  input = "supersecret"
+}
+resource "crowdstrike_container_registry" "test" {
+  url  = "https://myregistry.azurecr.io/"
+  type = "acr"
+  credential = {
+    username = "u"
+    password = terraform_data.pw.id
+  }
+}
+`,
+			expectError:  nil,
+			nonEmptyPlan: true,
+		},
+		// Regression for #418: a derived cert (the method discriminator) must
+		// not trigger a false error while unknown.
+		"acr_cert_derived_value": {
+			config: acctest.ProviderConfig + `
+resource "terraform_data" "cert" {
+  input = "MIIBASE64=="
+}
+resource "crowdstrike_container_registry" "test" {
+  url  = "https://myregistry.azurecr.io/"
+  type = "acr"
+  credential = {
+    cert      = terraform_data.cert.id
+    auth_type = "cert"
+    tenant_id = "tid"
+    client    = "cid"
+  }
+}
+`,
+			expectError:  nil,
+			nonEmptyPlan: true,
+		},
+		// A required cert-auth sub-field (tenant_id) derived from another
+		// resource is unknown at plan time. Validation must not report it as
+		// missing while unknown; the error may only fire once the value is
+		// known and actually absent.
+		"acr_cert_derived_subfield": {
+			config: acctest.ProviderConfig + `
+resource "terraform_data" "tenant" {
+  input = "tid"
+}
+resource "crowdstrike_container_registry" "test" {
+  url  = "https://myregistry.azurecr.io/"
+  type = "acr"
+  credential = {
+    cert      = "MIIBASE64=="
+    auth_type = "cert"
+    tenant_id = terraform_data.tenant.id
+    client    = "cid"
+  }
+}
+`,
+			expectError:  nil,
+			nonEmptyPlan: true,
+		},
 		"oracle_missing_password": {
 			config: acctest.ProviderConfig + `
 resource "crowdstrike_container_registry" "test" {
@@ -278,9 +347,10 @@ resource "crowdstrike_container_registry" "test" {
 				ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 				Steps: []resource.TestStep{
 					{
-						Config:      tc.config,
-						PlanOnly:    true,
-						ExpectError: tc.expectError,
+						Config:             tc.config,
+						PlanOnly:           true,
+						ExpectError:        tc.expectError,
+						ExpectNonEmptyPlan: tc.nonEmptyPlan,
 					},
 				},
 			})


### PR DESCRIPTION
acr config validation branched on cert/password using utils.IsKnown, which treats an unknown value the same as absent. A credential derived from another resource (e.g. password = random_string.result) is unknown during ValidateConfig, so the switch fell through to the default case and raised a false "Invalid Credential for acr" error even when username + password were supplied. Hard-coded values are known and validated fine.

Skip the acr auth-method checks while cert or password is unknown: such a value may still resolve to null at apply time, so the chosen auth method cannot be determined without risking a false error. Once both are known, validation runs unchanged; the API validates the deferred cases on create.

Fixes #418