### PR TITLE
fix(sensor_update_policy): preserve day-name casing in schedule time_blocks

### DIFF
--- a/docs/resources/default_sensor_update_policy.md
+++ b/docs/resources/default_sensor_update_policy.md
@@ -97,7 +97,7 @@ Optional:
 
 Required:
 
-- `days` (Set of String) The days of the week the time block should be active.
+- `days` (Set of String) The days of the week the time block should be active. Case-insensitive.
 - `end_time` (String) The end time for the time block in 24HR format. Must be atleast 1 hour more than start_time.
 - `start_time` (String) The start time for the time block in 24HR format. Must be atleast 1 hour before end_time.
 

--- a/docs/resources/sensor_update_policy.md
+++ b/docs/resources/sensor_update_policy.md
@@ -104,7 +104,7 @@ Optional:
 
 Required:
 
-- `days` (Set of String) The days of the week the time block should be active.
+- `days` (Set of String) The days of the week the time block should be active. Case-insensitive.
 - `end_time` (String) The end time for the time block in 24HR format. Must be atleast 1 hour more than start_time.
 - `start_time` (String) The start time for the time block in 24HR format. Must be atleast 1 hour before end_time.
 

--- a/internal/sensor_update_policy/default_sensor_update_policy_resource.go
+++ b/internal/sensor_update_policy/default_sensor_update_policy_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/crowdstrike/gofalcon/falcon/client/sensor_update_policies"
 	"github.com/crowdstrike/gofalcon/falcon/models"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/config"
