### PR TITLE
fix(docs): correct terraform import commands in default_prevention_policy import scripts

### DIFF
--- a/examples/resources/crowdstrike_default_prevention_policy_linux/import.sh
+++ b/examples/resources/crowdstrike_default_prevention_policy_linux/import.sh
@@ -1,2 +1,2 @@
-# The mac default prevention policy can be imported by specifying the id.
-terraform import crowdstrike_default_prevention_policy_mac.default 7fb858a949034a0cbca175f660f1e769
+# The linux default prevention policy can be imported by specifying the id.
+terraform import crowdstrike_default_prevention_policy_linux.default 7fb858a949034a0cbca175f660f1e769

--- a/examples/resources/crowdstrike_default_prevention_policy_mac/import.sh
+++ b/examples/resources/crowdstrike_default_prevention_policy_mac/import.sh
@@ -1,2 +1,2 @@
-# The windows default prevention policy can be imported by specifying the id.
-terraform import crowdstrike_default_prevention_policy_windows.default 7fb858a949034a0cbca175f660f1e769
+# The mac default prevention policy can be imported by specifying the id.
+terraform import crowdstrike_default_prevention_policy_mac.default 7fb858a949034a0cbca175f660f1e769

--- a/examples/resources/crowdstrike_default_prevention_policy_windows/import.sh
+++ b/examples/resources/crowdstrike_default_prevention_policy_windows/import.sh
@@ -1,2 +1,2 @@
-# The linux default prevention policy can be imported by specifying the id.
-terraform import crowdstrike_default_prevention_policy_linux.default 7fb858a949034a0cbca175f660f1e769
+# The windows default prevention policy can be imported by specifying the id.
+terraform import crowdstrike_default_prevention_policy_windows.default 7fb858a949034a0cbca175f660f1e769


### PR DESCRIPTION
The generated docs for the linux, mac, and windows default prevention policies had correct terraform import commands, but the source import.sh scripts they are generated from still referenced the wrong OS resource.

Update the three source scripts so each references its own OS resource, ensuring future doc regeneration with `make gen` keeps the import commands correct:

- crowdstrike_default_prevention_policy_linux: mac -> linux
- crowdstrike_default_prevention_policy_mac: windows -> mac
- crowdstrike_default_prevention_policy_windows: linux -> windows