### PR TITLE
docs(provider): clarify cloud attribute autodiscover limitation for gov clouds

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,6 @@ provider "crowdstrike" {
 
 - `client_id` (String, Sensitive) Falcon Client Id for authenticating to the CrowdStrike APIs. Will use FALCON_CLIENT_ID environment variable when left blank.
 - `client_secret` (String, Sensitive) Falcon Client Secret used for authenticating to the CrowdStrike APIs. Will use FALCON_CLIENT_SECRET environment variable when left blank.
-- `cloud` (String) Falcon Cloud to authenticate to. Valid values are autodiscover, us-1, us-2, us-3, eu-1, us-gov-1, us-gov-2. Will use FALCON_CLOUD environment variable when left blank.
+- `cloud` (String) Falcon Cloud to authenticate to. Valid values are `autodiscover`, `us-1`, `us-2`, `us-3`, `eu-1`, `us-gov-1`, `us-gov-2`. Defaults to the `FALCON_CLOUD` environment variable when left blank. GovCloud regions (`us-gov-1`, `us-gov-2`) do not support `autodiscover`, so this value must be set explicitly (either here or via `FALCON_CLOUD`) when authenticating to those clouds.
 - `host_override` (String) Override the host used when communicating with the CrowdStrike APIs. Will use HOST_OVERRIDE environment variable when left blank. This is primarily used for testing and should not be set in normal usage.
 - `member_cid` (String) For MSSP Master CIDs, optionally lock the token to act on behalf of this member CID

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -112,7 +112,7 @@ func (p *CrowdStrikeProvider) Schema(
 				Optional:            true,
 			},
 			"cloud": schema.StringAttribute{
-				MarkdownDescription: "Falcon Cloud to authenticate to. Valid values are autodiscover, us-1, us-2, us-3, eu-1, us-gov-1, us-gov-2. Will use FALCON_CLOUD environment variable when left blank.",
+				MarkdownDescription: "Falcon Cloud to authenticate to. Valid values are `autodiscover`, `us-1`, `us-2`, `us-3`, `eu-1`, `us-gov-1`, `us-gov-2`. Defaults to the `FALCON_CLOUD` environment variable when left blank. GovCloud regions (`us-gov-1`, `us-gov-2`) do not support `autodiscover`, so this value must be set explicitly (either here or via `FALCON_CLOUD`) when authenticating to those clouds.",
 				Optional:            true,
 				Validators: []validator.String{
 					stringvalidator.OneOfCaseInsensitive(


### PR DESCRIPTION
Note that GovCloud regions (us-gov-1, us-gov-2) do not support the autodiscover value, so the cloud attribute must be set explicitly (either in configuration or via FALCON_CLOUD) when authenticating to those clouds. Also backtick the valid values for cleaner rendering. Regenerate docs.