### PR TITLE
feat(prevention_policy): add non-executable on-write settings

### DIFF
--- a/docs/resources/default_prevention_policy_linux.md
+++ b/docs/resources/default_prevention_policy_linux.md
@@ -61,6 +61,8 @@ resource "crowdstrike_default_prevention_policy_linux" "default" {
   tls_visibility                               = true
   sensor_tampering_protection                  = true
   on_write_script_file_visibility              = true
+  detect_non_executables_on_write              = true
+  quarantine_non_executables_on_write          = true
   memory_visibility                            = true
   extended_command_line_visibility             = true
   dbus_visibility                              = true
@@ -92,6 +94,7 @@ output "default_prevention_policy_linux" {
 - `custom_blocking` (Boolean) Whether to enable the setting. Block processes matching hashes that you add to IOC Management with the action set to "Block" or "Block, hide detection".
 - `dbus_visibility` (Boolean) Whether to enable the setting. Allows the sensor to monitor local D-Bus traffic for malicious patterns and improved detections.
 - `description` (String) Description of the prevention policy.
+- `detect_non_executables_on_write` (Boolean) Whether to enable the setting. Detect non-executable files, classified as malicious by CrowdStrike’s Intelligence analysts, when they are written to disk. Requires filesystem_visibility to be enabled.
 - `drift_prevention` (Boolean) Whether to enable the setting. Block new processes originating from files written in a container. This prevents a container from drifting from its immutable runtime state.
 - `email_protocol_visibility` (Boolean) Whether to enable the setting. Allows the sensor to monitor SMTP, IMAP, and POP3 traffic for malicious patterns and improved detections.
 - `enhance_environment_variable_visibility` (Boolean) Whether to enable the setting. Allows the sensor to monitor an extended set of changes to environment variables in order to enhance visibility.
@@ -107,6 +110,7 @@ output "default_prevention_policy_linux" {
 - `php_script_optimization` (Boolean) Whether to enable the setting. Mitigates high volume PHP script execution to only the first time it's seen by the server.
 - `prevent_suspicious_processes` (Boolean) Whether to enable the setting. Block processes that CrowdStrike analysts classify as suspicious. These are focused on dynamic IOAs, such as malware, exploits and other threats.
 - `quarantine` (Boolean) Whether to enable the setting. Quarantine executable files after they’re prevented by NGAV. When this is enabled, we recommend setting anti-malware prevention levels to Moderate or higher and not using other antivirus solutions.
+- `quarantine_non_executables_on_write` (Boolean) Whether to enable the setting. Quarantine non-executable files, classified as malicious by CrowdStrike’s Intelligence analysts, when they are written to disk. Requires detect_non_executables_on_write and quarantine to be enabled.
 - `retrospective_detections` (Boolean) Whether to enable the setting. Use of tagged binaries to automatically create detections for behaviors which occurred within a lookback period.
 - `script_based_execution_monitoring` (Boolean) Whether to enable the setting. Provides visibility into suspicious scripts, including shell and other scripting languages.
 - `sensor_anti_malware` (Attributes) For offline and online hosts, use sensor-based machine learning to identify and analyze unknown executables as they run to detect and prevent malware. (see [below for nested schema](#nestedatt--sensor_anti_malware))

--- a/docs/resources/default_prevention_policy_mac.md
+++ b/docs/resources/default_prevention_policy_mac.md
@@ -61,6 +61,8 @@ resource "crowdstrike_default_prevention_policy_mac" "default" {
   prevent_suspicious_processes                 = true
   quarantine                                   = true
   quarantine_on_write                          = true
+  detect_non_executables_on_write              = true
+  quarantine_non_executables_on_write          = true
   script_based_execution_monitoring            = true
   sensor_tampering_protection                  = true
   upload_unknown_executables                   = true
@@ -92,6 +94,7 @@ output "default_prevention_policy_mac" {
 - `cloud_anti_malware` (Attributes) Use cloud-based machine learning informed by global analysis of executables to detect and prevent known malware for your online hosts. (see [below for nested schema](#nestedatt--cloud_anti_malware))
 - `custom_blocking` (Boolean) Whether to enable the setting. Block processes matching hashes that you add to IOC Management with the action set to "Block" or "Block, hide detection".
 - `description` (String) Description of the prevention policy.
+- `detect_non_executables_on_write` (Boolean) Whether to enable the setting. Detect non-executable files, classified as malicious by CrowdStrike’s Intelligence analysts, when they are written to disk.
 - `detect_on_write` (Boolean) Whether to enable the setting. Use machine learning to analyze suspicious files when they're written to disk. To adjust detection sensitivity, change Anti-malware Detection levels in Sensor Machine Learning and Cloud Machine Learning.
 - `empyre_backdoor` (Boolean) Whether to enable the setting. A process with behaviors indicative of the Empyre Backdoor was terminated.
 - `enhanced_network_visibility` (Boolean) Whether to enable the setting. Provides enhanced visibility into network activities and detections.
@@ -101,6 +104,7 @@ output "default_prevention_policy_mac" {
 - `notify_end_users` (Boolean) Whether to enable the setting. Show a pop-up notification to the end user when the Falcon sensor blocks, kills, or quarantines. See these messages in Console.app by searching for Process: Falcon Notifications.
 - `prevent_suspicious_processes` (Boolean) Whether to enable the setting. Block processes that CrowdStrike analysts classify as suspicious. These are focused on dynamic IOAs, such as malware, exploits and other threats.
 - `quarantine` (Boolean) Whether to enable the setting. Quarantine executable files after they’re prevented by NGAV. When this is enabled, we recommend setting anti-malware prevention levels to Moderate or higher and not using other antivirus solutions.
+- `quarantine_non_executables_on_write` (Boolean) Whether to enable the setting. Quarantine non-executable files, classified as malicious by CrowdStrike’s Intelligence analysts, when they are written to disk. Requires detect_non_executables_on_write and quarantine to be enabled.
 - `quarantine_on_write` (Boolean) Whether to enable the setting. Use machine learning to quarantine suspicious files when they're written to disk. To adjust quarantine sensitivity, change Anti-malware Prevention levels in Sensor Machine Learning and Cloud Machine Learning.
 - `retrospective_detections` (Boolean) Whether to enable the setting. Use of tagged binaries to automatically create detections for behaviors which occurred within a lookback period.
 - `script_based_execution_monitoring` (Boolean) Whether to enable the setting. Provides visibility into suspicious scripts, including shell and other scripting languages.

--- a/docs/resources/default_prevention_policy_windows.md
+++ b/docs/resources/default_prevention_policy_windows.md
@@ -110,6 +110,8 @@ resource "crowdstrike_default_prevention_policy_windows" "default" {
   quarantine_and_security_center_registration    = true
   quarantine_on_removable_media                  = true
   quarantine_on_write                            = true
+  detect_non_executables_on_write                = true
+  quarantine_non_executables_on_write            = true
   script_based_execution_monitoring              = true
   sensor_tampering_protection                    = true
   suspicious_registry_operations                 = true
@@ -158,6 +160,7 @@ output "default_prevention_policy_windows" {
 - `cryptowall` (Boolean) Whether to enable the setting. A process associated with Cryptowall was blocked.
 - `custom_blocking` (Boolean) Whether to enable the setting. Block processes matching hashes that you add to IOC Management with the action set to "Block" or "Block, hide detection".
 - `description` (String) Description of the prevention policy.
+- `detect_non_executables_on_write` (Boolean) Whether to enable the setting. Detect non-executable files, classified as malicious by CrowdStrike’s Intelligence analysts, when they are written to disk.
 - `detect_on_write` (Boolean) Whether to enable the setting. Use machine learning to analyze suspicious files when they're written to disk. To adjust detection sensitivity, change Anti-malware Detection levels in Sensor Machine Learning and Cloud Machine Learning.
 - `drive_by_download` (Boolean) Whether to enable the setting. A suspicious file written by a browser attempted to execute and was blocked.
 - `driver_load_prevention` (Boolean) Whether to enable the setting. Block the loading of kernel drivers that CrowdStrike analysts have identified as malicious. Available on Windows 10 and Windows Server 2016 and later.
@@ -186,6 +189,7 @@ output "default_prevention_policy_windows" {
 - `on_write_script_file_visibility` (Boolean) Whether to enable the setting. Provides improved visibility into various script files being written to disk in addition to clouding a portion of their content.
 - `prevent_suspicious_processes` (Boolean) Whether to enable the setting. Block processes that CrowdStrike analysts classify as suspicious. These are focused on dynamic IOAs, such as malware, exploits and other threats.
 - `quarantine_and_security_center_registration` (Boolean) Whether to enable the setting. Quarantine executable files after they’re prevented by NGAV. When this is enabled, we recommend setting anti-malware prevention levels to Moderate or higher and not using other antivirus solutions. CrowdStrike Falcon registers with Windows Security Center, disabling Windows Defender.
+- `quarantine_non_executables_on_write` (Boolean) Whether to enable the setting. Quarantine non-executable files, classified as malicious by CrowdStrike’s Intelligence analysts, when they are written to disk. Requires detect_non_executables_on_write and quarantine_and_security_center_registration to be enabled.
 - `quarantine_on_removable_media` (Boolean) Whether to enable the setting. Quarantine executable files after they’re prevented by NGAV.
 - `quarantine_on_write` (Boolean) Whether to enable the setting. Use machine learning to quarantine suspicious files when they're written to disk. To adjust quarantine sensitivity, change Anti-malware Prevention levels in Sensor Machine Learning and Cloud Machine Learning.
 - `redact_http_detection_details` (Boolean) Whether to enable the setting. Remove certain information from HTTP Detection events, including URL, raw HTTP header and POST bodies if they were present. This does not affect the generation of HTTP Detections, only additional details that would be included and may include personal information (depending on the malware in question). When disabled, the information is used to improve the response to detection events. Has no effect unless HTTP Detections is also enabled.

--- a/docs/resources/prevention_policy_linux.md
+++ b/docs/resources/prevention_policy_linux.md
@@ -64,6 +64,8 @@ resource "crowdstrike_prevention_policy_linux" "example" {
   tls_visibility                               = true
   sensor_tampering_protection                  = true
   on_write_script_file_visibility              = true
+  detect_non_executables_on_write              = true
+  quarantine_non_executables_on_write          = true
   memory_visibility                            = true
   extended_command_line_visibility             = true
   dbus_visibility                              = true
@@ -97,6 +99,7 @@ output "prevention_policy_linux" {
 - `custom_blocking` (Boolean) Whether to enable the setting. Block processes matching hashes that you add to IOC Management with the action set to "Block" or "Block, hide detection".
 - `dbus_visibility` (Boolean) Whether to enable the setting. Allows the sensor to monitor local D-Bus traffic for malicious patterns and improved detections.
 - `description` (String) Description of the prevention policy.
+- `detect_non_executables_on_write` (Boolean) Whether to enable the setting. Detect non-executable files, classified as malicious by CrowdStrike’s Intelligence analysts, when they are written to disk. Requires filesystem_visibility to be enabled.
 - `drift_prevention` (Boolean) Whether to enable the setting. Block new processes originating from files written in a container. This prevents a container from drifting from its immutable runtime state.
 - `email_protocol_visibility` (Boolean) Whether to enable the setting. Allows the sensor to monitor SMTP, IMAP, and POP3 traffic for malicious patterns and improved detections.
 - `enabled` (Boolean) Enable the prevention policy.
@@ -113,6 +116,7 @@ output "prevention_policy_linux" {
 - `php_script_optimization` (Boolean) Whether to enable the setting. Mitigates high volume PHP script execution to only the first time it's seen by the server.
 - `prevent_suspicious_processes` (Boolean) Whether to enable the setting. Block processes that CrowdStrike analysts classify as suspicious. These are focused on dynamic IOAs, such as malware, exploits and other threats.
 - `quarantine` (Boolean) Whether to enable the setting. Quarantine executable files after they’re prevented by NGAV. When this is enabled, we recommend setting anti-malware prevention levels to Moderate or higher and not using other antivirus solutions.
+- `quarantine_non_executables_on_write` (Boolean) Whether to enable the setting. Quarantine non-executable files, classified as malicious by CrowdStrike’s Intelligence analysts, when they are written to disk. Requires detect_non_executables_on_write and quarantine to be enabled.
 - `retrospective_detections` (Boolean) Whether to enable the setting. Use of tagged binaries to automatically create detections for behaviors which occurred within a lookback period.
 - `script_based_execution_monitoring` (Boolean) Whether to enable the setting. Provides visibility into suspicious scripts, including shell and other scripting languages.
 - `sensor_anti_malware` (Attributes) For offline and online hosts, use sensor-based machine learning to identify and analyze unknown executables as they run to detect and prevent malware. (see [below for nested schema](#nestedatt--sensor_anti_malware))

--- a/docs/resources/prevention_policy_mac.md
+++ b/docs/resources/prevention_policy_mac.md
@@ -64,6 +64,8 @@ resource "crowdstrike_prevention_policy_mac" "example" {
   prevent_suspicious_processes                 = true
   quarantine                                   = true
   quarantine_on_write                          = true
+  detect_non_executables_on_write              = true
+  quarantine_non_executables_on_write          = true
   script_based_execution_monitoring            = true
   sensor_tampering_protection                  = true
   upload_unknown_executables                   = true
@@ -97,6 +99,7 @@ output "prevention_policy_mac" {
 - `cloud_anti_malware` (Attributes) Use cloud-based machine learning informed by global analysis of executables to detect and prevent known malware for your online hosts. (see [below for nested schema](#nestedatt--cloud_anti_malware))
 - `custom_blocking` (Boolean) Whether to enable the setting. Block processes matching hashes that you add to IOC Management with the action set to "Block" or "Block, hide detection".
 - `description` (String) Description of the prevention policy.
+- `detect_non_executables_on_write` (Boolean) Whether to enable the setting. Detect non-executable files, classified as malicious by CrowdStrike’s Intelligence analysts, when they are written to disk.
 - `detect_on_write` (Boolean) Whether to enable the setting. Use machine learning to analyze suspicious files when they're written to disk. To adjust detection sensitivity, change Anti-malware Detection levels in Sensor Machine Learning and Cloud Machine Learning.
 - `empyre_backdoor` (Boolean) Whether to enable the setting. A process with behaviors indicative of the Empyre Backdoor was terminated.
 - `enabled` (Boolean) Enable the prevention policy.
@@ -107,6 +110,7 @@ output "prevention_policy_mac" {
 - `notify_end_users` (Boolean) Whether to enable the setting. Show a pop-up notification to the end user when the Falcon sensor blocks, kills, or quarantines. See these messages in Console.app by searching for Process: Falcon Notifications.
 - `prevent_suspicious_processes` (Boolean) Whether to enable the setting. Block processes that CrowdStrike analysts classify as suspicious. These are focused on dynamic IOAs, such as malware, exploits and other threats.
 - `quarantine` (Boolean) Whether to enable the setting. Quarantine executable files after they’re prevented by NGAV. When this is enabled, we recommend setting anti-malware prevention levels to Moderate or higher and not using other antivirus solutions.
+- `quarantine_non_executables_on_write` (Boolean) Whether to enable the setting. Quarantine non-executable files, classified as malicious by CrowdStrike’s Intelligence analysts, when they are written to disk. Requires detect_non_executables_on_write and quarantine to be enabled.
 - `quarantine_on_write` (Boolean) Whether to enable the setting. Use machine learning to quarantine suspicious files when they're written to disk. To adjust quarantine sensitivity, change Anti-malware Prevention levels in Sensor Machine Learning and Cloud Machine Learning.
 - `retrospective_detections` (Boolean) Whether to enable the setting. Use of tagged binaries to automatically create detections for behaviors which occurred within a lookback period.
 - `script_based_execution_monitoring` (Boolean) Whether to enable the setting. Provides visibility into suspicious scripts, including shell and other scripting languages.

--- a/docs/resources/prevention_policy_windows.md
+++ b/docs/resources/prevention_policy_windows.md
@@ -116,6 +116,8 @@ resource "crowdstrike_prevention_policy_windows" "example" {
   quarantine_and_security_center_registration    = true
   quarantine_on_removable_media                  = true
   quarantine_on_write                            = true
+  detect_non_executables_on_write                = true
+  quarantine_non_executables_on_write            = true
   script_based_execution_monitoring              = true
   sensor_tampering_protection                    = true
   suspicious_registry_operations                 = true
@@ -166,6 +168,7 @@ output "prevention_policy_windows" {
 - `cryptowall` (Boolean) Whether to enable the setting. A process associated with Cryptowall was blocked.
 - `custom_blocking` (Boolean) Whether to enable the setting. Block processes matching hashes that you add to IOC Management with the action set to "Block" or "Block, hide detection".
 - `description` (String) Description of the prevention policy.
+- `detect_non_executables_on_write` (Boolean) Whether to enable the setting. Detect non-executable files, classified as malicious by CrowdStrike’s Intelligence analysts, when they are written to disk.
 - `detect_on_write` (Boolean) Whether to enable the setting. Use machine learning to analyze suspicious files when they're written to disk. To adjust detection sensitivity, change Anti-malware Detection levels in Sensor Machine Learning and Cloud Machine Learning.
 - `drive_by_download` (Boolean) Whether to enable the setting. A suspicious file written by a browser attempted to execute and was blocked.
 - `driver_load_prevention` (Boolean) Whether to enable the setting. Block the loading of kernel drivers that CrowdStrike analysts have identified as malicious. Available on Windows 10 and Windows Server 2016 and later.
@@ -195,6 +198,7 @@ output "prevention_policy_windows" {
 - `on_write_script_file_visibility` (Boolean) Whether to enable the setting. Provides improved visibility into various script files being written to disk in addition to clouding a portion of their content.
 - `prevent_suspicious_processes` (Boolean) Whether to enable the setting. Block processes that CrowdStrike analysts classify as suspicious. These are focused on dynamic IOAs, such as malware, exploits and other threats.
 - `quarantine_and_security_center_registration` (Boolean) Whether to enable the setting. Quarantine executable files after they’re prevented by NGAV. When this is enabled, we recommend setting anti-malware prevention levels to Moderate or higher and not using other antivirus solutions. CrowdStrike Falcon registers with Windows Security Center, disabling Windows Defender.
+- `quarantine_non_executables_on_write` (Boolean) Whether to enable the setting. Quarantine non-executable files, classified as malicious by CrowdStrike’s Intelligence analysts, when they are written to disk. Requires detect_non_executables_on_write and quarantine_and_security_center_registration to be enabled.
 - `quarantine_on_removable_media` (Boolean) Whether to enable the setting. Quarantine executable files after they’re prevented by NGAV.
 - `quarantine_on_write` (Boolean) Whether to enable the setting. Use machine learning to quarantine suspicious files when they're written to disk. To adjust quarantine sensitivity, change Anti-malware Prevention levels in Sensor Machine Learning and Cloud Machine Learning.
 - `redact_http_detection_details` (Boolean) Whether to enable the setting. Remove certain information from HTTP Detection events, including URL, raw HTTP header and POST bodies if they were present. This does not affect the generation of HTTP Detections, only additional details that would be included and may include personal information (depending on the malware in question). When disabled, the information is used to improve the response to detection events. Has no effect unless HTTP Detections is also enabled.

--- a/examples/resources/crowdstrike_default_prevention_policy_linux/resource.tf
+++ b/examples/resources/crowdstrike_default_prevention_policy_linux/resource.tf
@@ -37,6 +37,8 @@ resource "crowdstrike_default_prevention_policy_linux" "default" {
   tls_visibility                               = true
   sensor_tampering_protection                  = true
   on_write_script_file_visibility              = true
+  detect_non_executables_on_write              = true
+  quarantine_non_executables_on_write          = true
   memory_visibility                            = true
   extended_command_line_visibility             = true
   dbus_visibility                              = true

--- a/examples/resources/crowdstrike_default_prevention_policy_mac/resource.tf
+++ b/examples/resources/crowdstrike_default_prevention_policy_mac/resource.tf
@@ -37,6 +37,8 @@ resource "crowdstrike_default_prevention_policy_mac" "default" {
   prevent_suspicious_processes                 = true
   quarantine                                   = true
   quarantine_on_write                          = true
+  detect_non_executables_on_write              = true
+  quarantine_non_executables_on_write          = true
   script_based_execution_monitoring            = true
   sensor_tampering_protection                  = true
   upload_unknown_executables                   = true

--- a/examples/resources/crowdstrike_default_prevention_policy_windows/resource.tf
+++ b/examples/resources/crowdstrike_default_prevention_policy_windows/resource.tf
@@ -86,6 +86,8 @@ resource "crowdstrike_default_prevention_policy_windows" "default" {
   quarantine_and_security_center_registration    = true
   quarantine_on_removable_media                  = true
   quarantine_on_write                            = true
+  detect_non_executables_on_write                = true
+  quarantine_non_executables_on_write            = true
   script_based_execution_monitoring              = true
   sensor_tampering_protection                    = true
   suspicious_registry_operations                 = true

--- a/examples/resources/crowdstrike_prevention_policy_linux/resource.tf
+++ b/examples/resources/crowdstrike_prevention_policy_linux/resource.tf
@@ -40,6 +40,8 @@ resource "crowdstrike_prevention_policy_linux" "example" {
   tls_visibility                               = true
   sensor_tampering_protection                  = true
   on_write_script_file_visibility              = true
+  detect_non_executables_on_write              = true
+  quarantine_non_executables_on_write          = true
   memory_visibility                            = true
   extended_command_line_visibility             = true
   dbus_visibility                              = true

--- a/examples/resources/crowdstrike_prevention_policy_mac/resource.tf
+++ b/examples/resources/crowdstrike_prevention_policy_mac/resource.tf
@@ -40,6 +40,8 @@ resource "crowdstrike_prevention_policy_mac" "example" {
   prevent_suspicious_processes                 = true
   quarantine                                   = true
   quarantine_on_write                          = true
+  detect_non_executables_on_write              = true
+  quarantine_non_executables_on_write          = true
   script_based_execution_monitoring            = true
   sensor_tampering_protection                  = true
   upload_unknown_executables                   = true

--- a/examples/resources/crowdstrike_prevention_policy_windows/resource.tf
+++ b/examples/resources/crowdstrike_prevention_policy_windows/resource.tf
@@ -92,6 +92,8 @@ resource "crowdstrike_prevention_policy_windows" "example" {
   quarantine_and_security_center_registration    = true
   quarantine_on_removable_media                  = true
   quarantine_on_write                            = true
+  detect_non_executables_on_write                = true
+  quarantine_non_executables_on_write            = true
   script_based_execution_monitoring              = true
   sensor_tampering_protection                    = true
   suspicious_registry_operations                 = true

--- a/internal/prevention_policy/default_linux_policy.go
+++ b/internal/prevention_policy/default_linux_policy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/crowdstrike/gofalcon/falcon/models"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/config"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/framework/flex"
+	fwvalidators "github.com/crowdstrike/terraform-provider-crowdstrike/internal/framework/validators"
 	ioarulegroup "github.com/crowdstrike/terraform-provider-crowdstrike/internal/ioa_rule_group"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/utils"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -57,6 +58,8 @@ type defaultPreventionPolicyLinuxResourceModel struct {
 	SensorTamperingProtection            types.Bool   `tfsdk:"sensor_tampering_protection"`
 	MemoryVisibility                     types.Bool   `tfsdk:"memory_visibility"`
 	OnWriteScriptFileVisibility          types.Bool   `tfsdk:"on_write_script_file_visibility"`
+	DetectPackageOnWrite                 types.Bool   `tfsdk:"detect_non_executables_on_write"`
+	QuarantinePackageOnWrite             types.Bool   `tfsdk:"quarantine_non_executables_on_write"`
 	ExtendedCommandLineVisibility        types.Bool   `tfsdk:"extended_command_line_visibility"`
 	DBusVisibility                       types.Bool   `tfsdk:"dbus_visibility"`
 	EnhancePHPVisibility                 types.Bool   `tfsdk:"enhance_php_visibility"`
@@ -109,6 +112,8 @@ func (m *defaultPreventionPolicyLinuxResourceModel) generatePreventionSettings(c
 		"SensorTamperingProtection":            m.SensorTamperingProtection,
 		"MemoryVisibility":                     m.MemoryVisibility,
 		"OnWriteScriptFileVisibility":          m.OnWriteScriptFileVisibility,
+		"DetectPackageOnWrite":                 m.DetectPackageOnWrite,
+		"QuarantinePackageOnWrite":             m.QuarantinePackageOnWrite,
 		"ExtendedCommandLineVisibility":        m.ExtendedCommandLineVisibility,
 		"DBusVisibility":                       m.DBusVisibility,
 		"EnhancePHPVisibility":                 m.EnhancePHPVisibility,
@@ -200,6 +205,8 @@ func (m *defaultPreventionPolicyLinuxResourceModel) assignPreventionSettings(
 	m.OnWriteScriptFileVisibility = defaultBoolFalse(
 		toggleSettings["OnWriteScriptFileVisibility"],
 	)
+	m.DetectPackageOnWrite = defaultBoolFalse(toggleSettings["DetectPackageOnWrite"])
+	m.QuarantinePackageOnWrite = defaultBoolFalse(toggleSettings["QuarantinePackageOnWrite"])
 	m.ExtendedCommandLineVisibility = defaultBoolFalse(
 		toggleSettings["ExtendedCommandLineVisibility"],
 	)
@@ -437,6 +444,30 @@ func (r *defaultPreventionPolicyLinuxResource) ValidateConfig(
 	}
 
 	resp.Diagnostics.Append(utils.ValidateEmptyIDs(ctx, config.RuleGroups, "ioa_rule_groups")...)
+
+	resp.Diagnostics.Append(
+		fwvalidators.BoolRequiresBool(
+			config.DetectPackageOnWrite,
+			config.FilesystemVisibility,
+			"detect_non_executables_on_write",
+			"filesystem_visibility",
+		)...)
+
+	resp.Diagnostics.Append(
+		fwvalidators.BoolRequiresBool(
+			config.QuarantinePackageOnWrite,
+			config.DetectPackageOnWrite,
+			"quarantine_non_executables_on_write",
+			"detect_non_executables_on_write",
+		)...)
+
+	resp.Diagnostics.Append(
+		fwvalidators.BoolRequiresBool(
+			config.QuarantinePackageOnWrite,
+			config.NextGenAV,
+			"quarantine_non_executables_on_write",
+			"quarantine",
+		)...)
 
 	if utils.IsKnown(config.CloudAntiMalware) {
 		var slider mlSlider

--- a/internal/prevention_policy/default_mac_policy.go
+++ b/internal/prevention_policy/default_mac_policy.go
@@ -49,6 +49,8 @@ type defaultPreventionPolicyMacResourceModel struct {
 	ScriptBasedExecutionMonitoring     types.Bool   `tfsdk:"script_based_execution_monitoring"`
 	DetectOnWrite                      types.Bool   `tfsdk:"detect_on_write"`
 	QuarantineOnWrite                  types.Bool   `tfsdk:"quarantine_on_write"`
+	DetectPackageOnWrite               types.Bool   `tfsdk:"detect_non_executables_on_write"`
+	QuarantinePackageOnWrite           types.Bool   `tfsdk:"quarantine_non_executables_on_write"`
 	NextGenAV                          types.Bool   `tfsdk:"quarantine"`
 	CustomBlacklisting                 types.Bool   `tfsdk:"custom_blocking"`
 	PreventSuspiciousProcesses         types.Bool   `tfsdk:"prevent_suspicious_processes"`
@@ -95,6 +97,8 @@ func (m *defaultPreventionPolicyMacResourceModel) generatePreventionSettings(ctx
 		"ScriptBasedExecutionMonitoring":     m.ScriptBasedExecutionMonitoring,
 		"DetectOnWrite":                      m.DetectOnWrite,
 		"QuarantineOnWrite":                  m.QuarantineOnWrite,
+		"DetectPackageOnWrite":               m.DetectPackageOnWrite,
+		"QuarantinePackageOnWrite":           m.QuarantinePackageOnWrite,
 		"NextGenAV":                          m.NextGenAV,
 		"CustomBlacklisting":                 m.CustomBlacklisting,
 		"PreventSuspiciousProcesses":         m.PreventSuspiciousProcesses,
@@ -195,6 +199,8 @@ func (m *defaultPreventionPolicyMacResourceModel) assignPreventionSettings(
 	)
 	m.DetectOnWrite = defaultBoolFalse(toggleSettings["DetectOnWrite"])
 	m.QuarantineOnWrite = defaultBoolFalse(toggleSettings["QuarantineOnWrite"])
+	m.DetectPackageOnWrite = defaultBoolFalse(toggleSettings["DetectPackageOnWrite"])
+	m.QuarantinePackageOnWrite = defaultBoolFalse(toggleSettings["QuarantinePackageOnWrite"])
 	m.NextGenAV = defaultBoolFalse(toggleSettings["NextGenAV"])
 	m.CustomBlacklisting = defaultBoolFalse(toggleSettings["CustomBlacklisting"])
 	m.PreventSuspiciousProcesses = defaultBoolFalse(
@@ -463,6 +469,22 @@ func (r *defaultPreventionPolicyMacResource) ValidateConfig(
 			config.DetectOnWrite,
 			"quarantine_on_write",
 			"detect_on_write",
+		)...)
+
+	resp.Diagnostics.Append(
+		fwvalidators.BoolRequiresBool(
+			config.QuarantinePackageOnWrite,
+			config.DetectPackageOnWrite,
+			"quarantine_non_executables_on_write",
+			"detect_non_executables_on_write",
+		)...)
+
+	resp.Diagnostics.Append(
+		fwvalidators.BoolRequiresBool(
+			config.QuarantinePackageOnWrite,
+			config.NextGenAV,
+			"quarantine_non_executables_on_write",
+			"quarantine",
 		)...)
 
 	if utils.IsKnown(config.CloudAntiMalware) {

--- a/internal/prevention_policy/default_windows_policy.go
+++ b/internal/prevention_policy/default_windows_policy.go
@@ -69,6 +69,8 @@ type defaultPreventionPolicyWindowsResourceModel struct {
 	USBInsertionTriggeredScan                  types.Bool   `tfsdk:"usb_insertion_triggered_scan"`
 	DetectOnWrite                              types.Bool   `tfsdk:"detect_on_write"`
 	QuarantineOnWrite                          types.Bool   `tfsdk:"quarantine_on_write"`
+	DetectPackageOnWrite                       types.Bool   `tfsdk:"detect_non_executables_on_write"`
+	QuarantinePackageOnWrite                   types.Bool   `tfsdk:"quarantine_non_executables_on_write"`
 	OnWriteScriptFileVisibility                types.Bool   `tfsdk:"on_write_script_file_visibility"`
 	NextGenAV                                  types.Bool   `tfsdk:"quarantine_and_security_center_registration"`
 	NextGenAVQuarantineOnRemovableMedia        types.Bool   `tfsdk:"quarantine_on_removable_media"`
@@ -151,6 +153,8 @@ func (m *defaultPreventionPolicyWindowsResourceModel) generatePreventionSettings
 		"USBInsertionTriggeredScan":                 m.USBInsertionTriggeredScan,
 		"DetectOnWrite":                             m.DetectOnWrite,
 		"QuarantineOnWrite":                         m.QuarantineOnWrite,
+		"DetectPackageOnWrite":                      m.DetectPackageOnWrite,
+		"QuarantinePackageOnWrite":                  m.QuarantinePackageOnWrite,
 		"OnWriteScriptFileVisibility":               m.OnWriteScriptFileVisibility,
 		"NextGenAV":                                 m.NextGenAV,
 		"NextGenAVQuarantineOnRemovableMedia":       m.NextGenAVQuarantineOnRemovableMedia,
@@ -358,6 +362,8 @@ func (m *defaultPreventionPolicyWindowsResourceModel) assignPreventionSettings(
 	m.USBInsertionTriggeredScan = defaultBoolFalse(toggleSettings["USBInsertionTriggeredScan"])
 	m.DetectOnWrite = defaultBoolFalse(toggleSettings["DetectOnWrite"])
 	m.QuarantineOnWrite = defaultBoolFalse(toggleSettings["QuarantineOnWrite"])
+	m.DetectPackageOnWrite = defaultBoolFalse(toggleSettings["DetectPackageOnWrite"])
+	m.QuarantinePackageOnWrite = defaultBoolFalse(toggleSettings["QuarantinePackageOnWrite"])
 	m.OnWriteScriptFileVisibility = defaultBoolFalse(
 		toggleSettings["OnWriteScriptFileVisibility"],
 	)
@@ -808,6 +814,22 @@ func (r *defaultPreventionPolicyWindowsResource) ValidateConfig(
 			config.DetectOnWrite,
 			"quarantine_on_write",
 			"detect_on_write",
+		)...)
+
+	resp.Diagnostics.Append(
+		fwvalidators.BoolRequiresBool(
+			config.QuarantinePackageOnWrite,
+			config.DetectPackageOnWrite,
+			"quarantine_non_executables_on_write",
+			"detect_non_executables_on_write",
+		)...)
+
+	resp.Diagnostics.Append(
+		fwvalidators.BoolRequiresBool(
+			config.QuarantinePackageOnWrite,
+			config.NextGenAV,
+			"quarantine_non_executables_on_write",
+			"quarantine_and_security_center_registration",
 		)...)
 
 	resp.Diagnostics.Append(

--- a/internal/prevention_policy/default_windows_policy_test.go
+++ b/internal/prevention_policy/default_windows_policy_test.go
@@ -25,6 +25,19 @@ resource "crowdstrike_default_prevention_policy_windows" "test" {
 }`
 }
 
+// testAccDefaultPreventionPolicyWindowsConfig_nonExecutablesOnWriteError builds
+// configs that fail validation at plan time, so they are never applied to the
+// tenant's real default policy.
+func testAccDefaultPreventionPolicyWindowsConfig_nonExecutablesOnWriteError(
+	toggles string,
+) string {
+	return acctest.ProviderConfig + fmt.Sprintf(`
+resource "crowdstrike_default_prevention_policy_windows" "test" {
+  ioa_rule_groups = []
+%s
+}`, toggles)
+}
+
 func testAccDefaultPreventionPolicyWindowsConfig_basic() string {
 	return acctest.ProviderConfig + `
 resource "crowdstrike_default_prevention_policy_windows" "test" {
@@ -36,6 +49,7 @@ resource "crowdstrike_default_prevention_policy_windows" "test" {
   wsl2_visibility                        = true
   suspicious_file_analysis               = true
   retrospective_detections               = true
+  detect_non_executables_on_write        = true
 
   cloud_anti_malware_microsoft_office_files = {
     detection  = "MODERATE"
@@ -66,6 +80,7 @@ resource "crowdstrike_default_prevention_policy_windows" "test" {
   wsl2_visibility                        = false
   suspicious_file_analysis               = false
   retrospective_detections               = false
+  detect_non_executables_on_write        = false
 
   cloud_anti_malware_microsoft_office_files = {
     detection  = "MODERATE"
@@ -94,6 +109,7 @@ resource "crowdstrike_default_prevention_policy_windows" "test" {
   wsl2_visibility                        = true
   suspicious_file_analysis               = true
   retrospective_detections               = true
+  detect_non_executables_on_write        = true
 
   cloud_anti_malware_microsoft_office_files = {
     detection  = "MODERATE"
@@ -202,6 +218,40 @@ func TestAccDefaultPreventionPolicyWindowsResource_validationError(t *testing.T)
 	})
 }
 
+func TestAccDefaultPreventionPolicyWindowsResource_nonExecutablesOnWriteValidationError(
+	t *testing.T,
+) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0"))),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDefaultPreventionPolicyWindowsConfig_nonExecutablesOnWriteError(`
+  quarantine_non_executables_on_write         = true
+  detect_non_executables_on_write             = false
+  quarantine_and_security_center_registration = true
+`),
+				ExpectError: regexp.MustCompile(
+					"quarantine_non_executables_on_write requires detect_non_executables_on_write",
+				),
+			},
+			{
+				Config: testAccDefaultPreventionPolicyWindowsConfig_nonExecutablesOnWriteError(`
+  quarantine_non_executables_on_write         = true
+  detect_non_executables_on_write             = true
+  quarantine_and_security_center_registration = false
+`),
+				ExpectError: regexp.MustCompile(
+					"quarantine_non_executables_on_write requires quarantine_and_security_center_registration",
+				),
+			},
+		},
+	})
+}
+
 // regression test for https://github.com/CrowdStrike/terraform-provider-crowdstrike/issues/149
 func TestAccDefaultPreventionPolicyWindowsResource_descriptionRemoval(t *testing.T) {
 	resourceName := "crowdstrike_default_prevention_policy_windows.test"
@@ -285,6 +335,11 @@ func TestAccDefaultPreventionPolicyWindowsResource(t *testing.T) {
 					),
 					resource.TestCheckResourceAttr(
 						resourceName,
+						"detect_non_executables_on_write",
+						"true",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
 						"cloud_anti_malware_microsoft_office_files.detection",
 						"MODERATE",
 					),
@@ -361,6 +416,11 @@ func TestAccDefaultPreventionPolicyWindowsResource(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						resourceName,
 						"retrospective_detections",
+						"false",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"detect_non_executables_on_write",
 						"false",
 					),
 					resource.TestCheckResourceAttr(

--- a/internal/prevention_policy/linux.go
+++ b/internal/prevention_policy/linux.go
@@ -9,6 +9,7 @@ import (
 	"github.com/crowdstrike/gofalcon/falcon/models"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/config"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/framework/flex"
+	fwvalidators "github.com/crowdstrike/terraform-provider-crowdstrike/internal/framework/validators"
 	hostgroups "github.com/crowdstrike/terraform-provider-crowdstrike/internal/host_groups"
 	ioarulegroup "github.com/crowdstrike/terraform-provider-crowdstrike/internal/ioa_rule_group"
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/utils"
@@ -65,6 +66,8 @@ type preventionPolicyLinuxResourceModel struct {
 	SensorTamperingProtection            types.Bool   `tfsdk:"sensor_tampering_protection"`
 	MemoryVisibility                     types.Bool   `tfsdk:"memory_visibility"`
 	OnWriteScriptFileVisibility          types.Bool   `tfsdk:"on_write_script_file_visibility"`
+	DetectPackageOnWrite                 types.Bool   `tfsdk:"detect_non_executables_on_write"`
+	QuarantinePackageOnWrite             types.Bool   `tfsdk:"quarantine_non_executables_on_write"`
 	ExtendedCommandLineVisibility        types.Bool   `tfsdk:"extended_command_line_visibility"`
 	DBusVisibility                       types.Bool   `tfsdk:"dbus_visibility"`
 	EnhancePHPVisibility                 types.Bool   `tfsdk:"enhance_php_visibility"`
@@ -420,6 +423,30 @@ func (r *preventionPolicyLinuxResource) ValidateConfig(
 	resp.Diagnostics.Append(utils.ValidateEmptyIDs(ctx, config.HostGroups, "host_groups")...)
 	resp.Diagnostics.Append(utils.ValidateEmptyIDs(ctx, config.RuleGroups, "ioa_rule_groups")...)
 
+	resp.Diagnostics.Append(
+		fwvalidators.BoolRequiresBool(
+			config.DetectPackageOnWrite,
+			config.FilesystemVisibility,
+			"detect_non_executables_on_write",
+			"filesystem_visibility",
+		)...)
+
+	resp.Diagnostics.Append(
+		fwvalidators.BoolRequiresBool(
+			config.QuarantinePackageOnWrite,
+			config.DetectPackageOnWrite,
+			"quarantine_non_executables_on_write",
+			"detect_non_executables_on_write",
+		)...)
+
+	resp.Diagnostics.Append(
+		fwvalidators.BoolRequiresBool(
+			config.QuarantinePackageOnWrite,
+			config.NextGenAV,
+			"quarantine_non_executables_on_write",
+			"quarantine",
+		)...)
+
 	if utils.IsKnown(config.CloudAntiMalware) {
 		var slider mlSlider
 		if diagsSlider := config.CloudAntiMalware.As(ctx, &slider, basetypes.ObjectAsOptions{}); !diagsSlider.HasError() {
@@ -501,6 +528,8 @@ func (r *preventionPolicyLinuxResource) assignPreventionSettings(
 	state.OnWriteScriptFileVisibility = defaultBoolFalse(
 		toggleSettings["OnWriteScriptFileVisibility"],
 	)
+	state.DetectPackageOnWrite = defaultBoolFalse(toggleSettings["DetectPackageOnWrite"])
+	state.QuarantinePackageOnWrite = defaultBoolFalse(toggleSettings["QuarantinePackageOnWrite"])
 	state.ExtendedCommandLineVisibility = defaultBoolFalse(
 		toggleSettings["ExtendedCommandLineVisibility"],
 	)
@@ -565,6 +594,8 @@ func (r *preventionPolicyLinuxResource) generatePreventionSettings(
 		"SensorTamperingProtection":            config.SensorTamperingProtection,
 		"MemoryVisibility":                     config.MemoryVisibility,
 		"OnWriteScriptFileVisibility":          config.OnWriteScriptFileVisibility,
+		"DetectPackageOnWrite":                 config.DetectPackageOnWrite,
+		"QuarantinePackageOnWrite":             config.QuarantinePackageOnWrite,
 		"ExtendedCommandLineVisibility":        config.ExtendedCommandLineVisibility,
 		"DBusVisibility":                       config.DBusVisibility,
 		"EnhancePHPVisibility":                 config.EnhancePHPVisibility,

--- a/internal/prevention_policy/linux_test.go
+++ b/internal/prevention_policy/linux_test.go
@@ -76,6 +76,8 @@ func TestAccPreventionPolicyLinux_update(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("sensor_tampering_protection"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory_visibility"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("on_write_script_file_visibility"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("detect_non_executables_on_write"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("quarantine_non_executables_on_write"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("extended_command_line_visibility"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("dbus_visibility"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enhance_php_visibility"), knownvalue.Bool(false)),
@@ -119,6 +121,8 @@ func TestAccPreventionPolicyLinux_update(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("sensor_tampering_protection"), knownvalue.Bool(true)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory_visibility"), knownvalue.Bool(true)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("on_write_script_file_visibility"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("detect_non_executables_on_write"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("quarantine_non_executables_on_write"), knownvalue.Bool(true)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("extended_command_line_visibility"), knownvalue.Bool(true)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("dbus_visibility"), knownvalue.Bool(true)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enhance_php_visibility"), knownvalue.Bool(true)),
@@ -162,6 +166,8 @@ func TestAccPreventionPolicyLinux_update(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("sensor_tampering_protection"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory_visibility"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("on_write_script_file_visibility"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("detect_non_executables_on_write"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("quarantine_non_executables_on_write"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("extended_command_line_visibility"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("dbus_visibility"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enhance_php_visibility"), knownvalue.Bool(false)),
@@ -203,6 +209,48 @@ func TestAccPreventionPolicyLinux_validationError(t *testing.T) {
 	})
 }
 
+func TestAccPreventionPolicyLinux_nonExecutablesOnWriteValidationError(t *testing.T) {
+	rName := acctest.RandomResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPreventionPolicyLinuxConfig_nonExecutablesOnWrite(rName, `
+  detect_non_executables_on_write = true
+  filesystem_visibility           = false
+`),
+				ExpectError: regexp.MustCompile(
+					"detect_non_executables_on_write requires filesystem_visibility",
+				),
+			},
+			{
+				Config: testAccPreventionPolicyLinuxConfig_nonExecutablesOnWrite(rName, `
+  quarantine_non_executables_on_write = true
+  detect_non_executables_on_write     = false
+  filesystem_visibility               = true
+  quarantine                          = true
+`),
+				ExpectError: regexp.MustCompile(
+					"quarantine_non_executables_on_write requires detect_non_executables_on_write",
+				),
+			},
+			{
+				Config: testAccPreventionPolicyLinuxConfig_nonExecutablesOnWrite(rName, `
+  quarantine_non_executables_on_write = true
+  detect_non_executables_on_write     = true
+  filesystem_visibility               = true
+  quarantine                          = false
+`),
+				ExpectError: regexp.MustCompile(
+					"quarantine_non_executables_on_write requires quarantine",
+				),
+			},
+		},
+	})
+}
+
 func testAccPreventionPolicyLinuxConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "crowdstrike_prevention_policy_linux" "test" {
@@ -237,6 +285,8 @@ resource "crowdstrike_prevention_policy_linux" "test" {
   sensor_tampering_protection                  = true
   memory_visibility                            = true
   on_write_script_file_visibility              = true
+  detect_non_executables_on_write               = true
+  quarantine_non_executables_on_write          = true
   extended_command_line_visibility             = true
   dbus_visibility                              = true
   enhance_php_visibility                       = true
@@ -257,6 +307,16 @@ resource "crowdstrike_prevention_policy_linux" "test" {
     prevention = "CAUTIOUS"
   }
 }`, name)
+}
+
+func testAccPreventionPolicyLinuxConfig_nonExecutablesOnWrite(name, toggles string) string {
+	return fmt.Sprintf(`
+resource "crowdstrike_prevention_policy_linux" "test" {
+  name           = %[1]q
+  host_groups    = []
+  ioa_rule_groups = []
+%[2]s
+}`, name, toggles)
 }
 
 func testAccPreventionPolicyLinuxConfig_validationError(name string) string {

--- a/internal/prevention_policy/mac.go
+++ b/internal/prevention_policy/mac.go
@@ -58,6 +58,8 @@ type preventionPolicyMacResourceModel struct {
 	ScriptBasedExecutionMonitoring     types.Bool   `tfsdk:"script_based_execution_monitoring"`
 	DetectOnWrite                      types.Bool   `tfsdk:"detect_on_write"`
 	QuarantineOnWrite                  types.Bool   `tfsdk:"quarantine_on_write"`
+	DetectPackageOnWrite               types.Bool   `tfsdk:"detect_non_executables_on_write"`
+	QuarantinePackageOnWrite           types.Bool   `tfsdk:"quarantine_non_executables_on_write"`
 	NextGenAV                          types.Bool   `tfsdk:"quarantine"`
 	CustomBlacklisting                 types.Bool   `tfsdk:"custom_blocking"`
 	PreventSuspiciousProcesses         types.Bool   `tfsdk:"prevent_suspicious_processes"`
@@ -432,6 +434,22 @@ func (r *preventionPolicyMacResource) ValidateConfig(
 			"detect_on_write",
 		)...)
 
+	resp.Diagnostics.Append(
+		fwvalidators.BoolRequiresBool(
+			config.QuarantinePackageOnWrite,
+			config.DetectPackageOnWrite,
+			"quarantine_non_executables_on_write",
+			"detect_non_executables_on_write",
+		)...)
+
+	resp.Diagnostics.Append(
+		fwvalidators.BoolRequiresBool(
+			config.QuarantinePackageOnWrite,
+			config.NextGenAV,
+			"quarantine_non_executables_on_write",
+			"quarantine",
+		)...)
+
 	if utils.IsKnown(config.CloudAntiMalware) {
 		var slider mlSlider
 		if diagsSlider := config.CloudAntiMalware.As(ctx, &slider, basetypes.ObjectAsOptions{}); !diagsSlider.HasError() {
@@ -522,6 +540,8 @@ func (r *preventionPolicyMacResource) assignPreventionSettings(
 	)
 	state.DetectOnWrite = defaultBoolFalse(toggleSettings["DetectOnWrite"])
 	state.QuarantineOnWrite = defaultBoolFalse(toggleSettings["QuarantineOnWrite"])
+	state.DetectPackageOnWrite = defaultBoolFalse(toggleSettings["DetectPackageOnWrite"])
+	state.QuarantinePackageOnWrite = defaultBoolFalse(toggleSettings["QuarantinePackageOnWrite"])
 	state.NextGenAV = defaultBoolFalse(toggleSettings["NextGenAV"])
 	state.CustomBlacklisting = defaultBoolFalse(toggleSettings["CustomBlacklisting"])
 	state.PreventSuspiciousProcesses = defaultBoolFalse(
@@ -593,6 +613,8 @@ func (r *preventionPolicyMacResource) generatePreventionSettings(
 		"ScriptBasedExecutionMonitoring":     config.ScriptBasedExecutionMonitoring,
 		"DetectOnWrite":                      config.DetectOnWrite,
 		"QuarantineOnWrite":                  config.QuarantineOnWrite,
+		"DetectPackageOnWrite":               config.DetectPackageOnWrite,
+		"QuarantinePackageOnWrite":           config.QuarantinePackageOnWrite,
 		"NextGenAV":                          config.NextGenAV,
 		"CustomBlacklisting":                 config.CustomBlacklisting,
 		"PreventSuspiciousProcesses":         config.PreventSuspiciousProcesses,

--- a/internal/prevention_policy/mac_test.go
+++ b/internal/prevention_policy/mac_test.go
@@ -2,6 +2,7 @@ package preventionpolicy_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/crowdstrike/terraform-provider-crowdstrike/internal/acctest"
@@ -65,6 +66,8 @@ func TestAccPreventionPolicyMac_update(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("script_based_execution_monitoring"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("detect_on_write"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("quarantine_on_write"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("detect_non_executables_on_write"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("quarantine_non_executables_on_write"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("quarantine"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("custom_blocking"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("intelligence_sourced_threats"), knownvalue.Bool(false)),
@@ -105,6 +108,8 @@ func TestAccPreventionPolicyMac_update(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("custom_blocking"), knownvalue.Bool(true)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("detect_on_write"), knownvalue.Bool(true)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("quarantine_on_write"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("detect_non_executables_on_write"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("quarantine_non_executables_on_write"), knownvalue.Bool(true)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("script_based_execution_monitoring"), knownvalue.Bool(true)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("upload_unknown_detection_related_executables"), knownvalue.Bool(true)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("upload_unknown_executables"), knownvalue.Bool(true)),
@@ -143,6 +148,8 @@ func TestAccPreventionPolicyMac_update(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("script_based_execution_monitoring"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("detect_on_write"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("quarantine_on_write"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("detect_non_executables_on_write"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("quarantine_non_executables_on_write"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("quarantine"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("custom_blocking"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("intelligence_sourced_threats"), knownvalue.Bool(false)),
@@ -175,6 +182,47 @@ func TestAccPreventionPolicyMac_update(t *testing.T) {
 	})
 }
 
+func TestAccPreventionPolicyMac_nonExecutablesOnWriteValidationError(t *testing.T) {
+	rName := acctest.RandomResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPreventionPolicyMacConfig_nonExecutablesOnWrite(rName, `
+  quarantine_non_executables_on_write = true
+  detect_non_executables_on_write     = false
+  quarantine                          = true
+`),
+				ExpectError: regexp.MustCompile(
+					"quarantine_non_executables_on_write requires detect_non_executables_on_write",
+				),
+			},
+			{
+				Config: testAccPreventionPolicyMacConfig_nonExecutablesOnWrite(rName, `
+  quarantine_non_executables_on_write = true
+  detect_non_executables_on_write     = true
+  quarantine                          = false
+`),
+				ExpectError: regexp.MustCompile(
+					"quarantine_non_executables_on_write requires quarantine",
+				),
+			},
+		},
+	})
+}
+
+func testAccPreventionPolicyMacConfig_nonExecutablesOnWrite(name, toggles string) string {
+	return fmt.Sprintf(`
+resource "crowdstrike_prevention_policy_mac" "test" {
+  name           = %[1]q
+  host_groups    = []
+  ioa_rule_groups = []
+%[2]s
+}`, name, toggles)
+}
+
 func testAccPreventionPolicyMacConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "crowdstrike_prevention_policy_mac" "test" {
@@ -201,6 +249,8 @@ resource "crowdstrike_prevention_policy_mac" "test" {
   custom_blocking                            = true
   detect_on_write                            = true
   quarantine_on_write                        = true
+  detect_non_executables_on_write            = true
+  quarantine_non_executables_on_write        = true
   script_based_execution_monitoring          = true
   upload_unknown_detection_related_executables = true
   upload_unknown_executables                 = true

--- a/internal/prevention_policy/schema.go
+++ b/internal/prevention_policy/schema.go
@@ -317,6 +317,12 @@ func generateWindowsSchema(defaultPolicy bool) schema.Schema {
 			"quarantine_on_write": toggleAttribute(
 				"Use machine learning to quarantine suspicious files when they're written to disk. To adjust quarantine sensitivity, change Anti-malware Prevention levels in Sensor Machine Learning and Cloud Machine Learning.",
 			),
+			"detect_non_executables_on_write": toggleAttribute(
+				"Detect non-executable files, classified as malicious by CrowdStrike’s Intelligence analysts, when they are written to disk.",
+			),
+			"quarantine_non_executables_on_write": toggleAttribute(
+				"Quarantine non-executable files, classified as malicious by CrowdStrike’s Intelligence analysts, when they are written to disk. Requires detect_non_executables_on_write and quarantine_and_security_center_registration to be enabled.",
+			),
 			"on_write_script_file_visibility": toggleAttribute(
 				"Provides improved visibility into various script files being written to disk in addition to clouding a portion of their content.",
 			),
@@ -518,6 +524,12 @@ func generateMacSchema(defaultPolicy bool) schema.Schema {
 			"quarantine_on_write": toggleAttribute(
 				"Use machine learning to quarantine suspicious files when they're written to disk. To adjust quarantine sensitivity, change Anti-malware Prevention levels in Sensor Machine Learning and Cloud Machine Learning.",
 			),
+			"detect_non_executables_on_write": toggleAttribute(
+				"Detect non-executable files, classified as malicious by CrowdStrike’s Intelligence analysts, when they are written to disk.",
+			),
+			"quarantine_non_executables_on_write": toggleAttribute(
+				"Quarantine non-executable files, classified as malicious by CrowdStrike’s Intelligence analysts, when they are written to disk. Requires detect_non_executables_on_write and quarantine to be enabled.",
+			),
 			"quarantine": toggleAttribute(
 				"Quarantine executable files after they’re prevented by NGAV. When this is enabled, we recommend setting anti-malware prevention levels to Moderate or higher and not using other antivirus solutions.",
 			),
@@ -668,6 +680,12 @@ func generateLinuxSchema(defaultPolicy bool) schema.Schema {
 			),
 			"on_write_script_file_visibility": toggleAttribute(
 				"Provides improved visibility into various script files being written to disk in addition to clouding a portion of their content.",
+			),
+			"detect_non_executables_on_write": toggleAttribute(
+				"Detect non-executable files, classified as malicious by CrowdStrike’s Intelligence analysts, when they are written to disk. Requires filesystem_visibility to be enabled.",
+			),
+			"quarantine_non_executables_on_write": toggleAttribute(
+				"Quarantine non-executable files, classified as malicious by CrowdStrike’s Intelligence analysts, when they are written to disk. Requires detect_non_executables_on_write and quarantine to be enabled.",
 			),
 			"extended_command_line_visibility": toggleAttribute(
 				"Allows the sensor to monitor full CLI commands that include pipes and redirects. This is applicable only for User mode.",

--- a/internal/prevention_policy/windows.go
+++ b/internal/prevention_policy/windows.go
@@ -77,6 +77,8 @@ type preventionPolicyWindowsResourceModel struct {
 	USBInsertionTriggeredScan                  types.Bool   `tfsdk:"usb_insertion_triggered_scan"`
 	DetectOnWrite                              types.Bool   `tfsdk:"detect_on_write"`
 	QuarantineOnWrite                          types.Bool   `tfsdk:"quarantine_on_write"`
+	DetectPackageOnWrite                       types.Bool   `tfsdk:"detect_non_executables_on_write"`
+	QuarantinePackageOnWrite                   types.Bool   `tfsdk:"quarantine_non_executables_on_write"`
 	OnWriteScriptFileVisibility                types.Bool   `tfsdk:"on_write_script_file_visibility"`
 	NextGenAV                                  types.Bool   `tfsdk:"quarantine_and_security_center_registration"`
 	NextGenAVQuarantineOnRemovableMedia        types.Bool   `tfsdk:"quarantine_on_removable_media"`
@@ -554,6 +556,22 @@ func (r *preventionPolicyWindowsResource) ValidateConfig(
 
 	resp.Diagnostics.Append(
 		fwvalidators.BoolRequiresBool(
+			config.QuarantinePackageOnWrite,
+			config.DetectPackageOnWrite,
+			"quarantine_non_executables_on_write",
+			"detect_non_executables_on_write",
+		)...)
+
+	resp.Diagnostics.Append(
+		fwvalidators.BoolRequiresBool(
+			config.QuarantinePackageOnWrite,
+			config.NextGenAV,
+			"quarantine_non_executables_on_write",
+			"quarantine_and_security_center_registration",
+		)...)
+
+	resp.Diagnostics.Append(
+		fwvalidators.BoolRequiresBool(
 			config.ScriptBasedExecutionMonitoring,
 			config.NextGenAV,
 			"script_based_execution_monitoring",
@@ -762,6 +780,8 @@ func (r *preventionPolicyWindowsResource) assignPreventionSettings(
 	state.USBInsertionTriggeredScan = defaultBoolFalse(toggleSettings["USBInsertionTriggeredScan"])
 	state.DetectOnWrite = defaultBoolFalse(toggleSettings["DetectOnWrite"])
 	state.QuarantineOnWrite = defaultBoolFalse(toggleSettings["QuarantineOnWrite"])
+	state.DetectPackageOnWrite = defaultBoolFalse(toggleSettings["DetectPackageOnWrite"])
+	state.QuarantinePackageOnWrite = defaultBoolFalse(toggleSettings["QuarantinePackageOnWrite"])
 	state.OnWriteScriptFileVisibility = defaultBoolFalse(
 		toggleSettings["OnWriteScriptFileVisibility"],
 	)
@@ -941,6 +961,8 @@ func (r *preventionPolicyWindowsResource) generatePreventionSettings(
 		"USBInsertionTriggeredScan":                 config.USBInsertionTriggeredScan,
 		"DetectOnWrite":                             config.DetectOnWrite,
 		"QuarantineOnWrite":                         config.QuarantineOnWrite,
+		"DetectPackageOnWrite":                      config.DetectPackageOnWrite,
+		"QuarantinePackageOnWrite":                  config.QuarantinePackageOnWrite,
 		"OnWriteScriptFileVisibility":               config.OnWriteScriptFileVisibility,
 		"NextGenAV":                                 config.NextGenAV,
 		"NextGenAVQuarantineOnRemovableMedia":       config.NextGenAVQuarantineOnRemovableMedia,

--- a/internal/prevention_policy/windows_test.go
+++ b/internal/prevention_policy/windows_test.go
@@ -28,6 +28,9 @@ resource "crowdstrike_prevention_policy_windows" "test" {
   wsl2_visibility                        = true
   suspicious_file_analysis               = true
   retrospective_detections               = true
+  quarantine_and_security_center_registration = true
+  detect_non_executables_on_write             = true
+  quarantine_non_executables_on_write         = true
   cloud_anti_malware_microsoft_office_files = {
     detection  = "MODERATE"
     prevention = "MODERATE"
@@ -56,6 +59,9 @@ resource "crowdstrike_prevention_policy_windows" "test" {
   wsl2_visibility                        = true
   suspicious_file_analysis               = true
   retrospective_detections               = true
+  quarantine_and_security_center_registration = true
+  detect_non_executables_on_write             = true
+  quarantine_non_executables_on_write         = true
   cloud_anti_malware_microsoft_office_files = {
     detection  = "MODERATE"
     prevention = "MODERATE"
@@ -90,6 +96,9 @@ resource "crowdstrike_prevention_policy_windows" "test" {
   wsl2_visibility                        = false
   suspicious_file_analysis               = false
   retrospective_detections               = false
+  quarantine_and_security_center_registration = false
+  detect_non_executables_on_write             = false
+  quarantine_non_executables_on_write         = false
   cloud_anti_malware_microsoft_office_files = {
     detection  = "MODERATE"
     prevention = "DISABLED"
@@ -117,6 +126,20 @@ resource "crowdstrike_prevention_policy_windows" "test" {
   boot_configuration_database_protection = true
 }
 `, rName)
+}
+
+func testAccPreventionPolicyWindowsConfig_nonExecutablesOnWrite(
+	rName string,
+	toggles string,
+) string {
+	return acctest.ProviderConfig + fmt.Sprintf(`
+resource "crowdstrike_prevention_policy_windows" "test" {
+  name            = "%s"
+  host_groups     = []
+  ioa_rule_groups = []
+%s
+}
+`, rName, toggles)
 }
 
 // regression test to handle unknown states https://github.com/CrowdStrike/terraform-provider-crowdstrike/issues/136
@@ -236,6 +259,37 @@ func TestAccPreventionPolicyWindowsResource_validationError(t *testing.T) {
 	})
 }
 
+func TestAccPreventionPolicyWindowsResource_nonExecutablesOnWriteValidationError(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPreventionPolicyWindowsConfig_nonExecutablesOnWrite(rName, `
+  quarantine_non_executables_on_write         = true
+  detect_non_executables_on_write             = false
+  quarantine_and_security_center_registration = true
+`),
+				ExpectError: regexp.MustCompile(
+					"quarantine_non_executables_on_write requires detect_non_executables_on_write",
+				),
+			},
+			{
+				Config: testAccPreventionPolicyWindowsConfig_nonExecutablesOnWrite(rName, `
+  quarantine_non_executables_on_write         = true
+  detect_non_executables_on_write             = true
+  quarantine_and_security_center_registration = false
+`),
+				ExpectError: regexp.MustCompile(
+					"quarantine_non_executables_on_write requires quarantine_and_security_center_registration",
+				),
+			},
+		},
+	})
+}
+
 func TestAccPreventionPolicyWindowsResource(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "crowdstrike_prevention_policy_windows.test"
@@ -285,6 +339,16 @@ func TestAccPreventionPolicyWindowsResource(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						resourceName,
 						"retrospective_detections",
+						"true",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"detect_non_executables_on_write",
+						"true",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"quarantine_non_executables_on_write",
 						"true",
 					),
 					resource.TestCheckResourceAttr(
@@ -374,6 +438,16 @@ func TestAccPreventionPolicyWindowsResource(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						resourceName,
 						"retrospective_detections",
+						"false",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"detect_non_executables_on_write",
+						"false",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"quarantine_non_executables_on_write",
 						"false",
 					),
 					resource.TestCheckResourceAttr(


### PR DESCRIPTION
Adds `detect_non_executables_on_write` (DetectPackageOnWrite) and `quarantine_non_executables_on_write` (QuarantinePackageOnWrite) to the Linux, Mac, and Windows prevention policy resources and their default_prevention_policy counterparts. Both settings are returned in the On Write category on all three platforms and are writable toggles, but the provider had no way to manage them.

Each platform enforces its own prerequisites at plan time. Linux requires filesystem_visibility for detection; every platform requires detection plus the platform's quarantine toggle (quarantine on Linux and Mac, quarantine_and_security_center_registration on Windows) before quarantining.

Closes #481
