### PR TITLE
fix(sensor_update_policy): keep null description null after apply

### DIFF
--- a/internal/sensor_update_policy/sensor_update_policy_resource.go
+++ b/internal/sensor_update_policy/sensor_update_policy_resource.go
@@ -91,7 +91,7 @@ func (d *sensorUpdatePolicyResourceModel) wrap(
 
 	d.ID = types.StringValue(*policy.ID)
 	d.Name = types.StringValue(*policy.Name)
-	d.Description = types.StringValue(*policy.Description)
+	d.Description = utils.PlanAwareStringValue(d.Description, policy.Description)
 	d.Enabled = types.BoolValue(*policy.Enabled)
 
 	if validateHostGroups {

--- a/internal/sensor_update_policy/sensor_update_policy_resource_test.go
+++ b/internal/sensor_update_policy/sensor_update_policy_resource_test.go
@@ -17,7 +17,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 // sensorUpdatePolicyConfig represents a complete policy configuration for testing.
@@ -1373,10 +1376,12 @@ resource "crowdstrike_sensor_update_policy" "test" {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"last_updated"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// The API reports an unset description as "", which import cannot tell apart
+				// from an explicit description = "". Import resolves it to null.
+				ImportStateVerifyIgnore: []string{"last_updated", "description"},
 			},
 		},
 	})
@@ -1523,6 +1528,163 @@ resource "crowdstrike_sensor_update_policy" "test" {
 			},
 		},
 	})
+}
+
+func testAccSensorUpdatePolicyConfig_noDescription(rName string) string {
+	return acctest.ProviderConfig + fmt.Sprintf(`
+resource "crowdstrike_sensor_update_policy" "test" {
+  name          = %q
+  platform_name = "Windows"
+  build         = ""
+  schedule = {
+    enabled = false
+  }
+}
+`, rName)
+}
+
+func testAccSensorUpdatePolicyConfig_withDescription(rName, description string) string {
+	return acctest.ProviderConfig + fmt.Sprintf(`
+resource "crowdstrike_sensor_update_policy" "test" {
+  name          = %q
+  description   = %q
+  platform_name = "Windows"
+  build         = ""
+  schedule = {
+    enabled = false
+  }
+}
+`, rName, description)
+}
+
+func TestAccSensorUpdatePolicyResource_nullDescription(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "crowdstrike_sensor_update_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSensorUpdatePolicyConfig_noDescription(rName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("description"), knownvalue.Null()),
+				},
+			},
+			{
+				Config: testAccSensorUpdatePolicyConfig_withDescription(rName, "made with terraform"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("description"), knownvalue.StringExact("made with terraform")),
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_updated"},
+			},
+		},
+	})
+}
+
+// TestAccSensorUpdatePolicyResource_emptyDescription verifies that practitioners who
+// already have description = "" in their configuration keep working. An explicit empty
+// string must stay an empty string in state, not be normalized to null.
+func TestAccSensorUpdatePolicyResource_emptyDescription(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "crowdstrike_sensor_update_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSensorUpdatePolicyConfig_withDescription(rName, ""),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("description"), knownvalue.StringExact("")),
+				},
+			},
+			{
+				Config:   testAccSensorUpdatePolicyConfig_withDescription(rName, ""),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// TestWrapDescription verifies that wrap preserves the practitioner's intent for the
+// optional description: a null config stays null when the API echoes back "", while an
+// explicit empty string is kept as an empty string for backwards compatibility.
+func TestWrapDescription(t *testing.T) {
+	tests := []struct {
+		name   string
+		plan   types.String
+		apiVal *string
+		want   types.String
+	}{
+		{
+			name:   "null plan with empty api value stays null",
+			plan:   types.StringNull(),
+			apiVal: utils.Addr(""),
+			want:   types.StringNull(),
+		},
+		{
+			name:   "null plan with nil api value stays null",
+			plan:   types.StringNull(),
+			apiVal: nil,
+			want:   types.StringNull(),
+		},
+		{
+			name:   "empty plan with empty api value stays empty",
+			plan:   types.StringValue(""),
+			apiVal: utils.Addr(""),
+			want:   types.StringValue(""),
+		},
+		{
+			name:   "set plan takes the api value",
+			plan:   types.StringValue("made with terraform"),
+			apiVal: utils.Addr("made with terraform"),
+			want:   types.StringValue("made with terraform"),
+		},
+		{
+			name:   "null plan takes a non empty api value",
+			plan:   types.StringNull(),
+			apiVal: utils.Addr("set outside terraform"),
+			want:   types.StringValue("set outside terraform"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			build := "1234"
+			policy := models.SensorUpdatePolicyV2{
+				ID:           utils.Addr("policy-1"),
+				Name:         utils.Addr("test"),
+				Description:  tt.apiVal,
+				Enabled:      utils.Addr(true),
+				PlatformName: utils.Addr("Windows"),
+				Settings: &models.SensorUpdateSettingsRespV2{
+					Build:               utils.Addr(build),
+					UninstallProtection: utils.Addr("DISABLED"),
+				},
+			}
+
+			model := sensorupdatepolicy.SensorUpdatePolicyResourceModel{
+				Build:       types.StringValue(build),
+				Description: tt.plan,
+			}
+
+			diags := sensorupdatepolicy.WrapSensorUpdatePolicy(&model, t.Context(), policy, false, false)
+			if diags.HasError() {
+				t.Fatalf("expected no diagnostics, got: %v", diags.Errors())
+			}
+
+			if !model.Description.Equal(tt.want) {
+				t.Errorf("description = %s, want %s", model.Description, tt.want)
+			}
+		})
+	}
 }
 
 // TestWrapDropsFlightControlPlaceholderGroups verifies that empty-ID host group


### PR DESCRIPTION
## Summary

Creating a `crowdstrike_sensor_update_policy` without `description` failed with `.description: was null, but now cty.StringVal("")`. The API returns an empty string for an unset description and `wrap` passed it straight through with `types.StringValue`, while the schema declares `description` as optional and not computed.

`wrap` now uses the existing `utils.PlanAwareStringValue` helper, which returns null when the plan is null and the API value is nil or empty, and otherwise passes the API value through. A configuration that explicitly sets `description = ""` keeps the empty string, so existing configurations are unaffected.

`crowdstrike_default_sensor_update_policy` has no `description` attribute and is unaffected.

Two things worth a reviewer's attention. Because the helper keys off the plan, `terraform import` has no plan and resolves the API's empty string to null, so `description` was added to `ImportStateVerifyIgnore` in one existing test. Separately, `description` still cannot be cleared once set, which is an SDK level issue: `models.SensorUpdateUpdatePolicyReqV2.Description` is a `string` with `omitempty`, so an empty string is dropped from the request body. The prevention policy equivalent uses `*string` and works. That is out of scope here and needs an upstream gofalcon change.

Closes #201
