### PR TITLE
fix(firewall): preserve duplicate rules and match criteria

### DIFF
--- a/internal/firewall/rule_group_helpers.go
+++ b/internal/firewall/rule_group_helpers.go
@@ -198,7 +198,9 @@ func orderRulesByRuleIDs(
 	return ordered
 }
 
-// orderRulesByPlanNames orders API rules to match plan order.
+// orderRulesByPlanNames orders API rules to match plan order. Rule IDs are
+// preferred because Falcon permits duplicate names. Name matching is a FIFO
+// fallback for plans where computed IDs are not yet known.
 func orderRulesByPlanNames(
 	ctx context.Context,
 	apiRules []*models.FwmgrFirewallRuleV1,
@@ -215,11 +217,17 @@ func orderRulesByPlanNames(
 		return apiRules, diags
 	}
 
-	// Build a map of rule name to API rule
-	rulesByName := make(map[string]*models.FwmgrFirewallRuleV1)
+	rulesByID := make(map[string]*models.FwmgrFirewallRuleV1, len(apiRules))
+	rulesByName := make(map[string][]*models.FwmgrFirewallRuleV1)
 	for _, rule := range apiRules {
-		if rule != nil && rule.Name != nil {
-			rulesByName[*rule.Name] = rule
+		if rule == nil {
+			continue
+		}
+		if rule.ID != nil {
+			rulesByID[*rule.ID] = rule
+		}
+		if rule.Name != nil {
+			rulesByName[*rule.Name] = append(rulesByName[*rule.Name], rule)
 		}
 	}
 
@@ -232,20 +240,30 @@ func orderRulesByPlanNames(
 
 	// Build ordered slice matching plan order
 	ordered := make([]*models.FwmgrFirewallRuleV1, 0, len(planRuleModels))
+	seen := make(map[*models.FwmgrFirewallRuleV1]bool, len(apiRules))
 	for _, planRule := range planRuleModels {
-		name := planRule.Name.ValueString()
-		if rule, found := rulesByName[name]; found {
+		if utils.IsKnown(planRule.ID) {
+			if rule, found := rulesByID[planRule.ID.ValueString()]; found && !seen[rule] {
+				ordered = append(ordered, rule)
+				seen[rule] = true
+				continue
+			}
+		}
+
+		for _, rule := range rulesByName[planRule.Name.ValueString()] {
+			if seen[rule] {
+				continue
+			}
 			ordered = append(ordered, rule)
-			delete(rulesByName, name) // Remove to avoid duplicates
+			seen[rule] = true
+			break
 		}
 	}
 
 	// Append any remaining rules not in plan (shouldn't happen normally)
 	for _, rule := range apiRules {
-		if rule != nil && rule.Name != nil {
-			if _, stillExists := rulesByName[*rule.Name]; stillExists {
-				ordered = append(ordered, rule)
-			}
+		if rule != nil && !seen[rule] {
+			ordered = append(ordered, rule)
 		}
 	}
 
@@ -265,17 +283,25 @@ func wrapRules(
 		return types.ListNull(types.ObjectType{AttrTypes: firewallRuleModel{}.attrTypes()}), diags
 	}
 
-	// Build a map of plan rules by name to preserve values the API doesn't return
-	planRulesByName := make(map[string]firewallRuleModel)
+	// Preserve plan-only values by stable rule ID. Name queues are needed only
+	// for create plans where computed IDs are not known yet.
+	planRulesByID := make(map[string]int)
+	planRulesByName := make(map[string][]int)
+	var planRuleModels []firewallRuleModel
 	if utils.IsKnown(planRules) {
-		var planRuleModels []firewallRuleModel
 		diags.Append(planRules.ElementsAs(ctx, &planRuleModels, false)...)
 		if !diags.HasError() {
-			for _, pr := range planRuleModels {
-				planRulesByName[pr.Name.ValueString()] = pr
+			for i, pr := range planRuleModels {
+				if utils.IsKnown(pr.ID) {
+					planRulesByID[pr.ID.ValueString()] = i
+				}
+				name := pr.Name.ValueString()
+				planRulesByName[name] = append(planRulesByName[name], i)
 			}
 		}
 	}
+	planNameIndexes := make(map[string]int)
+	usedPlanIndexes := make(map[int]bool, len(planRuleModels))
 
 	rules := make([]firewallRuleModel, 0, len(apiRules))
 	for _, apiRule := range apiRules {
@@ -306,9 +332,24 @@ func wrapRules(
 		// Get plan rule for preserving values the API rewrites (address "*"
 		// sentinel and single-port end values).
 		var planRule *firewallRuleModel
-		if apiRule.Name != nil {
-			if pr, ok := planRulesByName[*apiRule.Name]; ok {
-				planRule = &pr
+		if apiRule.ID != nil {
+			if index, ok := planRulesByID[*apiRule.ID]; ok {
+				planRule = &planRuleModels[index]
+				usedPlanIndexes[index] = true
+			}
+		}
+		if planRule == nil && apiRule.Name != nil {
+			name := *apiRule.Name
+			candidates := planRulesByName[name]
+			for planNameIndexes[name] < len(candidates) {
+				candidateIndex := candidates[planNameIndexes[name]]
+				planNameIndexes[name]++
+				if usedPlanIndexes[candidateIndex] {
+					continue
+				}
+				planRule = &planRuleModels[candidateIndex]
+				usedPlanIndexes[candidateIndex] = true
+				break
 			}
 		}
 
@@ -723,24 +764,25 @@ func (r *firewallRuleGroupResource) buildDiffOperations(
 		}
 	}
 
-	// Build maps for state rules - by name to ID and by name to rule model
-	stateRulesByName := make(map[string]string)
-	stateRuleModelsByName := make(map[string]firewallRuleModel)
+	type existingRule struct {
+		familyID string
+		model    firewallRuleModel
+	}
+	stateRulesByID := make(map[string]existingRule)
+	stateRulesByName := make(map[string][]existingRule)
 	for i, rule := range stateRules {
 		if utils.IsKnown(rule.ID) && i < len(ruleGroup.RuleIds) {
-			stateRulesByName[rule.Name.ValueString()] = ruleGroup.RuleIds[i]
-			stateRuleModelsByName[rule.Name.ValueString()] = rule
+			existing := existingRule{familyID: ruleGroup.RuleIds[i], model: rule}
+			stateRulesByID[rule.ID.ValueString()] = existing
+			name := rule.Name.ValueString()
+			stateRulesByName[name] = append(stateRulesByName[name], existing)
 		}
 	}
-
-	// Build a map of rule ID to index for replace operations
-	ruleIDToIndex := make(map[string]int)
-	for i, id := range ruleGroup.RuleIds {
-		ruleIDToIndex[id] = i
-	}
+	stateNameIndexes := make(map[string]int)
 
 	// Track which existing rule IDs are still in use
 	usedRuleIDs := make(map[string]bool)
+	matchedRuleIDs := make(map[string]bool)
 
 	// Track rules that need to be added (new or modified)
 	type ruleToAdd struct {
@@ -753,10 +795,26 @@ func (r *firewallRuleGroupResource) buildDiffOperations(
 	tempIDCounter := 1
 	for _, planRule := range planRules {
 		ruleName := planRule.Name.ValueString()
-		if existingID, found := stateRulesByName[ruleName]; found {
+		existing, found := existingRule{}, false
+		if utils.IsKnown(planRule.ID) {
+			existing, found = stateRulesByID[planRule.ID.ValueString()]
+		}
+		if !found {
+			candidates := stateRulesByName[ruleName]
+			for stateNameIndexes[ruleName] < len(candidates) {
+				candidate := candidates[stateNameIndexes[ruleName]]
+				stateNameIndexes[ruleName]++
+				if matchedRuleIDs[candidate.familyID] {
+					continue
+				}
+				existing, found = candidate, true
+				break
+			}
+		}
+		if found {
+			matchedRuleIDs[existing.familyID] = true
 			// Existing rule - check if it has changed
-			stateRule := stateRuleModelsByName[ruleName]
-			if r.ruleHasChanged(planRule, stateRule) {
+			if r.ruleHasChanged(planRule, existing.model) {
 				// Rule properties changed - needs remove+add with temp_id
 				tempID := fmt.Sprintf("temp_id:%d", tempIDCounter)
 				tempIDCounter++
@@ -768,9 +826,9 @@ func (r *firewallRuleGroupResource) buildDiffOperations(
 				newRuleVersions = append(newRuleVersions, 0)
 			} else {
 				// Rule unchanged - keep existing ID
-				newRuleIDs = append(newRuleIDs, existingID)
+				newRuleIDs = append(newRuleIDs, existing.familyID)
 				newRuleVersions = append(newRuleVersions, 0)
-				usedRuleIDs[existingID] = true
+				usedRuleIDs[existing.familyID] = true
 			}
 		} else {
 			// New rule - add with temp_id
@@ -814,7 +872,7 @@ func (r *firewallRuleGroupResource) buildDiffOperations(
 // buildRulePayloadForDiff creates a rule payload map for JSON Patch add operations.
 func (r *firewallRuleGroupResource) buildRulePayloadForDiff(
 	rule firewallRuleModel,
-	_ string,
+	platform string,
 	tempID string,
 ) map[string]interface{} {
 	// Map protocol name to IANA number
@@ -835,6 +893,25 @@ func (r *firewallRuleGroupResource) buildRulePayloadForDiff(
 		// The API requires "log" but never returns it and the console has no
 		// control for it, so it is not part of the schema. Send a constant false.
 		"log": false,
+	}
+
+	fqdn := rule.Fqdn.ValueString()
+	payload["fqdn"] = fqdn
+	payload["fqdn_enabled"] = fqdn != ""
+
+	if protocol == protocolMapping["ICMPV4"] || protocol == protocolMapping["ICMPV6"] {
+		icmpType := rule.IcmpType.ValueString()
+		icmpCode := rule.IcmpCode.ValueString()
+		if icmpType == "" {
+			icmpType = "*"
+		}
+		if icmpCode == "" {
+			icmpCode = "*"
+		}
+		payload["icmp"] = map[string]interface{}{
+			"icmp_type": icmpType,
+			"icmp_code": icmpCode,
+		}
 	}
 
 	// Add local_address if specified
@@ -871,9 +948,13 @@ func (r *firewallRuleGroupResource) buildRulePayloadForDiff(
 	})
 
 	if !rule.ExecutablePath.IsNull() && rule.ExecutablePath.ValueString() != "" {
+		pathType := "windows_path"
+		if platform == "Mac" || platform == "Linux" {
+			pathType = "unix_path"
+		}
 		fields = append(fields, map[string]interface{}{
 			"name":  "image_name",
-			"type":  "windows_path",
+			"type":  pathType,
 			"value": rule.ExecutablePath.ValueString(),
 		})
 	}

--- a/internal/firewall/rule_group_helpers_test.go
+++ b/internal/firewall/rule_group_helpers_test.go
@@ -1,9 +1,12 @@
 package firewall
 
 import (
+	"context"
+	"reflect"
 	"testing"
 
 	"github.com/crowdstrike/gofalcon/falcon/models"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func fwRule(id, family, name string) *models.FwmgrFirewallRuleV1 {
@@ -14,12 +17,125 @@ func fwRule(id, family, name string) *models.FwmgrFirewallRuleV1 {
 	}
 }
 
+func tfRule(id, name string) firewallRuleModel {
+	return firewallRuleModel{
+		ID:              types.StringValue(id),
+		Name:            types.StringValue(name),
+		Description:     types.StringNull(),
+		Enabled:         types.BoolValue(true),
+		Action:          types.StringValue("DENY"),
+		Direction:       types.StringValue("OUT"),
+		Protocol:        types.StringValue("TCP"),
+		AddressFamily:   types.StringValue("IP4"),
+		LocalAddress:    types.ListNull(types.ObjectType{AttrTypes: addressRangeAttrTypes()}),
+		RemoteAddress:   types.ListNull(types.ObjectType{AttrTypes: addressRangeAttrTypes()}),
+		LocalPort:       types.ListNull(types.ObjectType{AttrTypes: portRangeAttrTypes()}),
+		RemotePort:      types.ListNull(types.ObjectType{AttrTypes: portRangeAttrTypes()}),
+		Fqdn:            types.StringNull(),
+		NetworkLocation: types.StringValue("ANY"),
+		ExecutablePath:  types.StringNull(),
+		ServiceName:     types.StringNull(),
+		IcmpType:        types.StringNull(),
+		IcmpCode:        types.StringNull(),
+		WatchMode:       types.BoolValue(false),
+	}
+}
+
+func tfRuleList(t *testing.T, rules []firewallRuleModel) types.List {
+	t.Helper()
+	list, diags := types.ListValueFrom(
+		context.Background(),
+		types.ObjectType{AttrTypes: firewallRuleModel{}.attrTypes()},
+		rules,
+	)
+	if diags.HasError() {
+		t.Fatalf("failed to create rule list: %v", diags)
+	}
+	return list
+}
+
 func ruleNames(rules []*models.FwmgrFirewallRuleV1) []string {
 	names := make([]string, 0, len(rules))
 	for _, r := range rules {
 		names = append(names, *r.Name)
 	}
 	return names
+}
+
+func TestOrderRulesByPlanNamesSupportsDuplicateNames(t *testing.T) {
+	apiRules := []*models.FwmgrFirewallRuleV1{
+		fwRule("rule-2", "family-2", "duplicate"),
+		fwRule("rule-1", "family-1", "duplicate"),
+	}
+	planRules := tfRuleList(t, []firewallRuleModel{
+		tfRule("rule-1", "duplicate"),
+		tfRule("rule-2", "duplicate"),
+	})
+
+	got, diags := orderRulesByPlanNames(context.Background(), apiRules, planRules)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if got[0] != apiRules[1] || got[1] != apiRules[0] {
+		t.Fatalf("expected duplicate names ordered by rule ID, got %v", ruleNames(got))
+	}
+}
+
+func TestBuildDiffOperationsSupportsDuplicateNames(t *testing.T) {
+	rules := []firewallRuleModel{
+		tfRule("rule-1", "duplicate"),
+		tfRule("rule-2", "duplicate"),
+	}
+	list := tfRuleList(t, rules)
+	model := firewallRuleGroupResourceModel{
+		ID:          types.StringValue("group-id"),
+		Name:        types.StringValue("group"),
+		Description: types.StringNull(),
+		Platform:    types.StringValue("Mac"),
+		Enabled:     types.BoolValue(true),
+		Rules:       list,
+	}
+	ruleGroup := &models.FwmgrAPIRuleGroupV1{RuleIds: []string{"family-1", "family-2"}}
+
+	diffs, ruleIDs, _, diags := (&firewallRuleGroupResource{}).buildDiffOperations(
+		context.Background(), model, model, ruleGroup,
+	)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if len(diffs) != 0 {
+		t.Fatalf("expected no diff operations, got %v", diffs)
+	}
+	if !reflect.DeepEqual(ruleIDs, ruleGroup.RuleIds) {
+		t.Fatalf("expected rule IDs %v, got %v", ruleGroup.RuleIds, ruleIDs)
+	}
+}
+
+func TestBuildRulePayloadForDiffPreservesMatchCriteria(t *testing.T) {
+	rule := tfRule("rule-1", "rule")
+	rule.Fqdn = types.StringValue("example.com")
+	rule.ExecutablePath = types.StringValue("/usr/bin/curl")
+
+	payload := (&firewallRuleGroupResource{}).buildRulePayloadForDiff(rule, "Mac", "temp_id:1")
+	if payload["fqdn"] != "example.com" || payload["fqdn_enabled"] != true {
+		t.Fatalf("expected FQDN criteria, got %v", payload)
+	}
+	fields := payload["fields"].([]map[string]interface{})
+	if fields[1]["type"] != "unix_path" {
+		t.Fatalf("expected macOS executable to use unix_path, got %v", fields[1])
+	}
+
+	rule.Protocol = types.StringValue("ICMPV4")
+	rule.Fqdn = types.StringNull()
+	rule.IcmpType = types.StringValue("8")
+	rule.IcmpCode = types.StringValue("0")
+	payload = (&firewallRuleGroupResource{}).buildRulePayloadForDiff(rule, "Mac", "temp_id:2")
+	if !reflect.DeepEqual(payload["icmp"], map[string]interface{}{
+		"icmp_type": "8",
+		"icmp_code": "0",
+	}) {
+		t.Fatalf("expected ICMP criteria, got %v", payload["icmp"])
+	}
 }
 
 func TestOrderRulesByRuleIDs(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix three firewall rule-group defects exposed while onboarding an existing Falcon tenant with duplicate rule names:

- correlate refreshed and updated rules by stable API rule ID, with ordered name queues only as a create-time fallback, so duplicate names are preserved instead of collapsing in maps
- include FQDN and ICMP criteria in remove-and-add replacement payloads
- use `unix_path` for macOS/Linux executable criteria during replacement, matching create behavior

## Why

Falcon permits duplicate firewall rule names. Provider 0.0.84 keyed read/update correlation by name, which could omit duplicated rules from refreshed state and associate multiple configured rules with one family ID after import. The replacement payload also omitted FQDN/ICMP criteria and always encoded executable paths as `windows_path`, risking broadened or ineffective rules when Write access is enabled.

## Validation

- `go test ./...`
- `go vet ./internal/firewall`
- `git diff --check`
- Added regression tests for duplicate-name ordering, duplicate-name no-op updates, FQDN/ICMP preservation, and macOS `unix_path`

Found during review of that import remains blocked until a provider release containing this fix produces a repeatable zero-change refresh plan.