### PR TITLE
refactor(user_management): move user_roles data source into user package

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -40,7 +40,6 @@ import (
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/testconfig"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/user"
 	usergroup "github.com/crowdstrike/terraform-provider-crowdstrike/internal/user_group"
-	userroles "github.com/crowdstrike/terraform-provider-crowdstrike/internal/user_roles"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/function"
@@ -392,7 +391,7 @@ func (p *CrowdStrikeProvider) DataSources(ctx context.Context) []func() datasour
 		correlationrules.NewCorrelationRulesDataSource,
 		ngsiem.NewDataConnectorDataSource,
 		ngsiem.NewDataConnectorsDataSource,
-		userroles.NewUserRolesDataSource,
+		user.NewUserRolesDataSource,
 	}
 }
 

--- a/internal/user/user_roles_data_source.go
+++ b/internal/user/user_roles_data_source.go
@@ -1,4 +1,4 @@
-package userroles
+package user
 
 import (
 	"context"
@@ -34,9 +34,8 @@ var (
 const entitiesRolesBatchSize = 5000
 
 var (
-	documentationSection          = "User Management"
 	dataSourceMarkdownDescription = "Lists the Falcon user roles available for a customer (CID), including default and custom roles with their display name, description, scope, and type."
-	requiredScopes                = []scopes.Scope{
+	dataSourceRequiredScopes      = []scopes.Scope{
 		{Name: "User Management", Read: true},
 	}
 )
@@ -115,7 +114,7 @@ func (d *userRolesDataSource) Schema(
 	resp *datasource.SchemaResponse,
 ) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: utils.MarkdownDescription(documentationSection, dataSourceMarkdownDescription, requiredScopes),
+		MarkdownDescription: utils.MarkdownDescription(documentationSection, dataSourceMarkdownDescription, dataSourceRequiredScopes),
 		Attributes: map[string]schema.Attribute{
 			"user_uuid": schema.StringAttribute{
 				Optional:            true,
@@ -247,7 +246,7 @@ func (d *userRolesDataSource) queryRoleIDs(
 
 	res, err := d.client.UserManagement.QueriesRolesV1(params)
 	if err != nil {
-		diags.Append(tferrors.NewDiagnosticFromAPIError(tferrors.Read, err, requiredScopes))
+		diags.Append(tferrors.NewDiagnosticFromAPIError(tferrors.Read, err, dataSourceRequiredScopes))
 		return nil, diags
 	}
 
@@ -292,7 +291,7 @@ func (d *userRolesDataSource) getRoles(
 
 		res, err := d.client.UserManagement.EntitiesRolesGETV2(params)
 		if err != nil {
-			diags.Append(tferrors.NewDiagnosticFromAPIError(tferrors.Read, err, requiredScopes))
+			diags.Append(tferrors.NewDiagnosticFromAPIError(tferrors.Read, err, dataSourceRequiredScopes))
 			return nil, diags
 		}
 

--- a/internal/user/user_roles_data_source_test.go
+++ b/internal/user/user_roles_data_source_test.go
@@ -1,4 +1,4 @@
-package userroles_test
+package user_test
 
 import (
 	"regexp"


### PR DESCRIPTION
The user_roles data source added in #454 lived in its own internal/user_roles/ package. Move it into internal/user/ alongside the other user resources so all user-related code shares one package.

Resolve package-level symbol collisions with the existing user package: drop the duplicate documentationSection constant and rename the data source's requiredScopes to dataSourceRequiredScopes. Update the provider registration to reference user.NewUserRolesDataSource.

No behavior change: the crowdstrike_user_roles data source type name and schema are unchanged.