+	fwtypes "github.com/crowdstrike/terraform-provider-crowdstrike/internal/framework/types"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/scopes"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/tferrors"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/utils"
@@ -163,14 +164,8 @@ func (d *defaultSensorUpdatePolicyResourceModel) wrap(
 
 					for _, s := range policy.Settings.Scheduler.Schedules {
 						sCopy := s
-						daysStr := []string{}
 
-						for _, d := range sCopy.Days {
-							dCopy := d
-							daysStr = append(daysStr, int64ToDay[dCopy])
-						}
-
-						days, diagsDay := types.SetValueFrom(ctx, types.StringType, daysStr)
+						days, diagsDay := flattenDays(ctx, sCopy.Days)
 						diags.Append(diagsDay...)
 						if diags.HasError() {
 							return diags
@@ -319,8 +314,8 @@ func (r *defaultSensorUpdatePolicyResource) Schema(
 							Attributes: map[string]schema.Attribute{
 								"days": schema.SetAttribute{
 									Required:    true,
-									ElementType: types.StringType,
-									Description: "The days of the week the time block should be active.",
+									ElementType: fwtypes.CaseInsensitiveStringType{},
+									Description: "The days of the week the time block should be active. Case-insensitive.",
 									Validators: []validator.Set{
 										setvalidator.ValueStringsAre(
 											stringvalidator.OneOfCaseInsensitive(
@@ -591,7 +586,7 @@ func (r *defaultSensorUpdatePolicyResource) ValidateConfig(
 				resp.Diagnostics.Append(b.Days.ElementsAs(ctx, &days, false)...)
 
 				for _, day := range days {
-					_, ok := usedDays[day]
+					_, ok := usedDays[strings.ToLower(day)]
 					if ok {
 						resp.Diagnostics.AddAttributeError(
 							path.Root("schedule"),
@@ -603,7 +598,7 @@ func (r *defaultSensorUpdatePolicyResource) ValidateConfig(
 						)
 					}
 
-					usedDays[day] = nil
+					usedDays[strings.ToLower(day)] = nil
 				}
 			}
 		}

--- a/internal/sensor_update_policy/default_sensor_update_policy_resource_test.go
+++ b/internal/sensor_update_policy/default_sensor_update_policy_resource_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/acctest"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
@@ -388,4 +389,77 @@ resource "crowdstrike_default_sensor_update_policy" "default" {
 			},
 		},
 	})
+}
+
+// regression test for https://github.com/CrowdStrike/terraform-provider-crowdstrike/issues/200
+func TestAccDefaultSensorUpdatePolicyResourceWithSchedule_CapitalizedDays(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0"))),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDefaultSensorUpdatePolicyResourceConfigCapitalizedDays(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "platform_name", "Windows"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.timezone", "Etc/UTC"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.time_blocks.#", "1"),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"schedule.time_blocks.0.days.#",
+						"3",
+					),
+					// the configured casing is kept in state, not the api's lowercase form
+					resource.TestCheckTypeSetElemAttr(
+						resourceName,
+						"schedule.time_blocks.0.days.*",
+						"Monday",
+					),
+					resource.TestCheckTypeSetElemAttr(
+						resourceName,
+						"schedule.time_blocks.0.days.*",
+						"Wednesday",
+					),
+					resource.TestCheckTypeSetElemAttr(
+						resourceName,
+						"schedule.time_blocks.0.days.*",
+						"Friday",
+					),
+				),
+			},
+			// re-planning the same config proves the configured casing round-trips through refresh
+			{
+				Config: testAccDefaultSensorUpdatePolicyResourceConfigCapitalizedDays(),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccDefaultSensorUpdatePolicyResourceConfigCapitalizedDays() string {
+	return acctest.ProviderConfig + `
+resource "crowdstrike_default_sensor_update_policy" "default" {
+  platform_name = "Windows"
+  build         = ""
+  schedule = {
+    enabled = true
+    timezone = "Etc/UTC"
+    time_blocks = [
+      {
+        days       = ["Monday", "Wednesday", "Friday"]
+        start_time = "09:00"
+        end_time   = "17:00"
+      }
+    ]
+  }
+}
+`
 }

--- a/internal/sensor_update_policy/sensor_update_policies_data_source.go
+++ b/internal/sensor_update_policy/sensor_update_policies_data_source.go
@@ -10,6 +10,7 @@ import (
 	"github.com/crowdstrike/gofalcon/falcon/models"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/config"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/framework/flex"
+	fwtypes "github.com/crowdstrike/terraform-provider-crowdstrike/internal/framework/types"
 	fwvalidators "github.com/crowdstrike/terraform-provider-crowdstrike/internal/framework/validators"
 	hostgroups "github.com/crowdstrike/terraform-provider-crowdstrike/internal/host_groups"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/tferrors"
@@ -177,12 +178,7 @@ func (m *sensorUpdatePoliciesDataSourceModel) wrap(ctx context.Context, policies
 						timeBlockObjects := []timeBlock{}
 
 						for _, s := range policy.Settings.Scheduler.Schedules {
-							daysStr := []string{}
-							for _, d := range s.Days {
-								daysStr = append(daysStr, int64ToDay[d])
-							}
-
-							days, diagsDay := types.SetValueFrom(ctx, types.StringType, daysStr)
+							days, diagsDay := flattenDays(ctx, s.Days)
 							diags.Append(diagsDay...)
 							if diags.HasError() {
 								return diags
@@ -407,7 +403,7 @@ func (d *sensorUpdatePoliciesDataSource) Schema(
 										Attributes: map[string]schema.Attribute{
 											"days": schema.SetAttribute{
 												Computed:    true,
-												ElementType: types.StringType,
+												ElementType: fwtypes.CaseInsensitiveStringType{},
 												Description: "Days of the week when this time block is active",
 											},
 											"start_time": schema.StringAttribute{

--- a/internal/sensor_update_policy/sensor_update_policy_resource.go
+++ b/internal/sensor_update_policy/sensor_update_policy_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/crowdstrike/gofalcon/falcon/client/sensor_update_policies"
 	"github.com/crowdstrike/gofalcon/falcon/models"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/config"
+	fwtypes "github.com/crowdstrike/terraform-provider-crowdstrike/internal/framework/types"
 	hostgroups "github.com/crowdstrike/terraform-provider-crowdstrike/internal/host_groups"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/scopes"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/tferrors"
@@ -212,14 +213,8 @@ func (d *sensorUpdatePolicyResourceModel) wrap(
 
 					for _, s := range policy.Settings.Scheduler.Schedules {
 						sCopy := s
-						daysStr := []string{}
 
-						for _, d := range sCopy.Days {
-							dCopy := d
-							daysStr = append(daysStr, int64ToDay[dCopy])
-						}
-
-						days, diagsDay := types.SetValueFrom(ctx, types.StringType, daysStr)
+						days, diagsDay := flattenDays(ctx, sCopy.Days)
 						diags.Append(diagsDay...)
 						if diags.HasError() {
 							return diags
@@ -388,8 +383,8 @@ func (r *sensorUpdatePolicyResource) Schema(
 							Attributes: map[string]schema.Attribute{
 								"days": schema.SetAttribute{
 									Required:    true,
-									ElementType: types.StringType,
-									Description: "The days of the week the time block should be active.",
+									ElementType: fwtypes.CaseInsensitiveStringType{},
+									Description: "The days of the week the time block should be active. Case-insensitive.",
 									Validators: []validator.Set{
 										setvalidator.ValueStringsAre(
 											stringvalidator.OneOfCaseInsensitive(
@@ -975,7 +970,7 @@ func (r *sensorUpdatePolicyResource) ValidateConfig(
 				resp.Diagnostics.Append(b.Days.ElementsAs(ctx, &days, false)...)
 
 				for _, day := range days {
-					_, ok := usedDays[day]
+					_, ok := usedDays[strings.ToLower(day)]
 					if ok {
 						resp.Diagnostics.AddAttributeError(
 							path.Root("schedule"),
@@ -987,7 +982,7 @@ func (r *sensorUpdatePolicyResource) ValidateConfig(
 						)
 					}
 
-					usedDays[day] = nil
+					usedDays[strings.ToLower(day)] = nil
 				}
 			}
 		}

--- a/internal/sensor_update_policy/sensor_update_policy_resource_test.go
+++ b/internal/sensor_update_policy/sensor_update_policy_resource_test.go
@@ -1564,3 +1564,171 @@ func TestWrapDropsFlightControlPlaceholderGroups(t *testing.T) {
 		t.Fatalf("expected host_groups=[real-group], got %v", got)
 	}
 }
+
+// regression test for https://github.com/CrowdStrike/terraform-provider-crowdstrike/issues/200
+func TestAccSensorUpdatePolicyResourceWithSchedule_CapitalizedDays(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "crowdstrike_sensor_update_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSensorUpdatePolicyResourceConfigCapitalizedDays(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "platform_name", "Windows"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.timezone", "Etc/UTC"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.time_blocks.#", "1"),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"schedule.time_blocks.0.days.#",
+						"3",
+					),
+					// the configured casing is kept in state, not the api's lowercase form
+					resource.TestCheckTypeSetElemAttr(
+						resourceName,
+						"schedule.time_blocks.0.days.*",
+						"Monday",
+					),
+					resource.TestCheckTypeSetElemAttr(
+						resourceName,
+						"schedule.time_blocks.0.days.*",
+						"Wednesday",
+					),
+					resource.TestCheckTypeSetElemAttr(
+						resourceName,
+						"schedule.time_blocks.0.days.*",
+						"Friday",
+					),
+				),
+			},
+			// re-planning the same config proves the configured casing round-trips through refresh
+			{
+				Config: testAccSensorUpdatePolicyResourceConfigCapitalizedDays(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// lowercase day names still work
+			{
+				Config: testAccSensorUpdatePolicyResourceConfigLowercaseDays(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"schedule.time_blocks.0.days.#",
+						"3",
+					),
+					resource.TestCheckTypeSetElemAttr(
+						resourceName,
+						"schedule.time_blocks.0.days.*",
+						"monday",
+					),
+				),
+			},
+			{
+				Config: testAccSensorUpdatePolicyResourceConfigLowercaseDays(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// import has no configuration, so it produces the canonical lowercase form
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_updated"},
+			},
+		},
+	})
+}
+
+func testAccSensorUpdatePolicyResourceConfigCapitalizedDays(rName string) string {
+	return acctest.ProviderConfig + fmt.Sprintf(`
+resource "crowdstrike_sensor_update_policy" "test" {
+  name          = %[1]q
+  description   = "made with terraform"
+  platform_name = "Windows"
+  build         = ""
+  schedule = {
+    enabled = true
+    timezone = "Etc/UTC"
+    time_blocks = [
+      {
+        days       = ["Monday", "Wednesday", "Friday"]
+        start_time = "09:00"
+        end_time   = "17:00"
+      }
+    ]
+  }
+}
+`, rName)
+}
+
+func testAccSensorUpdatePolicyResourceConfigLowercaseDays(rName string) string {
+	return acctest.ProviderConfig + fmt.Sprintf(`
+resource "crowdstrike_sensor_update_policy" "test" {
+  name          = %[1]q
+  description   = "made with terraform"
+  platform_name = "Windows"
+  build         = ""
+  schedule = {
+    enabled = true
+    timezone = "Etc/UTC"
+    time_blocks = [
+      {
+        days       = ["monday", "wednesday", "friday"]
+        start_time = "09:00"
+        end_time   = "17:00"
+      }
+    ]
+  }
+}
+`, rName)
+}
+
+// regression test for https://github.com/CrowdStrike/terraform-provider-crowdstrike/issues/200
+// duplicate day detection must be case-insensitive.
+func TestAccSensorUpdatePolicyResource_DuplicateDaysMixedCase(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderConfig + fmt.Sprintf(`
+resource "crowdstrike_sensor_update_policy" "test" {
+  name          = %[1]q
+  platform_name = "Windows"
+  build         = ""
+  schedule = {
+    enabled = true
+    timezone = "Etc/UTC"
+    time_blocks = [
+      {
+        days       = ["Monday"]
+        start_time = "09:00"
+        end_time   = "17:00"
+      },
+      {
+        days       = ["monday"]
+        start_time = "18:00"
+        end_time   = "20:00"
+      }
+    ]
+  }
+}
+`, rName),
+				ExpectError: regexp.MustCompile("(?i)Duplicate days in schedule"),
+			},
+		},
+	})
+}

--- a/internal/sensor_update_policy/shared.go
+++ b/internal/sensor_update_policy/shared.go
@@ -9,6 +9,7 @@ import (
 	"github.com/crowdstrike/gofalcon/falcon/client"
 	"github.com/crowdstrike/gofalcon/falcon/client/sensor_update_policies"
 	"github.com/crowdstrike/gofalcon/falcon/models"
+	fwtypes "github.com/crowdstrike/terraform-provider-crowdstrike/internal/framework/types"
 	hostgroups "github.com/crowdstrike/terraform-provider-crowdstrike/internal/host_groups"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/utils"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -144,10 +145,23 @@ type timeBlock struct {
 
 func (t timeBlock) AttributeTypes() map[string]attr.Type {
 	return map[string]attr.Type{
-		"days":       types.SetType{ElemType: types.StringType},
+		"days":       types.SetType{ElemType: fwtypes.CaseInsensitiveStringType{}},
 		"start_time": types.StringType,
 		"end_time":   types.StringType,
 	}
+}
+
+// flattenDays converts the day numbers used by the api into a set of day names.
+// The set uses fwtypes.CaseInsensitiveStringType so the casing a user configured
+// is preserved in state, since the api only returns day numbers.
+func flattenDays(ctx context.Context, days []int64) (types.Set, diag.Diagnostics) {
+	daysStr := make([]string, 0, len(days))
+
+	for _, d := range days {
+		daysStr = append(daysStr, int64ToDay[d])
+	}
+
+	return types.SetValueFrom(ctx, fwtypes.CaseInsensitiveStringType{}, daysStr)
 }
 
 // validTime checks if the start and end time are atleast 1 hour apart.


### PR DESCRIPTION
## Summary

Capitalized day names in `schedule.time_blocks.days` failed with `planned set element ... does not correlate with any element in actual`. The expand direction already lowercased day names for the API, but the flatten direction rebuilt them from a canonical lowercase map, discarding the casing the user wrote.

`days` now uses the `CaseInsensitiveStringType` custom type as its set element type, so the framework's semantic equality treats `Friday` and `friday` as equal and state keeps the configured casing. The change is applied to both resources and to the shared `timeBlock.AttributeTypes()`; the data source schema is updated for type consistency because it shares that map, and is a no-op at runtime. Duplicate day detection now lowercases its keys, so `Monday` and `monday` are still rejected as duplicates.

Known limitation: `terraform import` has no configuration to compare against, so it writes the canonical lowercase form. A following plan against a capitalized configuration shows a one time in place update that then converges.

Closes #200
