### PR TITLE
fix: clear unintended 30s request timeout in params overrides

### DIFF
--- a/internal/correlation_rules/patch_overrides.go
+++ b/internal/correlation_rules/patch_overrides.go
@@ -59,6 +59,12 @@ type patchRuleParams struct {
 }
 
 func (p *patchRuleParams) WriteToRequest(r runtime.ClientRequest, _ strfmt.Registry) error {
+	// Generated params clear the per-request timeout via SetTimeout; without it
+	// the request is capped at go-openapi's 30s DefaultTimeout instead of being
+	// bounded by the operation context.
+	if err := r.SetTimeout(0); err != nil {
+		return err
+	}
 	if p.Body == nil {
 		return nil
 	}

--- a/internal/correlation_rules/patch_overrides_test.go
+++ b/internal/correlation_rules/patch_overrides_test.go
@@ -1,0 +1,45 @@
+package correlationrules
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// timeoutRecordingRequest mirrors how go-openapi builds an outgoing request: the
+// per-request timeout is seeded with client.DefaultTimeout (30s) before the
+// params writer runs, so a writer that never calls SetTimeout leaves the 30s cap
+// in place.
+type timeoutRecordingRequest struct {
+	runtime.TestClientRequest
+	timeout    time.Duration
+	timeoutSet bool
+}
+
+func newTimeoutRecordingRequest() *timeoutRecordingRequest {
+	return &timeoutRecordingRequest{timeout: cr.DefaultTimeout}
+}
+
+func (r *timeoutRecordingRequest) SetTimeout(d time.Duration) error {
+	r.timeout = d
+	r.timeoutSet = true
+	return nil
+}
+
+func TestPatchRuleParamsClearDefaultTimeout(t *testing.T) {
+	t.Parallel()
+
+	body := []*rulePatchRequest{{}}
+	req := newTimeoutRecordingRequest()
+
+	err := (&patchRuleParams{Body: body}).WriteToRequest(req, nil)
+	require.NoError(t, err)
+
+	assert.True(t, req.timeoutSet, "WriteToRequest should override the default request timeout")
+	assert.Equal(t, time.Duration(0), req.timeout, "request should be bounded by the operation context, not a per-request timeout")
+	assert.Equal(t, body, req.GetBodyParam())
+}

--- a/internal/firewall/policy.go
+++ b/internal/firewall/policy.go
@@ -835,6 +835,12 @@ type firewallUpdateFirewallPoliciesParams struct {
 }
 
 func (p *firewallUpdateFirewallPoliciesParams) WriteToRequest(r runtime.ClientRequest, _ strfmt.Registry) error {
+	// Generated params clear the per-request timeout via SetTimeout; without it
+	// the request is capped at go-openapi's 30s DefaultTimeout instead of being
+	// bounded by the operation context.
+	if err := r.SetTimeout(0); err != nil {
+		return err
+	}
 	if p.Body != nil {
 		return r.SetBodyParam(p.Body)
 	}

--- a/internal/firewall/policy_params_test.go
+++ b/internal/firewall/policy_params_test.go
@@ -1,0 +1,48 @@
+package firewall
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// timeoutRecordingRequest mirrors how go-openapi builds an outgoing request: the
+// per-request timeout is seeded with client.DefaultTimeout (30s) before the
+// params writer runs, so a writer that never calls SetTimeout leaves the 30s cap
+// in place.
+type timeoutRecordingRequest struct {
+	runtime.TestClientRequest
+	timeout    time.Duration
+	timeoutSet bool
+}
+
+func newTimeoutRecordingRequest() *timeoutRecordingRequest {
+	return &timeoutRecordingRequest{timeout: cr.DefaultTimeout}
+}
+
+func (r *timeoutRecordingRequest) SetTimeout(d time.Duration) error {
+	r.timeout = d
+	r.timeoutSet = true
+	return nil
+}
+
+func TestFirewallUpdatePoliciesParamsClearDefaultTimeout(t *testing.T) {
+	t.Parallel()
+
+	id := "policy-id"
+	body := &firewallUpdateFirewallPoliciesReqV1{
+		Resources: []*firewallUpdateFirewallPolicyReqV1{{ID: &id}},
+	}
+	req := newTimeoutRecordingRequest()
+
+	err := (&firewallUpdateFirewallPoliciesParams{Body: body}).WriteToRequest(req, nil)
+	require.NoError(t, err)
+
+	assert.True(t, req.timeoutSet, "WriteToRequest should override the default request timeout")
+	assert.Equal(t, time.Duration(0), req.timeout, "request should be bounded by the operation context, not a per-request timeout")
+	assert.Equal(t, body, req.GetBodyParam())
+}

--- a/internal/ioa_exclusion/patch_overrides.go
+++ b/internal/ioa_exclusion/patch_overrides.go
@@ -35,6 +35,12 @@ type ioaExclusionsUpdateParams struct {
 }
 
 func (p *ioaExclusionsUpdateParams) WriteToRequest(r runtime.ClientRequest, _ strfmt.Registry) error {
+	// Generated params clear the per-request timeout via SetTimeout; without it
+	// the request is capped at go-openapi's 30s DefaultTimeout instead of being
+	// bounded by the operation context.
+	if err := r.SetTimeout(0); err != nil {
+		return err
+	}
 	if p.Body == nil {
 		return nil
 	}

--- a/internal/ioa_exclusion/patch_overrides_test.go
+++ b/internal/ioa_exclusion/patch_overrides_test.go
@@ -1,0 +1,47 @@
+package ioaexclusion
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// timeoutRecordingRequest mirrors how go-openapi builds an outgoing request: the
+// per-request timeout is seeded with client.DefaultTimeout (30s) before the
+// params writer runs, so a writer that never calls SetTimeout leaves the 30s cap
+// in place.
+type timeoutRecordingRequest struct {
+	runtime.TestClientRequest
+	timeout    time.Duration
+	timeoutSet bool
+}
+
+func newTimeoutRecordingRequest() *timeoutRecordingRequest {
+	return &timeoutRecordingRequest{timeout: cr.DefaultTimeout}
+}
+
+func (r *timeoutRecordingRequest) SetTimeout(d time.Duration) error {
+	r.timeout = d
+	r.timeoutSet = true
+	return nil
+}
+
+func TestIOAExclusionsUpdateParamsClearDefaultTimeout(t *testing.T) {
+	t.Parallel()
+
+	body := &ioaExclusionsUpdateRequest{
+		Exclusions: []*ioaExclusionUpdateRequest{{}},
+	}
+	req := newTimeoutRecordingRequest()
+
+	err := (&ioaExclusionsUpdateParams{Body: body}).WriteToRequest(req, nil)
+	require.NoError(t, err)
+
+	assert.True(t, req.timeoutSet, "WriteToRequest should override the default request timeout")
+	assert.Equal(t, time.Duration(0), req.timeout, "request should be bounded by the operation context, not a per-request timeout")
+	assert.Equal(t, body, req.GetBodyParam())
+}

--- a/internal/ngsiem/data_connection_overrides.go
+++ b/internal/ngsiem/data_connection_overrides.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/crowdstrike/gofalcon/falcon/client/ngsiem"
 	"github.com/crowdstrike/gofalcon/falcon/models"
-	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 )
@@ -33,13 +32,21 @@ type updateDataConnectionRequestOverride struct {
 }
 
 // createDataConnectionParamsOverride serializes the create request body using
-// the enrichment-corrected struct. It mirrors the generated
-// ExternalCreateDataConnectionParams.WriteToRequest (body only).
+// the enrichment-corrected struct. It delegates to the generated
+// ExternalCreateDataConnectionParams.WriteToRequest so the request inherits
+// everything the call site configured (notably the per-request timeout), then
+// replaces the body.
 type createDataConnectionParamsOverride struct {
-	body *createDataConnectionRequestOverride
+	generated runtime.ClientRequestWriter
+	body      *createDataConnectionRequestOverride
 }
 
-func (p *createDataConnectionParamsOverride) WriteToRequest(r runtime.ClientRequest, _ strfmt.Registry) error {
+func (p *createDataConnectionParamsOverride) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
+	if p.generated != nil {
+		if err := p.generated.WriteToRequest(r, reg); err != nil {
+			return err
+		}
+	}
 	if p.body != nil {
 		if err := r.SetBodyParam(p.body); err != nil {
 			return err
@@ -49,28 +56,24 @@ func (p *createDataConnectionParamsOverride) WriteToRequest(r runtime.ClientRequ
 }
 
 // updateDataConnectionParamsOverride serializes the update request body using
-// the enrichment-corrected struct. It mirrors the generated
-// ExternalUpdateDataConnectionParams.WriteToRequest, including the required
-// `ids` query param.
+// the enrichment-corrected struct. It delegates to the generated
+// ExternalUpdateDataConnectionParams.WriteToRequest, which writes the
+// per-request timeout and the required `ids` query param, then replaces the body.
 type updateDataConnectionParamsOverride struct {
-	body *updateDataConnectionRequestOverride
-	ids  string
+	generated runtime.ClientRequestWriter
+	body      *updateDataConnectionRequestOverride
 }
 
-func (p *updateDataConnectionParamsOverride) WriteToRequest(r runtime.ClientRequest, _ strfmt.Registry) error {
-	var res []error
+func (p *updateDataConnectionParamsOverride) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
+	if p.generated != nil {
+		if err := p.generated.WriteToRequest(r, reg); err != nil {
+			return err
+		}
+	}
 	if p.body != nil {
 		if err := r.SetBodyParam(p.body); err != nil {
 			return err
 		}
-	}
-	if p.ids != "" {
-		if err := r.SetQueryParam("ids", p.ids); err != nil {
-			return err
-		}
-	}
-	if len(res) > 0 {
-		return errors.CompositeValidationError(res...)
 	}
 	return nil
 }
@@ -80,6 +83,7 @@ func (p *updateDataConnectionParamsOverride) WriteToRequest(r runtime.ClientRequ
 func withCreateEnrichmentOverride(body *models.DataconnectionmanagementCreateDataConnectionRequest) ngsiem.ClientOption {
 	return func(op *runtime.ClientOperation) {
 		op.Params = &createDataConnectionParamsOverride{
+			generated: op.Params,
 			body: &createDataConnectionRequestOverride{
 				DataconnectionmanagementCreateDataConnectionRequest: *body,
 				EnableHostEnrichment: body.EnableHostEnrichment,
@@ -90,16 +94,16 @@ func withCreateEnrichmentOverride(body *models.DataconnectionmanagementCreateDat
 }
 
 // withUpdateEnrichmentOverride returns a ClientOption that swaps in the
-// enrichment-corrected update body serializer, preserving the `ids` query param.
-func withUpdateEnrichmentOverride(body *models.DataconnectionmanagementUpdateDataConnectionRequest, ids string) ngsiem.ClientOption {
+// enrichment-corrected update body serializer.
+func withUpdateEnrichmentOverride(body *models.DataconnectionmanagementUpdateDataConnectionRequest) ngsiem.ClientOption {
 	return func(op *runtime.ClientOperation) {
 		op.Params = &updateDataConnectionParamsOverride{
+			generated: op.Params,
 			body: &updateDataConnectionRequestOverride{
 				DataconnectionmanagementUpdateDataConnectionRequest: *body,
 				EnableHostEnrichment: body.EnableHostEnrichment,
 				EnableUserEnrichment: body.EnableUserEnrichment,
 			},
-			ids: ids,
 		}
 	}
 }

--- a/internal/ngsiem/data_connection_overrides_test.go
+++ b/internal/ngsiem/data_connection_overrides_test.go
@@ -1,13 +1,18 @@
 package ngsiem
 
 import (
+	"context"
 	"encoding/json"
 	"io"
+	"net/url"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/crowdstrike/gofalcon/falcon/client/ngsiem"
 	"github.com/crowdstrike/gofalcon/falcon/models"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 )
 
 // TestCreateEnrichmentOverrideSerializesFalse proves the create override struct
@@ -102,6 +107,133 @@ func TestEnrichmentOverrideSerializesTrue(t *testing.T) {
 	}
 	if !strings.Contains(got, `"enable_user_enrichment":true`) {
 		t.Errorf("expected enable_user_enrichment:true in body; got %s", got)
+	}
+}
+
+// timeoutRecordingRequest mirrors how go-openapi builds an outgoing request: the
+// per-request timeout is seeded with client.DefaultTimeout (30s) before the
+// params writer runs, so a writer that never calls SetTimeout leaves the 30s cap
+// in place.
+type timeoutRecordingRequest struct {
+	runtime.TestClientRequest
+	timeout    time.Duration
+	timeoutSet bool
+	query      url.Values
+}
+
+func newTimeoutRecordingRequest() *timeoutRecordingRequest {
+	return &timeoutRecordingRequest{timeout: cr.DefaultTimeout, query: url.Values{}}
+}
+
+func (r *timeoutRecordingRequest) SetTimeout(d time.Duration) error {
+	r.timeout = d
+	r.timeoutSet = true
+	return nil
+}
+
+func (r *timeoutRecordingRequest) SetQueryParam(name string, values ...string) error {
+	r.query[name] = values
+	return nil
+}
+
+func (r *timeoutRecordingRequest) GetQueryParams() url.Values { return r.query }
+
+// TestCreateEnrichmentOverrideInheritsParamsTimeout proves the create override
+// inherits the per-request timeout from the params the call site built instead of
+// leaving go-openapi's 30s DefaultTimeout in place.
+func TestCreateEnrichmentOverrideInheritsParamsTimeout(t *testing.T) {
+	body := &models.DataconnectionmanagementCreateDataConnectionRequest{Name: "test"}
+
+	op := &runtime.ClientOperation{
+		Params: ngsiem.NewExternalCreateDataConnectionParamsWithContext(context.Background()).
+			WithBody(body),
+	}
+	withCreateEnrichmentOverride(body)(op)
+
+	req := newTimeoutRecordingRequest()
+	if err := op.Params.WriteToRequest(req, nil); err != nil {
+		t.Fatalf("WriteToRequest: %s", err)
+	}
+
+	if !req.timeoutSet {
+		t.Fatal("expected WriteToRequest to set the per-request timeout")
+	}
+	if req.timeout != 0 {
+		t.Fatalf("expected the request to be bounded by the operation context, got a %s timeout", req.timeout)
+	}
+	if _, ok := req.GetBodyParam().(*createDataConnectionRequestOverride); !ok {
+		t.Fatalf("expected the enrichment-corrected body, got %T", req.GetBodyParam())
+	}
+}
+
+// TestUpdateEnrichmentOverrideInheritsParamsTimeout proves the same for update
+// and that the required `ids` query param still reaches the request.
+func TestUpdateEnrichmentOverrideInheritsParamsTimeout(t *testing.T) {
+	body := &models.DataconnectionmanagementUpdateDataConnectionRequest{Name: "test"}
+
+	op := &runtime.ClientOperation{
+		Params: ngsiem.NewExternalUpdateDataConnectionParamsWithContext(context.Background()).
+			WithIds("connection-id").
+			WithBody(body),
+	}
+	withUpdateEnrichmentOverride(body)(op)
+
+	req := newTimeoutRecordingRequest()
+	if err := op.Params.WriteToRequest(req, nil); err != nil {
+		t.Fatalf("WriteToRequest: %s", err)
+	}
+
+	if !req.timeoutSet {
+		t.Fatal("expected WriteToRequest to set the per-request timeout")
+	}
+	if req.timeout != 0 {
+		t.Fatalf("expected the request to be bounded by the operation context, got a %s timeout", req.timeout)
+	}
+	if _, ok := req.GetBodyParam().(*updateDataConnectionRequestOverride); !ok {
+		t.Fatalf("expected the enrichment-corrected body, got %T", req.GetBodyParam())
+	}
+	if got := req.GetQueryParams().Get("ids"); got != "connection-id" {
+		t.Fatalf("expected ids query param connection-id, got %q", got)
+	}
+}
+
+// TestEnrichmentOverridesHonorExplicitTimeout proves the overrides delegate to
+// the generated writer rather than hardcoding a timeout, so an explicit
+// per-request timeout on the params is still honored.
+func TestEnrichmentOverridesHonorExplicitTimeout(t *testing.T) {
+	want := 2 * time.Minute
+
+	createBody := &models.DataconnectionmanagementCreateDataConnectionRequest{Name: "test"}
+	createOp := &runtime.ClientOperation{
+		Params: ngsiem.NewExternalCreateDataConnectionParamsWithContext(context.Background()).
+			WithBody(createBody).
+			WithTimeout(want),
+	}
+	withCreateEnrichmentOverride(createBody)(createOp)
+
+	createReq := newTimeoutRecordingRequest()
+	if err := createOp.Params.WriteToRequest(createReq, nil); err != nil {
+		t.Fatalf("create WriteToRequest: %s", err)
+	}
+	if createReq.timeout != want {
+		t.Fatalf("expected create timeout %s, got %s", want, createReq.timeout)
+	}
+
+	updateBody := &models.DataconnectionmanagementUpdateDataConnectionRequest{Name: "test"}
+	updateOp := &runtime.ClientOperation{
+		Params: ngsiem.NewExternalUpdateDataConnectionParamsWithContext(context.Background()).
+			WithIds("connection-id").
+			WithBody(updateBody).
+			WithTimeout(want),
+	}
+	withUpdateEnrichmentOverride(updateBody)(updateOp)
+
+	updateReq := newTimeoutRecordingRequest()
+	if err := updateOp.Params.WriteToRequest(updateReq, nil); err != nil {
+		t.Fatalf("update WriteToRequest: %s", err)
+	}
+	if updateReq.timeout != want {
+		t.Fatalf("expected update timeout %s, got %s", want, updateReq.timeout)
 	}
 }
 

--- a/internal/ngsiem/data_connection_resource.go
+++ b/internal/ngsiem/data_connection_resource.go
@@ -258,8 +258,7 @@ func (r *dataConnectionResource) Create(
 		return
 	}
 
-	params := ngsiem.NewExternalCreateDataConnectionParams().
-		WithContext(ctx).
+	params := ngsiem.NewExternalCreateDataConnectionParamsWithContext(ctx).
 		WithBody(createRequest)
 
 	res, err := r.client.Ngsiem.ExternalCreateDataConnection(
@@ -384,14 +383,13 @@ func (r *dataConnectionResource) Update(
 		return
 	}
 
-	params := ngsiem.NewExternalUpdateDataConnectionParams().
-		WithContext(ctx).
+	params := ngsiem.NewExternalUpdateDataConnectionParamsWithContext(ctx).
 		WithIds(plan.ID.ValueString()).
 		WithBody(updateRequest)
 
 	_, err := r.client.Ngsiem.ExternalUpdateDataConnection(
 		params,
-		withUpdateEnrichmentOverride(updateRequest, plan.ID.ValueString()),
+		withUpdateEnrichmentOverride(updateRequest),
 	)
 	if err != nil {
 		resp.Diagnostics.Append(tferrors.NewDiagnosticFromAPIError(


### PR DESCRIPTION
## Summary

Hand-written `WriteToRequest` overrides in four resources set only the request body, so go-openapi's 30s `DefaultTimeout` seeded in `newRequest` was never cleared and every affected call carried a hard 30 second deadline. Generated writers avoid this by opening with `r.SetTimeout(o.timeout)`.

`firewall_policy`, `ioa_exclusion`, and `correlation_rule` now call `r.SetTimeout(0)`, matching the fix merged for ML exclusions in #463. Each of their call sites leaves the unexported `timeout` at zero, so this reproduces what the generated writer would have sent.

`ngsiem_data_connection` is handled differently. Its constructor `NewExternalCreateDataConnectionParams()` explicitly assigns `cr.DefaultTimeout`, and `.WithContext()` does not touch it, so a hardcoded `SetTimeout(0)` would silently contradict the constructor. The call sites now use `NewExternalCreateDataConnectionParamsWithContext(ctx)` and `NewExternalUpdateDataConnectionParamsWithContext(ctx)`, and the overrides delegate to the generated writer, replacing only the body. Delegation also covers the `ids` query param, so the override's duplicate `ids` field was removed.

Closes #464
Closes #465
Closes #466
Closes #467
