### PR TITLE
docs(user_management): document custom role home CID restriction

### DIFF
--- a/docs/resources/user_role_assignment.md
+++ b/docs/resources/user_role_assignment.md
@@ -8,8 +8,7 @@ description: |-
   The roles in role_ids are granted to the user in the CID set by cid. Use the crowdstrike_cid data source to get the CID for the authenticating credentials.
   Roles a user inherits through a user group or CID group (Falcon Flight Control), and temporary roles (granted with an expiration), are not shown or managed by this resource and are left untouched.
   Custom roles
-  Unlike default roles, which are global and valid in every CID, a custom role belongs to the CID it was created in. A custom role can only be granted to a user whose home CID is the CID that owns the role: the CID a user was created in, reported by the cid attribute of the crowdstrike_user resource. Granting a custom role to a user homed in any other CID fails with invalid roleID='<role id>' specified, even when cid is set to the CID that owns the role. This is a restriction of the Falcon platform, not of this provider.
-  To find the custom roles a user can be granted, set both cid and user_uuid on the crowdstrike_user_roles data source. Filtering by cid alone lists every custom role that CID owns, including roles that users homed elsewhere cannot receive.
+  Unlike default roles, custom roles are specific to the CID in which they are created. For Flight Control multi-CID environments, custom roles must be created and assigned in the home CID of the user. You can't assign a custom role to a user in a CID that is not their home CID.
   API Scopes
   The following API scopes are required:
   User management | Read & Write
@@ -29,9 +28,7 @@ Roles a user inherits through a user group or CID group (Falcon Flight Control),
 
 ## Custom roles
 
-Unlike default roles, which are global and valid in every CID, a custom role belongs to the CID it was created in. A custom role can only be granted to a user whose **home CID** is the CID that owns the role: the CID a user was created in, reported by the `cid` attribute of the `crowdstrike_user` resource. Granting a custom role to a user homed in any other CID fails with `invalid roleID='<role id>' specified`, even when `cid` is set to the CID that owns the role. This is a restriction of the Falcon platform, not of this provider.
-
-To find the custom roles a user can be granted, set both `cid` and `user_uuid` on the `crowdstrike_user_roles` data source. Filtering by `cid` alone lists every custom role that CID owns, including roles that users homed elsewhere cannot receive.
+Unlike default roles, custom roles are specific to the CID in which they are created. For Flight Control multi-CID environments, custom roles must be created and assigned in the home CID of the user. You can't assign a custom role to a user in a CID that is not their home CID.
 
 ## API Scopes
 

--- a/docs/resources/user_role_assignment.md
+++ b/docs/resources/user_role_assignment.md
@@ -7,6 +7,9 @@ description: |-
   Omitting role_ids leaves the user with no directly-assigned roles.
   The roles in role_ids are granted to the user in the CID set by cid. Use the crowdstrike_cid data source to get the CID for the authenticating credentials.
   Roles a user inherits through a user group or CID group (Falcon Flight Control), and temporary roles (granted with an expiration), are not shown or managed by this resource and are left untouched.
+  Custom roles
+  Unlike default roles, which are global and valid in every CID, a custom role belongs to the CID it was created in. A custom role can only be granted to a user whose home CID is the CID that owns the role: the CID a user was created in, reported by the cid attribute of the crowdstrike_user resource. Granting a custom role to a user homed in any other CID fails with invalid roleID='<role id>' specified, even when cid is set to the CID that owns the role. This is a restriction of the Falcon platform, not of this provider.
+  To find the custom roles a user can be granted, set both cid and user_uuid on the crowdstrike_user_roles data source. Filtering by cid alone lists every custom role that CID owns, including roles that users homed elsewhere cannot receive.
   API Scopes
   The following API scopes are required:
   User management | Read & Write
@@ -23,6 +26,12 @@ Omitting `role_ids` leaves the user with no directly-assigned roles.
 The roles in `role_ids` are granted to the user in the CID set by `cid`. Use the `crowdstrike_cid` data source to get the CID for the authenticating credentials.
 
 Roles a user inherits through a user group or CID group (Falcon Flight Control), and temporary roles (granted with an expiration), are not shown or managed by this resource and are left untouched.
