### PR TITLE
fix(ioa_rule_group): resolve rule type by name on read

### DIFF
--- a/internal/ioa_rule_group/ioa_rule_group_resource.go
+++ b/internal/ioa_rule_group/ioa_rule_group_resource.go
@@ -47,14 +47,6 @@ func invertMap[K, V comparable](m map[K]V) map[V]K {
 	return inv
 }
 
-func invertNestedMap[K, V comparable](m map[K]map[V]K) map[K]map[K]V {
-	inv := make(map[K]map[K]V, len(m))
-	for outerKey, inner := range m {
-		inv[outerKey] = invertMap(inner)
-	}
-	return inv
-}
-
 var apiScopesReadWrite = []scopes.Scope{
 	{
 		Name:  "Custom IOA Rules",
@@ -83,8 +75,6 @@ var ruleTypeIDMap = map[string]map[string]string{
 		"Domain Name":        "16",
 	},
 }
-
-var ruleTypeNameMap = invertNestedMap(ruleTypeIDMap)
 
 var dispositionMap = map[string]int32{
 	"Monitor":      10,
@@ -560,7 +550,6 @@ type trackedRule struct {
 func (m *ioaRuleGroupResourceModel) wrap(
 	ctx context.Context,
 	group *models.APIRuleGroupV1,
-	platform string,
 	trackedRules []trackedRule,
 ) diag.Diagnostics {
 	var diags diag.Diagnostics
@@ -588,7 +577,7 @@ func (m *ioaRuleGroupResourceModel) wrap(
 		m.CommittedOn = types.StringValue(group.CommittedOn.String())
 	}
 
-	rules, d := wrapRules(ctx, group.Rules, platform, trackedRules)
+	rules, d := wrapRules(ctx, group.Rules, trackedRules)
 	diags.Append(d...)
 	if diags.HasError() {
 		return diags
@@ -601,7 +590,6 @@ func (m *ioaRuleGroupResourceModel) wrap(
 func wrapRules(
 	ctx context.Context,
 	apiRules []*models.APIRuleV1,
-	platform string,
 	trackedRules []trackedRule,
 ) (types.List, diag.Diagnostics) {
 	var diags diag.Diagnostics
@@ -633,18 +621,8 @@ func wrapRules(
 		}
 
 		ruleTypeName := ""
-		if apiRule.RuletypeID != nil {
-			if nameMap, ok := ruleTypeNameMap[platform]; ok {
-				if name, found := nameMap[*apiRule.RuletypeID]; found {
-					ruleTypeName = name
-				} else {
-					diags.AddError(
-						"Unknown rule type ID",
-						fmt.Sprintf("Rule type ID %q for platform %q is not recognized by this provider version.", *apiRule.RuletypeID, platform),
-					)
-					return types.ListNull(types.ObjectType{AttrTypes: ruleAttrTypes}), diags
-				}
-			}
+		if apiRule.RuletypeName != nil {
+			ruleTypeName = *apiRule.RuletypeName
 		}
 
 		actionName := ""
@@ -1050,7 +1028,7 @@ func (r *ioaRuleGroupResource) Create(
 		return
 	}
 
-	resp.Diagnostics.Append(plan.wrap(ctx, group, plan.Platform.ValueString(), trackedRules)...)
+	resp.Diagnostics.Append(plan.wrap(ctx, group, trackedRules)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 
@@ -1087,12 +1065,7 @@ func (r *ioaRuleGroupResource) Read(
 		return
 	}
 
-	platform := ""
-	if group.Platform != nil {
-		platform = normalizePlatform(*group.Platform)
-	}
-
-	resp.Diagnostics.Append(state.wrap(ctx, group, platform, trackedRules)...)
+	resp.Diagnostics.Append(state.wrap(ctx, group, trackedRules)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -1246,7 +1219,7 @@ func (r *ioaRuleGroupResource) Update(
 		return
 	}
 
-	resp.Diagnostics.Append(plan.wrap(ctx, group, platform, trackedRules)...)
+	resp.Diagnostics.Append(plan.wrap(ctx, group, trackedRules)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 

--- a/internal/ioa_rule_group/ioa_rule_group_test.go
+++ b/internal/ioa_rule_group/ioa_rule_group_test.go
@@ -9,6 +9,83 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestWrapRulesResolvesTypeByName(t *testing.T) {
+	tests := []struct {
+		name         string
+		apiRules     []*models.APIRuleV1
+		expectedType map[string]string
+	}{
+		{
+			name: "canonical windows ids",
+			apiRules: []*models.APIRuleV1{
+				{
+					InstanceID:   utils.Addr("rule-1"),
+					Name:         utils.Addr("Proc"),
+					Description:  utils.Addr("d"),
+					RuletypeID:   utils.Addr("1"),
+					RuletypeName: utils.Addr("Process Creation"),
+				},
+			},
+			expectedType: map[string]string{"rule-1": "Process Creation"},
+		},
+		{
+			name: "legacy mac-range id in windows group resolves by name",
+			apiRules: []*models.APIRuleV1{
+				{
+					InstanceID:   utils.Addr("rule-1"),
+					Name:         utils.Addr("Proc"),
+					Description:  utils.Addr("d"),
+					RuletypeID:   utils.Addr("5"),
+					RuletypeName: utils.Addr("Process Creation"),
+				},
+			},
+			expectedType: map[string]string{"rule-1": "Process Creation"},
+		},
+		{
+			name: "id absent from current catalog resolves by name",
+			apiRules: []*models.APIRuleV1{
+				{
+					InstanceID:   utils.Addr("rule-1"),
+					Name:         utils.Addr("Net"),
+					Description:  utils.Addr("d"),
+					RuletypeID:   utils.Addr("3"),
+					RuletypeName: utils.Addr("Network Connection"),
+				},
+			},
+			expectedType: map[string]string{"rule-1": "Network Connection"},
+		},
+		{
+			name: "missing ruletype name yields empty type",
+			apiRules: []*models.APIRuleV1{
+				{
+					InstanceID:  utils.Addr("rule-1"),
+					Name:        utils.Addr("Proc"),
+					Description: utils.Addr("d"),
+					RuletypeID:  utils.Addr("1"),
+				},
+			},
+			expectedType: map[string]string{"rule-1": ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			list, diags := wrapRules(t.Context(), tt.apiRules, nil)
+			assert.False(t, diags.HasError())
+
+			rules := utils.ListTypeAs[ioaRuleModel](t.Context(), list, &diags)
+			assert.False(t, diags.HasError())
+			assert.Len(t, rules, len(tt.expectedType))
+
+			for _, r := range rules {
+				want, ok := tt.expectedType[r.InstanceID.ValueString()]
+				assert.True(t, ok, "unexpected instance id %q", r.InstanceID.ValueString())
+				assert.Equal(t, want, r.Type.ValueString())
+			}
+		})
+	}
+}
+
 func TestConvertIOARuleGroupsToIDs(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
The read path mapped the API's numeric ruletype_id back to a friendly type string by inverting a platform-keyed name->id map. This failed with "Unknown rule type ID" whenever Falcon returned an id the map didn't know for that platform, breaking plan/import/refresh on legacy or externally created rules (e.g. a Windows group carrying ruletype_id 5 or 3).

APIRuleV1 always returns ruletype_name alongside ruletype_id, so read now uses that value directly and resolves any id in one shot. The write path is unchanged: createRule still maps name to canonical id via ruleTypeIDMap, and updateRule never sends the ruletype field.

Drop the now-dead platform parameter from wrap/wrapRules and remove the unused ruleTypeNameMap and invertNestedMap helper.

Closes #400
