### PR TITLE
fix(response_policy_precedence): fix case insensitivity

### DIFF
--- a/internal/response_policy/response_policy_precedence.go
+++ b/internal/response_policy/response_policy_precedence.go
@@ -141,7 +141,7 @@ func (r *responsePolicyPrecedenceResource) Schema(
 				Required:    true,
 				Description: "The platform of the response policies. One of: Windows, Mac, Linux",
 				Validators: []validator.String{
-					stringvalidator.OneOf("Windows", "Linux", "Mac"),
+					stringvalidator.OneOfCaseInsensitive("Windows", "Linux", "Mac"),
 				},
 			},
 			"last_updated": schema.StringAttribute{


### PR DESCRIPTION
Currently the `platform_name` in crowdstrike_response_policy_precedence is case sensitive causing the terraform plan to fail if one uses the example code provided. eg (https://registry.terraform.io/providers/CrowdStrike/crowdstrike/latest/docs/resources/response_policy_precedence).

```
...
platform_name = "linux"
...
```

Terraform throws this error if lower case is used:

```
╷
│ Error: Invalid Attribute Value Match
│ 
│   with crowdstrike_response_policy_precedence.response_policy_precedence,
│   on response_policies.tf line 42, in resource "crowdstrike_response_policy_precedence" "response_policy_precedence":
│   42:   platform_name = "linux"
│ 
│ Attribute platform_name value must be one of: ["Windows" "Linux" "Mac"], got: "linux"
```