+
+## Custom roles
+
+Unlike default roles, which are global and valid in every CID, a custom role belongs to the CID it was created in. A custom role can only be granted to a user whose **home CID** is the CID that owns the role: the CID a user was created in, reported by the `cid` attribute of the `crowdstrike_user` resource. Granting a custom role to a user homed in any other CID fails with `invalid roleID='<role id>' specified`, even when `cid` is set to the CID that owns the role. This is a restriction of the Falcon platform, not of this provider.
+
+To find the custom roles a user can be granted, set both `cid` and `user_uuid` on the `crowdstrike_user_roles` data source. Filtering by `cid` alone lists every custom role that CID owns, including roles that users homed elsewhere cannot receive.
 
 ## API Scopes
 

--- a/internal/user/user_role_assignment.go
+++ b/internal/user/user_role_assignment.go
@@ -45,12 +45,7 @@ var (
 		"The roles in `role_ids` are granted to the user in the CID set by `cid`. Use the `crowdstrike_cid` data source to get the CID for the authenticating credentials.\n\n" +
 		"Roles a user inherits through a user group or CID group (Falcon Flight Control), and temporary roles (granted with an expiration), are not shown or managed by this resource and are left untouched.\n\n" +
 		"## Custom roles\n\n" +
-		"Unlike default roles, which are global and valid in every CID, a custom role belongs to the CID it was created in. " +
-		"A custom role can only be granted to a user whose **home CID** is the CID that owns the role: the CID a user was created in, reported by the `cid` attribute of the `crowdstrike_user` resource. " +
-		"Granting a custom role to a user homed in any other CID fails with `invalid roleID='<role id>' specified`, even when `cid` is set to the CID that owns the role. " +
-		"This is a restriction of the Falcon platform, not of this provider.\n\n" +
-		"To find the custom roles a user can be granted, set both `cid` and `user_uuid` on the `crowdstrike_user_roles` data source. " +
-		"Filtering by `cid` alone lists every custom role that CID owns, including roles that users homed elsewhere cannot receive."
+		"Unlike default roles, custom roles are specific to the CID in which they are created. For Flight Control multi-CID environments, custom roles must be created and assigned in the home CID of the user. You can't assign a custom role to a user in a CID that is not their home CID."
 	roleAssignmentRequiredScopes []scopes.Scope = []scopes.Scope{
 		{
 			Name:  "User management",

--- a/internal/user/user_role_assignment.go
+++ b/internal/user/user_role_assignment.go
@@ -43,7 +43,14 @@ var (
 		"Roles assigned directly outside of Terraform in this CID will be removed on the next apply.\n\n" +
 		"Omitting `role_ids` leaves the user with no directly-assigned roles.\n\n" +
 		"The roles in `role_ids` are granted to the user in the CID set by `cid`. Use the `crowdstrike_cid` data source to get the CID for the authenticating credentials.\n\n" +
-		"Roles a user inherits through a user group or CID group (Falcon Flight Control), and temporary roles (granted with an expiration), are not shown or managed by this resource and are left untouched."
+		"Roles a user inherits through a user group or CID group (Falcon Flight Control), and temporary roles (granted with an expiration), are not shown or managed by this resource and are left untouched.\n\n" +
+		"## Custom roles\n\n" +
+		"Unlike default roles, which are global and valid in every CID, a custom role belongs to the CID it was created in. " +
+		"A custom role can only be granted to a user whose **home CID** is the CID that owns the role: the CID a user was created in, reported by the `cid` attribute of the `crowdstrike_user` resource. " +
+		"Granting a custom role to a user homed in any other CID fails with `invalid roleID='<role id>' specified`, even when `cid` is set to the CID that owns the role. " +
+		"This is a restriction of the Falcon platform, not of this provider.\n\n" +
+		"To find the custom roles a user can be granted, set both `cid` and `user_uuid` on the `crowdstrike_user_roles` data source. " +
+		"Filtering by `cid` alone lists every custom role that CID owns, including roles that users homed elsewhere cannot receive."
 	roleAssignmentRequiredScopes []scopes.Scope = []scopes.Scope{
 		{
 			Name:  "User management",


### PR DESCRIPTION
Assigning a custom role to a user whose home CID does not own the role fails with `invalid roleID='<role id>' specified`, and nothing in the resource documentation explained why. The restriction is enforced by the Falcon platform: a custom role belongs to the CID it was created in and can only be granted to users homed in that CID, so setting `cid` to the CID that owns the role does not help.

Add a Custom roles section to the crowdstrike_user_role_assignment description covering the rule, the error it produces, and how to list the custom roles a given user can actually be granted.

Fixes #490