### PR TITLE
chore: migrate deprecated gofumpt config and pin golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run linters
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v4.0.0
         with:
-          version: latest
+          version: v2.13.1
           only-new-issues: true
 
   unit-test:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,4 +47,5 @@ formatters:
       - examples$
   settings:
     gofumpt:
-      extra-rules: true
+      extra:
+        group-params: true

--- a/internal/firewall/rule_group_helpers_test.go
+++ b/internal/firewall/rule_group_helpers_test.go
@@ -120,7 +120,10 @@ func TestBuildRulePayloadForDiffPreservesMatchCriteria(t *testing.T) {
 	if payload["fqdn"] != "example.com" || payload["fqdn_enabled"] != true {
 		t.Fatalf("expected FQDN criteria, got %v", payload)
 	}
-	fields := payload["fields"].([]map[string]interface{})
+	fields, ok := payload["fields"].([]map[string]interface{})
+	if !ok {
+		t.Fatalf("expected fields to be []map[string]interface{}, got %T", payload["fields"])
+	}
 	if fields[1]["type"] != "unix_path" {
 		t.Fatalf("expected macOS executable to use unix_path, got %v", fields[1])
 	}

--- a/internal/tferrors/errors.go
+++ b/internal/tferrors/errors.go
@@ -299,7 +299,7 @@ func handle207PayloadErrors(operation Operation, err error, cfg *errorConfig) di
 	}
 
 	payloadVal := reflect.ValueOf(payload)
-	if payloadVal.Kind() == reflect.Ptr {
+	if payloadVal.Kind() == reflect.Pointer {
 		payloadVal = payloadVal.Elem()
 	}
 
@@ -525,7 +525,7 @@ func renderPayloadError(payloadError reflect.Value) string {
 // non-nil, and plain fields when non-zero, which mirrors how these models are
 // declared: required fields are pointers and optional ones carry omitempty.
 func setFieldValue(field reflect.Value) (any, bool) {
-	if field.Kind() == reflect.Ptr {
+	if field.Kind() == reflect.Pointer {
 		if field.IsNil() {
 			return nil, false
 		}
@@ -579,7 +579,7 @@ func typedResponsePayload(err error) reflect.Value {
 // derefToStruct follows pointers down to a struct value, returning an invalid
 // Value when a nil pointer or a non-struct is encountered.
 func derefToStruct(value reflect.Value) reflect.Value {
-	for value.Kind() == reflect.Ptr || value.Kind() == reflect.Interface {
+	for value.Kind() == reflect.Pointer || value.Kind() == reflect.Interface {
 		if value.IsNil() {
 			return reflect.Value{}
 		}

--- a/internal/utils/schema.go
+++ b/internal/utils/schema.go
@@ -74,7 +74,7 @@ func SliceToListTypeObject[T any](
 
 	for _, elem := range elems {
 		v := reflect.ValueOf(elem)
-		if v.Kind() == reflect.Ptr && v.IsNil() {
+		if v.Kind() == reflect.Pointer && v.IsNil() {
 			continue
 		}
 		elemsSlice = append(elemsSlice, elem)


### PR DESCRIPTION
golangci-lint v2.13.1 reinterprets the deprecated gofumpt `extra-rules` key, which made it report 31 files as badly formatted even though none of them had changed. Migrating to the replacement `extra.group-params` key clears all 31 without reformatting any Go code, and silences the deprecation warning the linter emitted on every run.

CI asked for `version: latest`, so v2.13.1 rolled in on its own and broke the lint job without a repo change. Pin it so linter upgrades are deliberate and reviewable.

Also fix the two real findings that the formatting noise was hiding: an unchecked type assertion in the firewall rule group test, and four uses of `reflect.Ptr`, which govet now wants written as `reflect.Pointer`.