### PR TITLE
fix: improve 404 error messages in attachment resources

### DIFF
--- a/internal/fim/filevantage_policy_attachment.go
+++ b/internal/fim/filevantage_policy_attachment.go
@@ -11,6 +11,7 @@ import (
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/framework/flex"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/framework/validators"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/scopes"
+	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/tferrors"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -23,7 +24,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -38,6 +38,18 @@ var (
 	attachmentResourceMarkdownDescription string         = "This resource allows managing the host groups and rule groups attached to a FileVantage policy. By default (when `exclusive` is true), this resource takes exclusive ownership over the host groups and rule groups assigned to a FileVantage policy. When `exclusive` is false, this resource only manages the specific host groups and rule groups defined in the configuration. If you want to fully create or manage a FileVantage policy please use the `filevantage_policy` resource."
 	attachmentRequiredScopes              []scopes.Scope = apiScopesReadWrite
 )
+
+func newAttachmentPolicyNotFoundError(policyID string) diag.ErrorDiagnostic {
+	return diag.NewErrorDiagnostic(
+		"FileVantage Policy Not Found",
+		fmt.Sprintf(
+			"FileVantage policy with ID %q does not exist. "+
+				"This resource manages attachments to an existing policy and does not create a policy. "+
+				"Ensure the correct policy ID was provided or use the crowdstrike_filevantage_policy resource to create a policy.",
+			policyID,
+		),
+	)
+}
 
 func NewFilevantagePolicyAttachmentResource() resource.Resource {
 	return &filevantagePolicyAttachmentResource{}
@@ -249,8 +261,12 @@ func (r *filevantagePolicyAttachmentResource) Create(
 	}
 
 	policy, diags := getFilevantagePolicy(ctx, r.client, plan.ID.ValueString())
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
+	if diags.HasError() {
+		if tferrors.HasNotFoundError(diags) {
+			resp.Diagnostics.Append(newAttachmentPolicyNotFoundError(plan.ID.ValueString()))
+			return
+		}
+		resp.Diagnostics.Append(diags...)
 		return
 	}
 
@@ -294,8 +310,12 @@ func (r *filevantagePolicyAttachmentResource) Create(
 	}
 
 	policy, diags = getFilevantagePolicy(ctx, r.client, plan.ID.ValueString())
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
+	if diags.HasError() {
+		if tferrors.HasNotFoundError(diags) {
+			resp.Diagnostics.Append(newAttachmentPolicyNotFoundError(plan.ID.ValueString()))
+			return
+		}
+		resp.Diagnostics.Append(diags...)
 		return
 	}
 
@@ -316,20 +336,13 @@ func (r *filevantagePolicyAttachmentResource) Read(
 	}
 
 	policy, diags := getFilevantagePolicy(ctx, r.client, state.ID.ValueString())
-	for _, err := range diags.Errors() {
-		if err.Summary() == "Failed to get FileVantage policy" {
-			tflog.Warn(
-				ctx,
-				fmt.Sprintf("FileVantage policy %s not found, removing from state", state.ID),
-			)
-
+	if diags.HasError() {
+		if tferrors.HasNotFoundError(diags) {
+			resp.Diagnostics.Append(tferrors.NewResourceNotFoundWarningDiagnostic())
 			resp.State.RemoveResource(ctx)
 			return
 		}
-	}
-
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
+		resp.Diagnostics.Append(diags...)
 		return
 	}
 
@@ -367,8 +380,12 @@ func (r *filevantagePolicyAttachmentResource) Update(
 		}
 
 		policy, diags := getFilevantagePolicy(ctx, r.client, plan.ID.ValueString())
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
+		if diags.HasError() {
+			if tferrors.HasNotFoundError(diags) {
+				resp.Diagnostics.Append(newAttachmentPolicyNotFoundError(plan.ID.ValueString()))
+				return
+			}
+			resp.Diagnostics.Append(diags...)
 			return
 		}
 
@@ -432,8 +449,12 @@ func (r *filevantagePolicyAttachmentResource) Update(
 	}
 
 	policy, diags := getFilevantagePolicy(ctx, r.client, plan.ID.ValueString())
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
+	if diags.HasError() {
+		if tferrors.HasNotFoundError(diags) {
+			resp.Diagnostics.Append(newAttachmentPolicyNotFoundError(plan.ID.ValueString()))
+			return
+		}
+		resp.Diagnostics.Append(diags...)
 		return
 	}
 
@@ -498,18 +519,25 @@ func getFilevantagePolicy(
 		Ids:     []string{id},
 	})
 	if err != nil {
-		diags.AddError(
-			"Failed to get FileVantage policy",
-			fmt.Sprintf("Failed to get FileVantage policy (%s): %s", id, err),
+		diags.Append(
+			tferrors.NewDiagnosticFromAPIError(
+				tferrors.Read,
+				err,
+				attachmentRequiredScopes,
+				tferrors.WithNotFoundDetail(
+					fmt.Sprintf("No FileVantage policy with id: %s found.", id),
+				),
+			),
 		)
 
 		return nil, diags
 	}
 
-	if len(res.Payload.Resources) == 0 {
-		diags.AddError(
-			"Failed to get FileVantage policy",
-			fmt.Sprintf("FileVantage policy (%s) not found", id),
+	if res == nil || res.Payload == nil || len(res.Payload.Resources) == 0 {
+		diags.Append(
+			tferrors.NewNotFoundError(
+				fmt.Sprintf("No FileVantage policy with id: %s found.", id),
+			),
 		)
 
 		return nil, diags

--- a/internal/fim/filevantage_policy_attachment_test.go
+++ b/internal/fim/filevantage_policy_attachment_test.go
@@ -2,12 +2,52 @@ package fim_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/acctest"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
+
+func TestAccFilevantagePolicyAttachmentResource_policyNotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping acceptance test")
+	}
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck: func() {
+			acctest.PreCheck(t)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFilevantagePolicyAttachmentConfig_policyNotFound(rName),
+				ExpectError: regexp.MustCompile(
+					`FileVantage Policy Not Found[\s\S]*does\s+not\s+exist[\s\S]*crowdstrike_filevantage_policy`,
+				),
+			},
+		},
+	})
+}
+
+func testAccFilevantagePolicyAttachmentConfig_policyNotFound(rName string) string {
+	return acctest.ProviderConfig + fmt.Sprintf(`
+resource "crowdstrike_host_group" "test" {
+  name        = %[1]q
+  description = "test host group for attachment tests"
+  type        = "staticByID"
+  host_ids    = []
+}
+
+resource "crowdstrike_filevantage_policy_attachment" "test" {
+  id          = "00000000000000000000000000000000"
+  host_groups = [crowdstrike_host_group.test.id]
+}
+`, rName)
+}
 
 func TestAccFilevantagePolicyAttachmentResource_basic(t *testing.T) {
 	if testing.Short() {

--- a/internal/prevention_policy/errors.go
+++ b/internal/prevention_policy/errors.go
@@ -1,9 +1,12 @@
 package preventionpolicy
 
-import "github.com/hashicorp/terraform-plugin-framework/diag"
+import (
+	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/tferrors"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
 
-const notFoundErrorSummary = "Prevention Policy not found"
+const notFoundErrorSummary = tferrors.NotFoundErrorSummary
 
 func newNotFoundError(detail string) diag.ErrorDiagnostic {
-	return diag.NewErrorDiagnostic(notFoundErrorSummary, detail)
+	return tferrors.NewNotFoundError(detail)
 }

--- a/internal/prevention_policy/prevention_policy_attachment.go
+++ b/internal/prevention_policy/prevention_policy_attachment.go
@@ -12,6 +12,7 @@ import (
 	hostgroups "github.com/crowdstrike/terraform-provider-crowdstrike/internal/host_groups"
 	ioarulegroup "github.com/crowdstrike/terraform-provider-crowdstrike/internal/ioa_rule_group"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/scopes"
+	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/tferrors"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -24,7 +25,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -39,6 +39,18 @@ var (
 	resourceMarkdownDescription string         = "This resource allows managing the host groups and ioa rule groups attached to a prevention policy. By default (when `exclusive` is true), this resource takes exclusive ownership over the host groups and ioa rule groups assigned to a prevention policy. When `exclusive` is false, this resource only manages the specific host groups and ioa rule groups defined in the configuration. If you want to fully create or manage a prevention policy please use the `prevention_policy_*` resource for the platform you want to manage."
 	requiredScopes              []scopes.Scope = apiScopes
 )
+
+func newAttachmentPolicyNotFoundError(policyID string) diag.ErrorDiagnostic {
+	return diag.NewErrorDiagnostic(
+		"Prevention Policy Not Found",
+		fmt.Sprintf(
+			"Prevention policy with ID %q does not exist. "+
+				"This resource manages attachments to an existing policy and does not create a policy. "+
+				"Ensure the correct policy ID was provided or use the crowdstrike_prevention_policy_* resource for your platform to create a policy.",
+			policyID,
+		),
+	)
+}
 
 func NewPreventionPolicyAttachmentResource() resource.Resource {
 	return &preventionPolicyAttachmentResource{}
@@ -251,8 +263,12 @@ func (r *preventionPolicyAttachmentResource) Create(
 	}
 
 	policy, diags := getPreventionPolicy(ctx, r.client, plan.ID.ValueString())
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
+	if diags.HasError() {
+		if tferrors.HasNotFoundError(diags) {
+			resp.Diagnostics.Append(newAttachmentPolicyNotFoundError(plan.ID.ValueString()))
+			return
+		}
+		resp.Diagnostics.Append(diags...)
 		return
 	}
 
@@ -296,8 +312,12 @@ func (r *preventionPolicyAttachmentResource) Create(
 	}
 
 	policy, diags = getPreventionPolicy(ctx, r.client, plan.ID.ValueString())
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
+	if diags.HasError() {
+		if tferrors.HasNotFoundError(diags) {
+			resp.Diagnostics.Append(newAttachmentPolicyNotFoundError(plan.ID.ValueString()))
+			return
+		}
+		resp.Diagnostics.Append(diags...)
 		return
 	}
 
@@ -318,20 +338,13 @@ func (r *preventionPolicyAttachmentResource) Read(
 	}
 
 	policy, diags := getPreventionPolicy(ctx, r.client, state.ID.ValueString())
-	for _, err := range diags.Errors() {
-		if err.Summary() == notFoundErrorSummary {
-			tflog.Warn(
-				ctx,
-				fmt.Sprintf("prevention policy %s not found, removing from state", state.ID),
-			)
-
+	if diags.HasError() {
+		if tferrors.HasNotFoundError(diags) {
+			resp.Diagnostics.Append(tferrors.NewResourceNotFoundWarningDiagnostic())
 			resp.State.RemoveResource(ctx)
 			return
 		}
-	}
-
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
+		resp.Diagnostics.Append(diags...)
 		return
 	}
 
@@ -369,8 +382,12 @@ func (r *preventionPolicyAttachmentResource) Update(
 		}
 
 		policy, diags := getPreventionPolicy(ctx, r.client, plan.ID.ValueString())
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
+		if diags.HasError() {
+			if tferrors.HasNotFoundError(diags) {
+				resp.Diagnostics.Append(newAttachmentPolicyNotFoundError(plan.ID.ValueString()))
+				return
+			}
+			resp.Diagnostics.Append(diags...)
 			return
 		}
 
@@ -434,8 +451,12 @@ func (r *preventionPolicyAttachmentResource) Update(
 	}
 
 	policy, diags := getPreventionPolicy(ctx, r.client, plan.ID.ValueString())
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
+	if diags.HasError() {
+		if tferrors.HasNotFoundError(diags) {
+			resp.Diagnostics.Append(newAttachmentPolicyNotFoundError(plan.ID.ValueString()))
+			return
+		}
+		resp.Diagnostics.Append(diags...)
 		return
 	}
 

--- a/internal/prevention_policy/prevention_policy_attachment_test.go
+++ b/internal/prevention_policy/prevention_policy_attachment_test.go
@@ -3,12 +3,52 @@ package preventionpolicy_test
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/acctest"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
+
+func TestAccPreventionPolicyAttachmentResource_policyNotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping acceptance test")
+	}
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck: func() {
+			acctest.PreCheck(t)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPreventionPolicyAttachmentConfig_policyNotFound(rName),
+				ExpectError: regexp.MustCompile(
+					`Prevention Policy Not Found[\s\S]*does\s+not\s+exist[\s\S]*crowdstrike_prevention_policy_\*`,
+				),
+			},
+		},
+	})
+}
+
+func testAccPreventionPolicyAttachmentConfig_policyNotFound(rName string) string {
+	return acctest.ProviderConfig + fmt.Sprintf(`
+resource "crowdstrike_host_group" "test" {
+  name        = %[1]q
+  description = "test host group for attachment tests"
+  type        = "staticByID"
+  host_ids    = []
+}
+
+resource "crowdstrike_prevention_policy_attachment" "test" {
+  id          = "00000000000000000000000000000000"
+  host_groups = [crowdstrike_host_group.test.id]
+}
+`, rName)
+}
 
 func TestAccPreventionPolicyAttachmentResource_basic(t *testing.T) {
 	if testing.Short() {

--- a/internal/sensor_update_policy/errors.go
+++ b/internal/sensor_update_policy/errors.go
@@ -8,10 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 )
 
-const notFoundErrorSummary = "Sensor Update Policy not found"
-
 func newNotFoundError(detail string) diag.ErrorDiagnostic {
-	return diag.NewErrorDiagnostic(notFoundErrorSummary, detail)
+	return tferrors.NewNotFoundError(detail)
 }
 
 const invalidBuildPrefix = "invalid build"

--- a/internal/sensor_update_policy/sensor_update_policy_host_group_attachment.go
+++ b/internal/sensor_update_policy/sensor_update_policy_host_group_attachment.go
@@ -10,6 +10,7 @@ import (
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/framework/flex"
 	hostgroups "github.com/crowdstrike/terraform-provider-crowdstrike/internal/host_groups"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/scopes"
+	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/tferrors"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/utils"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -18,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -39,6 +39,18 @@ var (
 		},
 	}
 )
