### PR TITLE
fix(docs): correct terraform import commands in default_prevention_po…

### DIFF
--- a/docs/resources/default_prevention_policy_linux.md
+++ b/docs/resources/default_prevention_policy_linux.md
@@ -144,6 +144,6 @@ Required:
 Import is supported using the following syntax:
 
 ```shell
-# The mac default prevention policy can be imported by specifying the id.
+# The linux default prevention policy can be imported by specifying the id.
 terraform import crowdstrike_default_prevention_policy_linux.default 7fb858a949034a0cbca175f660f1e769
 ```

--- a/docs/resources/default_prevention_policy_linux.md
+++ b/docs/resources/default_prevention_policy_linux.md
@@ -145,5 +145,5 @@ Import is supported using the following syntax:
 
 ```shell
 # The mac default prevention policy can be imported by specifying the id.
-terraform import crowdstrike_default_prevention_policy_mac.default 7fb858a949034a0cbca175f660f1e769
+terraform import crowdstrike_default_prevention_policy_linux.default 7fb858a949034a0cbca175f660f1e769
 ```

--- a/docs/resources/default_prevention_policy_mac.md
+++ b/docs/resources/default_prevention_policy_mac.md
@@ -158,5 +158,5 @@ Import is supported using the following syntax:
 
 ```shell
 # The windows default prevention policy can be imported by specifying the id.
-terraform import crowdstrike_default_prevention_policy_windows.default 7fb858a949034a0cbca175f660f1e769
+terraform import crowdstrike_default_prevention_policy_mac.default 7fb858a949034a0cbca175f660f1e769
 ```

--- a/docs/resources/default_prevention_policy_mac.md
+++ b/docs/resources/default_prevention_policy_mac.md
@@ -157,6 +157,6 @@ Required:
 Import is supported using the following syntax:
 
 ```shell
-# The windows default prevention policy can be imported by specifying the id.
+# The mac default prevention policy can be imported by specifying the id.
 terraform import crowdstrike_default_prevention_policy_mac.default 7fb858a949034a0cbca175f660f1e769
 ```

--- a/docs/resources/default_prevention_policy_windows.md
+++ b/docs/resources/default_prevention_policy_windows.md
@@ -295,6 +295,6 @@ Required:
 Import is supported using the following syntax:
 
 ```shell
-# The linux default prevention policy can be imported by specifying the id.
+# The windows default prevention policy can be imported by specifying the id.
 terraform import crowdstrike_default_prevention_policy_windows.default 7fb858a949034a0cbca175f660f1e769
 ```

--- a/docs/resources/default_prevention_policy_windows.md
+++ b/docs/resources/default_prevention_policy_windows.md
@@ -296,5 +296,5 @@ Import is supported using the following syntax:
 
 ```shell
 # The linux default prevention policy can be imported by specifying the id.
-terraform import crowdstrike_default_prevention_policy_linux.default 7fb858a949034a0cbca175f660f1e769
+terraform import crowdstrike_default_prevention_policy_windows.default 7fb858a949034a0cbca175f660f1e769
 ```


### PR DESCRIPTION
Correct `terraform import` commands in:

default_prevention_policy_linux.md
default_prevention_policy_mac.md
default_prevention_policy_windows.md

At the moment the commands are incorrect, e.g under Linux the command is using `mac's` resource, etc.

```
# The mac default prevention policy can be imported by specifying the id.
terraform import crowdstrike_default_prevention_policy_mac.default 7fb858a949034a0cbca175f660f1e769
```