### PR TITLE
fix(cloud_group): reject empty owners list at plan time

### DIFF
--- a/internal/cloud_group/cloud_group.go
+++ b/internal/cloud_group/cloud_group.go
@@ -500,6 +500,7 @@ func (r *cloudGroupResource) Schema(
 				Description: "Contact information for stakeholders responsible for the cloud group. List of email addresses.",
 				ElementType: types.StringType,
 				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
 					listvalidator.UniqueValues(),
 					listvalidator.NoNullValues(),
 					listvalidator.ValueStringsAre(

--- a/internal/cloud_group/cloud_group_test.go
+++ b/internal/cloud_group/cloud_group_test.go
@@ -292,6 +292,10 @@ func TestAccCloudSecurityGroupResource_Validation(t *testing.T) {
 			configFunc:  testAccCloudSecurityGroupResourceConfigInvalidOwnerEmail,
 			expectError: regexp.MustCompile("Invalid Attribute Value|must be a valid email address"),
 		},
+		"empty_owners": {
+			configFunc:  testAccCloudSecurityGroupResourceConfigEmptyOwners,
+			expectError: regexp.MustCompile("Invalid Attribute Value|list must contain at least 1 elements"),
+		},
 		"duplicate_registry": {
 			configFunc:  testAccCloudSecurityGroupResourceConfigDuplicateRegistry,
 			expectError: regexp.MustCompile("Found duplicate registry value"),
@@ -589,6 +593,19 @@ func testAccCloudSecurityGroupResourceConfigInvalidEnvironment(rName string) str
 resource "crowdstrike_cloud_group" "test" {
   name        = %[1]q
   environment = "invalid"
+
+  aws = {
+    account_ids = ["123456789012"]
+  }
+}
+`, rName)
+}
+
+func testAccCloudSecurityGroupResourceConfigEmptyOwners(rName string) string {
+	return acctest.ProviderConfig + fmt.Sprintf(`
+resource "crowdstrike_cloud_group" "test" {
+  name   = %[1]q
+  owners = []
 
   aws = {
     account_ids = ["123456789012"]


### PR DESCRIPTION
On `crowdstrike_cloud_group`, `owners = []` passed plan and then failed apply with "Provider produced inconsistent result after apply". It is now rejected at plan time, consistent with every other collection attribute on this resource.