+
+func newAttachmentPolicyNotFoundError(policyID string) diag.ErrorDiagnostic {
+	return diag.NewErrorDiagnostic(
+		"Sensor Update Policy Not Found",
+		fmt.Sprintf(
+			"Sensor update policy with ID %q does not exist. "+
+				"This resource manages attachments to an existing policy and does not create a policy. "+
+				"Ensure the correct policy ID was provided or use the crowdstrike_sensor_update_policy resource to create a policy.",
+			policyID,
+		),
+	)
+}
 
 func NewSensorUpdatePolicyHostGroupAttachmentResource() resource.Resource {
 	return &sensorUpdatePolicyHostGroupAttachmentResource{}
@@ -191,8 +203,12 @@ func (r *sensorUpdatePolicyHostGroupAttachmentResource) Create(
 	}
 
 	policy, diags := getSensorUpdatePolicy(ctx, r.client, plan.ID.ValueString())
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
+	if diags.HasError() {
+		if tferrors.HasNotFoundError(diags) {
+			resp.Diagnostics.Append(newAttachmentPolicyNotFoundError(plan.ID.ValueString()))
+			return
+		}
+		resp.Diagnostics.Append(diags...)
 		return
 	}
 
@@ -218,8 +234,12 @@ func (r *sensorUpdatePolicyHostGroupAttachmentResource) Create(
 	}
 
 	policy, diags = getSensorUpdatePolicy(ctx, r.client, plan.ID.ValueString())
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
+	if diags.HasError() {
+		if tferrors.HasNotFoundError(diags) {
+			resp.Diagnostics.Append(newAttachmentPolicyNotFoundError(plan.ID.ValueString()))
+			return
+		}
+		resp.Diagnostics.Append(diags...)
 		return
 	}
 
@@ -240,19 +260,13 @@ func (r *sensorUpdatePolicyHostGroupAttachmentResource) Read(
 	}
 
 	policy, diags := getSensorUpdatePolicy(ctx, r.client, state.ID.ValueString())
-	for _, err := range diags.Errors() {
-		if err.Summary() == notFoundErrorSummary {
-			tflog.Warn(
-				ctx,
-				fmt.Sprintf("sensor update policy %s not found, removing from state", state.ID),
-			)
-
+	if diags.HasError() {
+		if tferrors.HasNotFoundError(diags) {
+			resp.Diagnostics.Append(tferrors.NewResourceNotFoundWarningDiagnostic())
 			resp.State.RemoveResource(ctx)
 			return
 		}
-	}
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
+		resp.Diagnostics.Append(diags...)
 		return
 	}
 
@@ -284,8 +298,12 @@ func (r *sensorUpdatePolicyHostGroupAttachmentResource) Update(
 		}
 
 		policy, diags := getSensorUpdatePolicy(ctx, r.client, plan.ID.ValueString())
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
+		if diags.HasError() {
+			if tferrors.HasNotFoundError(diags) {
+				resp.Diagnostics.Append(newAttachmentPolicyNotFoundError(plan.ID.ValueString()))
+				return
+			}
+			resp.Diagnostics.Append(diags...)
 			return
 		}
 
@@ -320,8 +338,12 @@ func (r *sensorUpdatePolicyHostGroupAttachmentResource) Update(
 	}
 
 	policy, diag := getSensorUpdatePolicy(ctx, r.client, plan.ID.ValueString())
-	resp.Diagnostics.Append(diag...)
-	if resp.Diagnostics.HasError() {
+	if diag.HasError() {
+		if tferrors.HasNotFoundError(diag) {
+			resp.Diagnostics.Append(newAttachmentPolicyNotFoundError(plan.ID.ValueString()))
+			return
+		}
+		resp.Diagnostics.Append(diag...)
 		return
 	}
 

--- a/internal/sensor_update_policy/sensor_update_policy_host_group_attachment_test.go
+++ b/internal/sensor_update_policy/sensor_update_policy_host_group_attachment_test.go
@@ -2,12 +2,52 @@ package sensorupdatepolicy_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/acctest"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
+
+func TestAccSensorUpdatePolicyHostGroupAttachmentResource_policyNotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping acceptance test")
+	}
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck: func() {
+			acctest.PreCheck(t)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSensorUpdatePolicyHostGroupAttachmentConfig_policyNotFound(rName),
+				ExpectError: regexp.MustCompile(
+					`Sensor Update Policy Not Found[\s\S]*does\s+not\s+exist[\s\S]*crowdstrike_sensor_update_policy`,
+				),
+			},
+		},
+	})
+}
+
+func testAccSensorUpdatePolicyHostGroupAttachmentConfig_policyNotFound(rName string) string {
+	return acctest.ProviderConfig + fmt.Sprintf(`
+resource "crowdstrike_host_group" "test" {
+  name        = %[1]q
+  description = "test host group for attachment tests"
+  type        = "staticByID"
+  host_ids    = []
+}
+
+resource "crowdstrike_sensor_update_policy_host_group_attachment" "test" {
+  id          = "00000000000000000000000000000000"
+  host_groups = [crowdstrike_host_group.test.id]
+}
+`, rName)
+}
 
 func TestAccSensorUpdatePolicyHostGroupAttachmentResource_basic(t *testing.T) {
 	if testing.Short() {

--- a/internal/sensor_visibility_exclusion/sensor_visibility_exclusion_attachment.go
+++ b/internal/sensor_visibility_exclusion/sensor_visibility_exclusion_attachment.go
@@ -40,6 +40,18 @@ var (
 	attachmentRequiredScopes              []scopes.Scope = apiScopes
 )
 
+func newAttachmentExclusionNotFoundError(exclusionID string) diag.ErrorDiagnostic {
+	return diag.NewErrorDiagnostic(
+		"Sensor Visibility Exclusion Not Found",
+		fmt.Sprintf(
+			"Sensor visibility exclusion with ID %q does not exist. "+
+				"This resource manages attachments to an existing exclusion and does not create an exclusion. "+
+				"Ensure the correct exclusion ID was provided or use the crowdstrike_sensor_visibility_exclusion resource to create an exclusion.",
+			exclusionID,
+		),
+	)
+}
+
 func NewSensorVisibilityExclusionAttachmentResource() resource.Resource {
 	return &sensorVisibilityExclusionAttachmentResource{}
 }
@@ -196,8 +208,12 @@ func (r *sensorVisibilityExclusionAttachmentResource) Create(
 	}
 
 	exclusion, diags := getSensorVisibilityExclusion(ctx, r.client, plan.ID.ValueString())
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
+	if diags.HasError() {
+		if tferrors.HasNotFoundError(diags) {
+			resp.Diagnostics.Append(newAttachmentExclusionNotFoundError(plan.ID.ValueString()))
+			return
+		}
+		resp.Diagnostics.Append(diags...)
 		return
 	}
 
@@ -223,8 +239,12 @@ func (r *sensorVisibilityExclusionAttachmentResource) Create(
 	}
 
 	exclusion, diags = getSensorVisibilityExclusion(ctx, r.client, plan.ID.ValueString())
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
+	if diags.HasError() {
+		if tferrors.HasNotFoundError(diags) {
+			resp.Diagnostics.Append(newAttachmentExclusionNotFoundError(plan.ID.ValueString()))
+			return
+		}
+		resp.Diagnostics.Append(diags...)
 		return
 	}
 
@@ -245,18 +265,13 @@ func (r *sensorVisibilityExclusionAttachmentResource) Read(
 	}
 
 	exclusion, diags := getSensorVisibilityExclusion(ctx, r.client, state.ID.ValueString())
-	if tferrors.HasNotFoundError(diags) {
-		tflog.Warn(
-			ctx,
-			fmt.Sprintf("sensor visibility exclusion %s not found, removing from state", state.ID),
-		)
-
-		resp.State.RemoveResource(ctx)
-		return
-	}
-
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
+	if diags.HasError() {
+		if tferrors.HasNotFoundError(diags) {
+			resp.Diagnostics.Append(tferrors.NewResourceNotFoundWarningDiagnostic())
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.Append(diags...)
 		return
 	}
 
@@ -282,8 +297,12 @@ func (r *sensorVisibilityExclusionAttachmentResource) Update(
 	planHostGroups := plan.HostGroups
 
 	exclusion, diags := getSensorVisibilityExclusion(ctx, r.client, plan.ID.ValueString())
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
+	if diags.HasError() {
+		if tferrors.HasNotFoundError(diags) {
+			resp.Diagnostics.Append(newAttachmentExclusionNotFoundError(plan.ID.ValueString()))
+			return
+		}
+		resp.Diagnostics.Append(diags...)
 		return
 	}
 
@@ -324,8 +343,12 @@ func (r *sensorVisibilityExclusionAttachmentResource) Update(
 	}
 
 	exclusion, diags = getSensorVisibilityExclusion(ctx, r.client, plan.ID.ValueString())
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
+	if diags.HasError() {
+		if tferrors.HasNotFoundError(diags) {
+			resp.Diagnostics.Append(newAttachmentExclusionNotFoundError(plan.ID.ValueString()))
+			return
+		}
+		resp.Diagnostics.Append(diags...)
 		return
 	}
 

--- a/internal/sensor_visibility_exclusion/sensor_visibility_exclusion_attachment_test.go
+++ b/internal/sensor_visibility_exclusion/sensor_visibility_exclusion_attachment_test.go
@@ -2,12 +2,52 @@ package sensorvisibilityexclusion_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/acctest"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
+
+func TestAccSensorVisibilityExclusionAttachmentResource_exclusionNotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping acceptance test")
+	}
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck: func() {
+			acctest.PreCheck(t)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSensorVisibilityExclusionAttachmentConfig_exclusionNotFound(rName),
+				ExpectError: regexp.MustCompile(
+					`Sensor Visibility Exclusion Not Found[\s\S]*does\s+not\s+exist[\s\S]*crowdstrike_sensor_visibility_exclusion`,
+				),
+			},
+		},
+	})
+}
+
+func testAccSensorVisibilityExclusionAttachmentConfig_exclusionNotFound(rName string) string {
+	return acctest.ProviderConfig + fmt.Sprintf(`
+resource "crowdstrike_host_group" "test" {
+  name        = %[1]q
+  description = "test host group for attachment tests"
+  type        = "staticByID"
+  host_ids    = []
+}
+
+resource "crowdstrike_sensor_visibility_exclusion_attachment" "test" {
+  id          = "00000000000000000000000000000000"
+  host_groups = [crowdstrike_host_group.test.id]
+}
+`, rName)
+}
 
 func TestAccSensorVisibilityExclusionAttachmentResource_basic(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
## Summary

Attachment resources pointed at a nonexistent policy returned a bare not found message with no indication that the resource attaches to an existing policy rather than creating one. This applies the pattern established in #240 to the remaining attachment resources: `filevantage_policy_attachment`, `prevention_policy_attachment`, `sensor_update_policy_host_group_attachment`, and `sensor_visibility_exclusion_attachment`.

Each now emits a specific summary plus a detail that names the missing ID and points at the resource used to create one.

Two changes reach beyond the attachment files and are worth a closer look. `getFilevantagePolicy` was rewritten to use the shared `tferrors` helpers and gained a nil response guard. `newNotFoundError` in the `prevention_policy` and `sensor_update_policy` packages now delegates to `tferrors.NewNotFoundError`, and those helpers are also consumed by non-attachment code in `windows.go`, `mac.go`, and `linux.go`.

Closes #241
