### PR TITLE
fix: clear default request timeout in ml exclusion update params

### DIFF
--- a/internal/ml_certificate_exclusion/ml_certificate_exclusion.go
+++ b/internal/ml_certificate_exclusion/ml_certificate_exclusion.go
@@ -655,6 +655,12 @@ type certExclusionsUpdateParams struct {
 }
 
 func (p *certExclusionsUpdateParams) WriteToRequest(r runtime.ClientRequest, _ strfmt.Registry) error {
+	// Generated params clear the per-request timeout via SetTimeout; without it
+	// the request is capped at go-openapi's 30s DefaultTimeout, which updates
+	// with large host_groups lists can exceed.
+	if err := r.SetTimeout(0); err != nil {
+		return err
+	}
 	if p.Body == nil {
 		return nil
 	}

--- a/internal/ml_certificate_exclusion/ml_certificate_exclusion_test.go
+++ b/internal/ml_certificate_exclusion/ml_certificate_exclusion_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/crowdstrike/gofalcon/falcon/models"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/utils"
+	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -149,5 +150,38 @@ func TestWrapPreservesOptionalNullsAndFlattensCertificate(t *testing.T) {
 	}
 	if !gotTo.Equal(wantTo) {
 		t.Fatalf("unexpected flattened valid_to: got %v, want %v", gotTo, wantTo)
+	}
+}
+
+type timeoutRecordingRequest struct {
+	runtime.TestClientRequest
+	timeout    time.Duration
+	timeoutSet bool
+}
+
+func (r *timeoutRecordingRequest) SetTimeout(d time.Duration) error {
+	r.timeout = d
+	r.timeoutSet = true
+	return nil
+}
+
+func TestCertExclusionsUpdateParamsClearDefaultTimeout(t *testing.T) {
+	id := "exclusion-id"
+	body := &certExclusionsUpdateReqV1{
+		Exclusions: []*certExclusionUpdateReqV1{{ID: &id}},
+	}
+	req := &timeoutRecordingRequest{}
+
+	if err := (&certExclusionsUpdateParams{Body: body}).WriteToRequest(req, nil); err != nil {
+		t.Fatalf("expected WriteToRequest to succeed, got %v", err)
+	}
+	if !req.timeoutSet {
+		t.Fatal("expected WriteToRequest to override the default request timeout")
+	}
+	if req.timeout != 0 {
+		t.Fatalf("expected request timeout to be cleared, got %v", req.timeout)
+	}
+	if got := req.GetBodyParam(); got != interface{}(body) {
+		t.Fatalf("unexpected body param: got %v, want %v", got, body)
 	}
 }

--- a/internal/ml_file_path_exclusion/ml_file_path_exclusion.go
+++ b/internal/ml_file_path_exclusion/ml_file_path_exclusion.go
@@ -531,6 +531,12 @@ type mlFilePathExclusionUpdateParams struct {
 }
 
 func (p *mlFilePathExclusionUpdateParams) WriteToRequest(r runtime.ClientRequest, _ strfmt.Registry) error {
+	// Generated params clear the per-request timeout via SetTimeout; without it
+	// the request is capped at go-openapi's 30s DefaultTimeout, which updates
+	// with large host_groups lists can exceed.
+	if err := r.SetTimeout(0); err != nil {
+		return err
+	}
 	if p.Body != nil {
 		if err := r.SetBodyParam(p.Body); err != nil {
 			return err

--- a/internal/ml_file_path_exclusion/ml_file_path_exclusion_test.go
+++ b/internal/ml_file_path_exclusion/ml_file_path_exclusion_test.go
@@ -7,10 +7,38 @@ import (
 
 	"github.com/crowdstrike/gofalcon/falcon/models"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/utils"
+	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type timeoutRecordingRequest struct {
+	runtime.TestClientRequest
+	timeout    time.Duration
+	timeoutSet bool
+}
+
+func (r *timeoutRecordingRequest) SetTimeout(d time.Duration) error {
+	r.timeout = d
+	r.timeoutSet = true
+	return nil
+}
+
+func TestMLFilePathExclusionUpdateParamsClearDefaultTimeout(t *testing.T) {
+	t.Parallel()
+
+	id := "exclusion-id"
+	body := &mlFilePathExclusionUpdateReqV1{ID: &id}
+	req := &timeoutRecordingRequest{}
+
+	err := (&mlFilePathExclusionUpdateParams{Body: body}).WriteToRequest(req, nil)
+	require.NoError(t, err)
+
+	assert.True(t, req.timeoutSet, "WriteToRequest should override the default request timeout")
+	assert.Equal(t, time.Duration(0), req.timeout, "request should be bounded by the operation context, not a per-request timeout")
+	assert.Equal(t, body, req.GetBodyParam())
+}
 
 func TestBuildExcludedFrom(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

Fixes #462.

`crowdstrike_ml_file_path_exclusion` and `crowdstrike_ml_certificate_exclusion` updates replace the generated SDK params with custom writers (to work around the SDK body models). The generated `WriteToRequest` implementations start with `r.SetTimeout(o.timeout)` — zero for params built with the `WithContext` constructor — which clears go-openapi's 30s `DefaultTimeout`. The custom writers skip that call, so every update PATCH for these two resources carries a hard, non-configurable 30-second deadline and fails with `context deadline exceeded` whenever the API takes longer. This is reliably reproducible with large `host_groups` lists; see #462 for the full analysis.

This change clears the per-request timeout in both custom writers so the request is bounded by the operation context, exactly like the generated params the writers replaced. `SetTimeout(0)` is the no-deadline path in go-openapi's `Submit`: `request.timeout == 0` wraps the operation context with `context.WithCancel` instead of `context.WithTimeout`.

## Changes

- `internal/ml_file_path_exclusion`: call `SetTimeout(0)` in `mlFilePathExclusionUpdateParams.WriteToRequest`
- `internal/ml_certificate_exclusion`: call `SetTimeout(0)` in `certExclusionsUpdateParams.WriteToRequest`
- unit tests asserting both writers clear the request timeout and still set the body

## Testing

- `go build ./...` and `go test ./internal/ml_file_path_exclusion/... ./internal/ml_certificate_exclusion/...` pass.
- The failure mode was observed on a live us-1 tenant running provider v0.0.79: `ml_file_path_exclusion` updates with ~36-group `host_groups` lists fail at exactly 30s on every retry, while `sensor_visibility_exclusion` updates in the same apply ran 39s+ without error (generated params, no cap).
